### PR TITLE
FieldValueByName does now only what it should

### DIFF
--- a/association.go
+++ b/association.go
@@ -177,7 +177,7 @@ func (association *Association) Count() int {
 		whereSql := fmt.Sprintf("%v.%v = ?", newScope.QuotedTableName(), relationship.ForeignKey)
 		scope.db.Model("").Table(newScope.QuotedTableName()).Where(whereSql, association.PrimaryKey).Count(&count)
 	} else if relationship.Kind == "belongs_to" {
-		if v, ok := scope.FieldValueByName(association.Column); ok {
+		if v, err := scope.FieldValueByName(association.Column); err == nil {
 			whereSql := fmt.Sprintf("%v.%v = ?", newScope.QuotedTableName(), relationship.ForeignKey)
 			scope.db.Model("").Table(newScope.QuotedTableName()).Where(whereSql, v).Count(&count)
 		}

--- a/scope.go
+++ b/scope.go
@@ -145,7 +145,7 @@ func (scope *Scope) HasColumn(column string) bool {
 }
 
 // FieldValueByName to get column's value and existence
-func (scope *Scope) FieldValueByName(name string) (interface{}, bool) {
+func (scope *Scope) FieldValueByName(name string) (interface{}, error) {
 	return FieldValueByName(name, scope.Value)
 }
 

--- a/scope_private.go
+++ b/scope_private.go
@@ -474,7 +474,7 @@ func (scope *Scope) related(value interface{}, foreignKeys ...string) *Scope {
 				}
 
 				// has one
-				if foreignValue, ok := scope.FieldValueByName(foreignKey); ok {
+				if foreignValue, err := scope.FieldValueByName(foreignKey); err == nil {
 					toScope.inlineCondition(foreignValue).callCallbacks(scope.db.parent.callback.queries)
 					return scope
 				}


### PR DESCRIPTION
FieldValueByName in utils.go does now only what it should and has proper errors.

For the future:
in scope.related and association.Count there should be proper error handling when scope.FieldValueByName (passes the stuff from FieldValueByName in utils.go) is called.
