### PR TITLE
Add model inheritance via struct's anonymous fields

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -224,10 +224,10 @@ func (scope *Scope) CombinedConditionSql() string {
 // Fields get value's fields
 func (scope *Scope) Fields() []*Field {
 	indirectValue := reflect.Indirect(reflect.ValueOf(scope.Value))
-	fields := []*Field{}
+	fields := make(map[string]*Field)
 
 	if !indirectValue.IsValid() {
-		return fields
+		return []*Field{}
 	}
 
 	scopeTyp := indirectValue.Type()
@@ -242,8 +242,11 @@ func (scope *Scope) Fields() []*Field {
 		elem := reflect.Indirect(value)
 
 		if fieldStruct.Anonymous && elem.Kind() == reflect.Struct {
-			inner_fields := scope.New(iface).Fields()
-			fields = append(fields, inner_fields...)
+			for _, f := range scope.New(iface).Fields() {
+				if _, ok := fields[f.Name]; !ok {
+					fields[f.Name] = f
+				}
+			}
 			continue
 		}
 
@@ -294,10 +297,14 @@ func (scope *Scope) Fields() []*Field {
 				}
 			}
 		}
-		fields = append(fields, &field)
+		fields[field.Name] = &field
 	}
 
-	return fields
+	field_list := make([]*Field, len(fields))
+	for _, field := range fields {
+		append(field_list, field)
+	}
+	return field_list
 }
 
 // Raw set sql


### PR DESCRIPTION
Hi,
I'd like to use anonymous struct fields as a way to create model inheritance. 
Simple example:

``` go
type BasePost struct {
    Id int64
    Title string
    Url string
}

type HNPost struct {
    BasePost
    Upvotes int32
    Uploader HNUser
}

type EngadgetPost {
    BasePost
    ImageUrl string
    Author EngadgetAuthor
}
```

which would end up being:

``` go
type HNPost struct {
    Id int64
    Title string
    Url string
    BasePost
    Upvotes int32
    Uploader HNUser
}

type EngadgetPost {
    BasePost
    ImageUrl string
    Author EngadgetAuthor
    Id int64
    Title string
    Url string
}
```

The current implementation creates ForeignKey in place of BasePost, in both EngadgetPost and HNPost. With this commit, this behavior is still there, but to use it one has to explicitly write:

``` go
type Model struct {
    ForeignKeyType ForeignKeyType
}
```
