### PR TITLE
Postgresql Dialect: fix primary tag for int types

### DIFF
--- a/dialect/postgres.go
+++ b/dialect/postgres.go
@@ -45,7 +45,7 @@ func (d *postgres) SqlTag(column interface{}, size int) string {
 func (s *postgres) PrimaryKeyTag(column interface{}, size int) string {
 	switch column.(type) {
 	case int, int8, int16, int32, uint, uint8, uint16, uint32:
-		return "sehrial"
+		return "serial"
 	case int64, uint64:
 		return "bigserial"
 	default:


### PR DESCRIPTION
There is not a `sehrial` type in postgresql
