### PR TITLE
Add basic support for DEFAULT values

### DIFF
--- a/field.go
+++ b/field.go
@@ -57,6 +57,11 @@ func parseSqlTag(str string) (typ string, addational_typ string, size int) {
 		}
 
 		addational_typ = m["NOT NULL"] + " " + m["UNIQUE"]
+
+		if len(m["DEFAULT"]) > 0 {
+			addational_typ = addational_typ + "DEFAULT " + m["DEFAULT"]
+		}
+
 	}
 	return
 }


### PR DESCRIPTION
This commit adds basic support to set `DEFAULT` collumn attributes.
I tested this only with postgres. While gorm cannot use it properly (as the structs are filled with data by default), it can at least create the tables in the database correctly.

This maybe a starting point to add proper `DEFAULT` support to gorm.
