### PR TITLE
.Count() should always use ToSnake'd foreign keys.

### DIFF
--- a/association.go
+++ b/association.go
@@ -170,15 +170,12 @@ func (association *Association) Count() int {
 			relationship.JoinTable,
 			scope.Quote(ToSnake(relationship.ForeignKey)))
 		scope.db.Model("").Table(newScope.QuotedTableName()).Where(whereSql, association.PrimaryKey).Count(&count)
-	} else if relationship.Kind == "has_many" {
+	} else if relationship.Kind == "has_many" || relationship.Kind == "has_one" {
 		whereSql := fmt.Sprintf("%v.%v = ?", newScope.QuotedTableName(), newScope.Quote(ToSnake(relationship.ForeignKey)))
-		scope.db.Model("").Table(newScope.QuotedTableName()).Where(whereSql, association.PrimaryKey).Count(&count)
-	} else if relationship.Kind == "has_one" {
-		whereSql := fmt.Sprintf("%v.%v = ?", newScope.QuotedTableName(), relationship.ForeignKey)
 		scope.db.Model("").Table(newScope.QuotedTableName()).Where(whereSql, association.PrimaryKey).Count(&count)
 	} else if relationship.Kind == "belongs_to" {
 		if v, err := scope.FieldValueByName(association.Column); err == nil {
-			whereSql := fmt.Sprintf("%v.%v = ?", newScope.QuotedTableName(), relationship.ForeignKey)
+			whereSql := fmt.Sprintf("%v.%v = ?", newScope.QuotedTableName(), newScope.Quote(ToSnake(relationship.ForeignKey)))
 			scope.db.Model("").Table(newScope.QuotedTableName()).Where(whereSql, v).Count(&count)
 		}
 	}


### PR DESCRIPTION
It looks like gorm always uses the snake form of a column by
convention, as seen by searching DBName in scope.go. These counts
were erroring out without the ToSnake'd foreign keys.

Further, the code for has_many and has_one becomes the same (which
makes sense), so I combined the two cases.
