### PR TITLE
* fix race condition

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -6,14 +6,23 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 )
 
-var toSnakeMap = map[string]string{}
+type SnakeMap struct {
+  Map map[string]string
+  mu sync.RWMutex
+}
+var snake = SnakeMap{Map:map[string]string{}}
 var toUpperMap = map[string]string{}
 
 func toSnake(u string) string {
-	if v := toSnakeMap[u]; v != "" {
+	snake.mu.RLock()
+	if v := snake.Map[u]; v != "" {
+		snake.mu.RUnlock()
 		return v
+	} else {
+		snake.mu.RUnlock()
 	}
 
 	buf := bytes.NewBufferString("")
@@ -25,7 +34,9 @@ func toSnake(u string) string {
 	}
 
 	s := strings.ToLower(buf.String())
-	toSnakeMap[u] = s
+	snake.mu.Lock()
+	defer snake.mu.Unlock()
+	snake.Map[u] = s
 	return s
 }
 


### PR DESCRIPTION
This fixes a race condition I experience

```
WARNING: DATA RACE
Write by goroutine 8:
  runtime.mapassign1()
      /usr/lib/go/src/pkg/runtime/hashmap.c:1289 +0x0
  github.com/jinzhu/gorm.toSnake()
      /home/edward/gopath/src/github.com/jinzhu/gorm/utils.go:28 +0x2dc
  github.com/jinzhu/gorm.func·001()
      /home/edward/gopath/src/github.com/jinzhu/gorm/model.go:80 +0x255
  gosched0()
      /usr/lib/go/src/pkg/runtime/proc.c:1218 +0x9f

Previous read by goroutine 7:
  runtime.mapaccess1_faststr()
      /usr/lib/go/src/pkg/runtime/hashmap.c:375 +0x0
  github.com/jinzhu/gorm.toSnake()
      /home/edward/gopath/src/github.com/jinzhu/gorm/utils.go:15 +0x74
  github.com/jinzhu/gorm.func·001()
      /home/edward/gopath/src/github.com/jinzhu/gorm/model.go:80 +0x255
  gosched0()
      /usr/lib/go/src/pkg/runtime/proc.c:1218 +0x9f
```
