### PR TITLE
set updated_at and created_at with the same timestamp

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -13,8 +13,9 @@ func BeforeCreate(scope *Scope) {
 
 func UpdateTimeStampWhenCreate(scope *Scope) {
 	if !scope.HasError() {
-		scope.SetColumn("CreatedAt", time.Now())
-		scope.SetColumn("UpdatedAt", time.Now())
+		now := time.Now()
+		scope.SetColumn("CreatedAt", now)
+		scope.SetColumn("UpdatedAt", now)
 	}
 }
 


### PR DESCRIPTION
 prevent record from having slight difference between fields
