### PR TITLE
Re-submission of docs typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ func init() {
 
 // user.go
 package user
-import "db"
+import . "db"
 ...
 DB.Save(&User{Name: "xxx"})
 ...


### PR DESCRIPTION
Fix import declaration in README ('.' instead of '_') demonstrating global namespace access to DB connection.

Please excuse the re-submitted PR.  The docs which you helpfully linked to (http://golang.org/ref/spec#Import_declarations), as well as the other comments on my closed PR (https://github.com/jinzhu/gorm/pull/33), led me to be able to successfully reproduce the result the author showed in the README.

To re-iterate: use of the underscore character in an import ("_") **does not** produce the results demonstrated in the README.  Use of the period character (".") does.
