### PR TITLE
Prevent panic for fields that implement sql.Scanner but aren't structs.

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,16 @@ type IgnoredEmbedStruct struct {
 	Name string
 }
 
+type NamedInt int64
+func (i *NamedInt) Scan(src interface{}) error {
+        v := reflect.ValueOf(src)
+        if v.Kind() != reflect.Int64 {
+                return errors.New("Cannot scan NamedInt from " + v.String())
+        }
+        *i = NamedInt(v.Int())
+        return nil
+}
+
 type User struct {
 	Id                 int64 // Id: Primary key
 	Age                int64
@@ -42,6 +52,7 @@ type User struct {
 	PasswordHash       []byte
 	IgnoreMe           int64    `sql:"-"`
 	IgnoreStringSlice  []string `sql:"-"`
+	NamedInt           NamedInt `sql:"type:bigint"`
 }
 
 type CreditCard struct {

--- a/scope_private.go
+++ b/scope_private.go
@@ -309,7 +309,7 @@ func (scope *Scope) sqlTagForField(field *Field) (tag string) {
 	value := field.Value
 	reflectValue := reflect.ValueOf(value)
 
-	if field.IsScanner() {
+	if field.IsScanner() && reflectValue.Kind() == reflect.Struct {
 		value = reflectValue.Field(0).Interface()
 	}
 


### PR DESCRIPTION
Hi

I ran into an issue when using a integer type as a field in my model. Here's an example:

type NamedInt int64

func (i *NamedInt) Scan(src interface{}) error {
        v := reflect.ValueOf(src)
        if v.Kind() != reflect.Int64 {
                return errors.New("Cannot scan NamedInt from " + v.String())
        }
        *i = NamedInt(v.Int())
        return nil
}

The model:

type Model struct {
    NamedInt NamedInt `sql:"type:bigint"`
}

Currently, the presence of the NamedInt field causes gorm to panic. This change allows it to work as expected.
