### PR TITLE
Allow .Open to reuse existing database connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ db, err := gorm.Open("postgres", "user=gorm dbname=gorm sslmode=disable")
 // db, err := gorm.Open("mysql", "user:password@/dbname?charset=utf8&parseTime=True")
 // db, err := gorm.Open("sqlite3", "/tmp/gorm.db")
 
+// You can also use an existing database connection handle
+// dbSql, _ := sql.Open("postgres", "user=gorm dbname=gorm sslmode=disable")
+// db := gorm.Open("postgres", dbSql)
+
 // Get database connection handle [*sql.DB](http://golang.org/pkg/database/sql/#DB)
 db.DB()
 

--- a/main_test.go
+++ b/main_test.go
@@ -554,6 +554,22 @@ func TestCompatibilityMode(t *testing.T) {
 	}
 }
 
+func TestOpenExistingDB(t *testing.T) {
+	DB.Save(&User{Name: "jnfeinstein"})
+	dialect := os.Getenv("GORM_DIALECT")
+
+	db, err := gorm.Open(dialect, DB.DB())
+	if err != nil {
+		t.Errorf("Should have wrapped the existing DB connection")
+	}
+
+	var user User
+	if db.Where("name = ?", "jnfeinstein").First(&user).Error == gorm.RecordNotFound {
+		t.Errorf("Should have found existing record")
+	}
+
+}
+
 func BenchmarkGorm(b *testing.B) {
 	b.N = 2000
 	for x := 0; x < b.N; x++ {


### PR DESCRIPTION
This commit allows you to pass a string or an existing database
connection as the source for gorm. The dialect is still required
because a) there is no common reference to it as far as i know, and
b) gorm allows the dialect to differ from the driver. So, for the sake
of simplicity, you still have to specity the dialect.

This is useful if you have an existing transaction, but still
want to use gorm to format your queries.

This is dependent on the defintion of DB in pkg database/sql having
the field 'dsn', which is the database source, obtained via reflect.

This is a better implementation than #277.
