### PR TITLE
Add DB.Tx() method to provide access to the underlying sql.Tx instance.

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,20 +28,15 @@ func Open(driver, source string) (DB, error) {
 	return db, err
 }
 
-// Return the underlying sql.DB instance.
-//
-// If called inside a transaction, it will panic.
-// Use Tx() instead in this case.
 func (s *DB) DB() *sql.DB {
 	return s.db.(*sql.DB)
 }
 
-// Return the underlying sql.Tx instance.
-//
-// If called outside of a transaction, it will panic.
-// Use DB() instead in this case.
-func (s *DB) Tx() *sql.Tx {
-	return s.db.(*sql.Tx)
+// Return the underlying sql.DB or sql.Tx instance.
+// Use of this method is discouraged. It's mainly intended to allow
+// coexistence with legacy non-GORM code.
+func (s *DB) CommonDB() sqlCommon {
+	return s.db
 }
 
 func (s *DB) Callback() *callback {

--- a/main_test.go
+++ b/main_test.go
@@ -1542,10 +1542,9 @@ func TestTransaction(t *testing.T) {
 		t.Errorf("Should find saved record, but got", err)
 	}
 
-	sql_tx := tx.Tx()  // This shouldn't panic.
-	if sql_tx == nil {
-		t.Errorf("Should return the underlying sql.Tx, but got nil")
-	}
+        if sql_tx, ok := tx.CommonDB().(*sql.Tx); !ok || sql_tx == nil {
+                t.Errorf("Should return the underlying sql.Tx")
+        }
 
 	tx.Rollback()
 


### PR DESCRIPTION
Hi

We have a lot of existing code that uses sql.DB and sql.Tx arguments. Sometimes it's necessary to for our new GORM code to interface with the old code. Calling DB.DB() is useful for this, but it doesn't work inside transactions. Inside transactions, it's more useful to access a sql.Tx instance instead. I've added a new DB.Tx() method to return the underlying sql.Tx instance. I think this will be useful for anyone who is migrating to GORM from existing database/sql code.

Regards,
Timothy
