### PR TITLE
Add default values support ( https://github.com/jinzhu/gorm/issues/251 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,7 +974,8 @@ If you have an existing database schema, and the primary key field is different 
 ```go
 type Animal struct {
 	AnimalId     int64 `gorm:"primary_key:yes"`
-	Birthday     time.Time
+	Birthday     time.Time `sql:"DEFAULT:NOW()"`
+    Name         string `sql:"default:'galeone'"`
 	Age          int64
 }
 ```
@@ -987,6 +988,46 @@ type Animal struct {
 	Birthday    time.Time `gorm:"column:day_of_the_beast"`
 	Age         int64     `gorm:"column:age_of_the_beast"`
 }
+```
+
+## Default values
+
+If you have defined a default value in the `sql` tag (see the struct Animal above) the generated queries will not contains the value for these fields if is not set.
+
+Eg.
+
+```go
+db.Save(&Animal{Age: 99})
+```
+
+The generated query will be:
+
+```sql
+INSERT INTO animals("birthday","age","name") values(NOW(), '99', 'galeone')
+```
+
+The same thing occurs in update statements.
+
+You should fetch the value again to get the default updated values in the struct.
+
+We can't do the same thing of the primary key (that is always filled with the right value) because default SQL values can be expressions and thus be different from the fields' type (eg. a time.Time fiels has a default value of "NOW()")
+
+So the right way to do an update/insert statement and be sure to get the default values in the struct is
+
+```go
+//Insert
+var animal Animal
+animal.Age = 99
+db.Save(&animal)
+db.First(&animal, animal.AnimalId)
+// Now wo have the animal struct with:
+// Birthday: the insert time
+// Name: the string galeone
+// Age: the setted one -> 99
+
+// For the update statements is the same
+// First save the struct
+// Than fetch it back again
 ```
 
 ## More examples with query chain
@@ -1032,7 +1073,7 @@ db.Where("email = ?", "x@example.org").Attrs(User{RegisteredIp: "111.111.111.111
 * db.RegisterFuncation("Search", func() {})
   db.Model(&[]User{}).Limit(10).Do("Search", "search func's argument")
   db.Mode(&User{}).Do("EditForm").Get("edit_form_html")
-  DefaultValue, DefaultTimeZone, R/W Splitting, Validation
+  DefaultTimeZone, R/W Splitting, Validation
 * Github Pages
 * Includes
 * AlertColumn, DropColumn

--- a/callback_create.go
+++ b/callback_create.go
@@ -2,6 +2,7 @@ package gorm
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -24,9 +25,11 @@ func Create(scope *Scope) {
 	if !scope.HasError() {
 		// set create sql
 		var sqls, columns []string
-
 		for _, field := range scope.Fields() {
 			if field.IsNormal && (!field.IsPrimaryKey || !scope.PrimaryKeyZero()) {
+				if field.DefaultValue != nil && reflect.DeepEqual(field.Field.Interface(), reflect.Zero(field.Field.Type()).Interface()) {
+					continue
+				}
 				columns = append(columns, scope.Quote(field.DBName))
 				sqls = append(sqls, scope.AddToVars(field.Field.Interface()))
 			}

--- a/callback_update.go
+++ b/callback_update.go
@@ -2,6 +2,7 @@ package gorm
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -49,6 +50,9 @@ func Update(scope *Scope) {
 		} else {
 			for _, field := range scope.Fields() {
 				if !field.IsPrimaryKey && field.IsNormal && !field.IsIgnored {
+					if field.DefaultValue != nil && reflect.DeepEqual(field.Field.Interface(), reflect.Zero(field.Field.Type()).Interface()) {
+						continue
+					}
 					sqls = append(sqls, fmt.Sprintf("%v = %v", scope.Quote(field.DBName), scope.AddToVars(field.Field.Interface())))
 				}
 			}

--- a/create_test.go
+++ b/create_test.go
@@ -56,7 +56,7 @@ func TestCreate(t *testing.T) {
 	}
 }
 
-func TestCreateWithNoStdPrimaryKey(t *testing.T) {
+func TestCreateWithNoStdPrimaryKeyAndDefaultValues(t *testing.T) {
 	animal := Animal{Name: "Ferdinand"}
 	if DB.Save(&animal).Error != nil {
 		t.Errorf("No error should happen when create an record without std primary key")
@@ -64,6 +64,26 @@ func TestCreateWithNoStdPrimaryKey(t *testing.T) {
 
 	if animal.Counter == 0 {
 		t.Errorf("No std primary key should be filled value after create")
+	}
+
+	if animal.Name != "Ferdinand" {
+		t.Errorf("Default value should be overrided")
+	}
+
+	// Test create with default value not overrided
+	an := Animal{From: "nerdz"}
+
+	if DB.Save(&an).Error != nil {
+		t.Errorf("No error should happen when create an record without std primary key")
+	}
+
+	// We must fetch the value again, to have the default fields updated
+	// (We can't do this in the update statements, since sql default can be expressions
+	// And be different from the fields' type (eg. a time.Time fiels has a default value of "now()"
+	DB.Model(Animal{}).Where(&Animal{Counter: an.Counter}).First(&an)
+
+	if an.Name != "galeone" {
+		t.Errorf("Default value should fill the field. But got %v", an.Name)
 	}
 }
 

--- a/field.go
+++ b/field.go
@@ -24,6 +24,7 @@ type Field struct {
 	IsBlank      bool
 	IsIgnored    bool
 	IsPrimaryKey bool
+	DefaultValue interface{}
 }
 
 func (field *Field) IsScanner() bool {

--- a/main_test.go
+++ b/main_test.go
@@ -8,8 +8,8 @@ import (
 
 	_ "github.com/denisenkom/go-mssqldb"
 	testdb "github.com/erikstmartin/go-testdb"
-	_ "github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/gorm"
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/now"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"

--- a/scope.go
+++ b/scope.go
@@ -299,6 +299,10 @@ func (scope *Scope) fieldFromStruct(fieldStruct reflect.StructField, withRelatio
 		field.IsPrimaryKey = true
 	}
 
+	if def, ok := parseTagSetting(fieldStruct.Tag.Get("sql"))["DEFAULT"]; ok {
+		field.DefaultValue = def
+	}
+
 	field.Tag = fieldStruct.Tag
 
 	if value, ok := settings["COLUMN"]; ok {

--- a/structs_test.go
+++ b/structs_test.go
@@ -125,9 +125,10 @@ func (i *Num) Scan(src interface{}) error {
 }
 
 type Animal struct {
-	Counter   uint64 `gorm:"primary_key:yes"`
-	Name      string
-	From      string //test reserved sql keyword as field name
+	Counter   uint64    `gorm:"primary_key:yes"`
+	Name      string    `sql:"DEFAULT:'galeone'"`
+	From      string    //test reserved sql keyword as field name
+	Age       time.Time `sql:"DEFAULT:NOW()"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/update_test.go
+++ b/update_test.go
@@ -69,7 +69,7 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
-func TestUpdateWithNoStdPrimaryKey(t *testing.T) {
+func TestUpdateWithNoStdPrimaryKeyAndDefaultValues(t *testing.T) {
 	animal := Animal{Name: "Ferdinand"}
 	DB.Save(&animal)
 	updatedAt1 := animal.UpdatedAt
@@ -84,6 +84,21 @@ func TestUpdateWithNoStdPrimaryKey(t *testing.T) {
 	DB.Find(&animals)
 	if count := DB.Model(Animal{}).Update("CreatedAt", time.Now().Add(2*time.Hour)).RowsAffected; count != int64(len(animals)) {
 		t.Error("RowsAffected should be correct when do batch update")
+	}
+
+	animal = Animal{From: "somewhere"}              // No name fields, should be filled with the default value (galeone)
+	DB.Save(&animal).Update("From", "a nice place") // The name field shoul be untouched
+	DB.First(&animal, animal.Counter)
+	if animal.Name != "galeone" {
+		t.Errorf("Name fiels shouldn't be changed if untouched, but got %v", animal.Name)
+	}
+
+	// When changing a field with a default value, the change must occur
+	animal.Name = "amazing horse"
+	DB.Save(&animal)
+	DB.First(&animal, animal.Counter)
+	if animal.Name != "amazing horse" {
+		t.Errorf("Update a filed with a default value should occur. But got %v\n", animal.Name)
 	}
 }
 


### PR DESCRIPTION
I added the default values support to gorm.

I updated the `README.md` and create the tests.
I tested it locally and works well.

When using the default values is required to fetch again the result of the insert/update statement (as is written into the `REAMDE.md`).
I think that's the only way we can handle these values, since in SQL we can specify default values that don't are strictly the same type of the field (think to the default values of "now()" for a time field or other expressions ).
