### PR TITLE
Timestamp should always be saved in UTC.

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -13,8 +13,8 @@ func BeforeCreate(scope *Scope) {
 
 func UpdateTimeStampWhenCreate(scope *Scope) {
 	if !scope.HasError() {
-		scope.SetColumn("CreatedAt", time.Now())
-		scope.SetColumn("UpdatedAt", time.Now())
+		scope.SetColumn("CreatedAt", time.Now().UTC())
+		scope.SetColumn("UpdatedAt", time.Now().UTC())
 	}
 }
 

--- a/callback_delete.go
+++ b/callback_delete.go
@@ -15,7 +15,7 @@ func Delete(scope *Scope) {
 			scope.Raw(
 				fmt.Sprintf("UPDATE %v SET deleted_at=%v %v",
 					scope.TableName(),
-					scope.AddToVars(time.Now()),
+					scope.AddToVars(time.Now().UTC()),
 					scope.CombinedConditionSql(),
 				))
 		} else {

--- a/callback_update.go
+++ b/callback_update.go
@@ -36,7 +36,7 @@ func BeforeUpdate(scope *Scope) {
 func UpdateTimeStampWhenUpdate(scope *Scope) {
 	_, ok := scope.Get("gorm:update_column")
 	if !ok {
-		scope.SetColumn("UpdatedAt", time.Now())
+		scope.SetColumn("UpdatedAt", time.Now().UTC())
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -574,9 +574,10 @@ func TestCount(t *testing.T) {
 	}
 }
 
-func TestCreatedAtAndUpdatedAt(t *testing.T) {
-	name := "check_created_at_and_updated_at"
+func TestCreatedAtAndUpdatedAtUpdateCorrectly(t *testing.T) {
+	name := "check_created_at_and_updated_at_update_correctly"
 	u := User{Name: name, Age: 1}
+
 	db.Save(&u)
 	created_at := u.CreatedAt
 	updated_at := u.UpdatedAt
@@ -599,6 +600,22 @@ func TestCreatedAtAndUpdatedAt(t *testing.T) {
 
 	if updated_at == updated_at2 {
 		t.Errorf("Updated At should be changed after update")
+	}
+}
+
+func TestCreatedAtAndUpdatedAtAreSavedAsUTC(t *testing.T) {
+	name := "check_created_at_and_updated_at_saved_as_utc"
+	u := User{Name: name, Age: 1}
+
+	db.Save(&u)
+	created_at := u.CreatedAt
+	updated_at := u.UpdatedAt
+
+	if created_at.Location() != time.UTC {
+		t.Errorf("created_at should be UTC")
+	}
+	if updated_at.Location() != time.UTC {
+		t.Errorf("updated_at should be UTC")
 	}
 }
 


### PR DESCRIPTION
When saving timestamps to the database, the timezone information is truncated.  When the timestamp is loaded again later, the timezone is changed, resulting in incorrect data.

Rails solves this by always saving timestamps as UTC.  This pull request only fixes the built-in CreatedAt and UpdatedAt behavior, not any timestamp the user saves.  If you like this approach, we could try to fix it globally.
