### PR TITLE
Create empty slice when records are not found.

### DIFF
--- a/callback_query.go
+++ b/callback_query.go
@@ -77,6 +77,15 @@ func Query(scope *Scope) {
 		}
 
 		if !anyRecordFound {
+			if isSlice && dest.IsNil() {
+				var emptySliceType reflect.Type
+				if isPtr {
+					emptySliceType = reflect.SliceOf(reflect.PtrTo(destType))
+				} else {
+					emptySliceType = reflect.SliceOf(destType)
+				}
+				dest.Set(reflect.MakeSlice(emptySliceType, 0, 0))
+			}
 			scope.Err(RecordNotFound)
 		}
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -78,6 +78,20 @@ func TestFindAsSliceOfPointers(t *testing.T) {
 	}
 }
 
+func TestFindWontReturnNilSlices(t *testing.T) {
+	randomNum := rand.Intn(1000000000)
+
+	var users []User
+	DB.Where("name = ?", randomNum).Find(&users)
+
+	var userPointers []*User
+	DB.Where("name = ?", randomNum).Find(&userPointers)
+
+	if reflect.ValueOf(users).IsNil() || reflect.ValueOf(userPointers).IsNil() {
+		t.Errorf("Should have returned empty slices")
+	}
+}
+
 func TestSearchWithPlainSQL(t *testing.T) {
 	user1 := User{Name: "PlainSqlUser1", Age: 1, Birthday: now.MustParse("2000-1-1")}
 	user2 := User{Name: "PlainSqlUser2", Age: 10, Birthday: now.MustParse("2010-1-1")}


### PR DESCRIPTION
There is a gotcha in golang (go figure!) resulting from the
difference between a nil slice and an empty slice. While the length
of both are `0`, the JSON encoder will interpret the nil slice as
`null` and the empty slice as `[]`. Other libraries (i.e. ActiveRecord)
will return `[]` when no values are found. I have found
that this translates into better client-side code, since you don't
have to protect against `null` arrays.

See [this](http://danott.co/posts/json-marshalling-empty-slices-to-empty-arrays-in-go.html) for more information.
