### PR TITLE
gorm: added ability to change the time.now format

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -3,7 +3,6 @@ package gorm
 import (
 	"fmt"
 	"strings"
-	"time"
 )
 
 func BeforeCreate(scope *Scope) {
@@ -13,14 +12,14 @@ func BeforeCreate(scope *Scope) {
 
 func UpdateTimeStampWhenCreate(scope *Scope) {
 	if !scope.HasError() {
-		now := time.Now()
+		now := NowFunc()
 		scope.SetColumn("CreatedAt", now)
 		scope.SetColumn("UpdatedAt", now)
 	}
 }
 
 func Create(scope *Scope) {
-	defer scope.Trace(time.Now())
+	defer scope.Trace(NowFunc())
 
 	if !scope.HasError() {
 		// set create sql

--- a/callback_delete.go
+++ b/callback_delete.go
@@ -1,9 +1,6 @@
 package gorm
 
-import (
-	"fmt"
-	"time"
-)
+import "fmt"
 
 func BeforeDelete(scope *Scope) {
 	scope.CallMethod("BeforeDelete")
@@ -15,7 +12,7 @@ func Delete(scope *Scope) {
 			scope.Raw(
 				fmt.Sprintf("UPDATE %v SET deleted_at=%v %v",
 					scope.QuotedTableName(),
-					scope.AddToVars(time.Now()),
+					scope.AddToVars(NowFunc()),
 					scope.CombinedConditionSql(),
 				))
 		} else {

--- a/callback_query.go
+++ b/callback_query.go
@@ -3,11 +3,10 @@ package gorm
 import (
 	"reflect"
 	"strings"
-	"time"
 )
 
 func Query(scope *Scope) {
-	defer scope.Trace(time.Now())
+	defer scope.Trace(NowFunc())
 
 	var (
 		isSlice        bool

--- a/callback_update.go
+++ b/callback_update.go
@@ -3,7 +3,6 @@ package gorm
 import (
 	"fmt"
 	"strings"
-	"time"
 )
 
 func AssignUpdateAttributes(scope *Scope) {
@@ -36,7 +35,7 @@ func BeforeUpdate(scope *Scope) {
 func UpdateTimeStampWhenUpdate(scope *Scope) {
 	_, ok := scope.Get("gorm:update_column")
 	if !ok {
-		scope.SetColumn("UpdatedAt", time.Now())
+		scope.SetColumn("UpdatedAt", NowFunc())
 	}
 }
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -27,7 +27,7 @@ There are four kinds of callbacks corresponds to sql's CURD: create callbacks, u
 
     func updateCreated(scope *Scope) {
         if scope.HasColumn("Created") {
-            scope.SetColumn("Created", time.Now())
+            scope.SetColumn("Created", NowFunc())
         }
     }
 

--- a/logger.go
+++ b/logger.go
@@ -24,7 +24,7 @@ var sqlRegexp = regexp.MustCompile(`(\$\d+)|\?`)
 func (logger Logger) Print(v ...interface{}) {
 	if len(v) > 1 {
 		level := v[0]
-		currentTime := "\n\033[33m[" + time.Now().Format("2006-01-02 15:04:05") + "]\033[0m"
+		currentTime := "\n\033[33m[" + NowFunc().Format("2006-01-02 15:04:05") + "]\033[0m"
 		source := fmt.Sprintf("\033[35m(%v)\033[0m", v[1])
 		messages := []interface{}{source, currentTime}
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 )
+
+// NowFunc returns current time, this function is exported in order to be able
+// to give the flexiblity to the developer to costumize it accoring to their
+// needs
+//
+//   e.g: return time.Now().UTC()
+//
+var NowFunc = func() time.Time {
+	return time.Now()
+}
 
 type DB struct {
 	Value         interface{}

--- a/main_private.go
+++ b/main_private.go
@@ -56,6 +56,6 @@ func (s *DB) log(v ...interface{}) {
 
 func (s *DB) slog(sql string, t time.Time, vars ...interface{}) {
 	if s.logMode == 2 {
-		s.print("sql", fileWithLineNum(), time.Now().Sub(t), sql, vars)
+		s.print("sql", fileWithLineNum(), NowFunc().Sub(t), sql, vars)
 	}
 }

--- a/scope.go
+++ b/scope.go
@@ -349,7 +349,7 @@ func (scope *Scope) Raw(sql string) *Scope {
 
 // Exec invoke sql
 func (scope *Scope) Exec() *Scope {
-	defer scope.Trace(time.Now())
+	defer scope.Trace(NowFunc())
 
 	if !scope.HasError() {
 		result, err := scope.DB().Exec(scope.Sql, scope.SqlVars...)

--- a/scope_private.go
+++ b/scope_private.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 )
 
 func (scope *Scope) primaryCondiation(value interface{}) string {
@@ -368,13 +367,13 @@ func (scope *Scope) sqlTagForField(field *Field) (typ string) {
 }
 
 func (scope *Scope) row() *sql.Row {
-	defer scope.Trace(time.Now())
+	defer scope.Trace(NowFunc())
 	scope.prepareQuerySql()
 	return scope.DB().QueryRow(scope.Sql, scope.SqlVars...)
 }
 
 func (scope *Scope) rows() (*sql.Rows, error) {
-	defer scope.Trace(time.Now())
+	defer scope.Trace(NowFunc())
 	scope.prepareQuerySql()
 	return scope.DB().Query(scope.Sql, scope.SqlVars...)
 }


### PR DESCRIPTION
Added a global exported function var, to be able to change the format/timezone of the created time struct.

In any point of time (before or after opening a connection) we can safely assingn our custom, `time.Now()` function to `NowFunc()`.
