### PR TITLE
Add support for sqlite3 hook

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -28,6 +28,8 @@ func NewDialect(driver string) Dialect {
 		d = &mysql{}
 	case "sqlite3":
 		d = &sqlite3{}
+	case "sqlite3hook":
+		d = &sqlite3{}	
 	default:
 		fmt.Printf("`%v` is not officially supported, running under compatibility mode.\n", driver)
 		d = &commonDialect{}


### PR DESCRIPTION
This is useful for adding backup functionality to SQLite as seen here:

https://github.com/mattn/go-sqlite3/blob/master/_example/hook/hook.go

In that sample, "sqlite3_with_hook_example" is the name of the driver to be registered. I used "sqlite3hook" in my fork as a generic name. Otherwise gorm will use SQLite in compatibility mode.
