### PR TITLE
HasTable Test should clean up.

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -133,6 +133,7 @@ func TestHasTable(t *testing.T) {
 		Id    int
 		Stuff string
 	}
+	db.DropTable(&Foo{})
 	if table_ok := db.HasTable(&Foo{}); table_ok {
 		t.Errorf("Table should not exist, but does")
 	}


### PR DESCRIPTION
Running tests more than once will cause a false failure. Sorry about that.
