### PR TITLE
Remove typo from DB access example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ func init() {
 
 // user.go
 package user
-import _ "db"
+import "db"
 ...
 DB.Save(&User{Name: "xxx"})
 ...


### PR DESCRIPTION
I am a Go n00b and was excited to discover gorm for my ORM needs.  It really does hit the "developer ease" note quite well!

However I believe there is a typo in the documentation -- importing the example "db" package with an underscore will cause the "DB" variable to fail to be exported, which means that the subsequent access in the main package will fail.  Once I changed that, it worked just fine so I thought I'd issue this PR so that others can be spared similar confusion.

thanks for a cool lib!
