### PR TITLE
Fields are cached when withRelation, so they should only be accessed when withRelation.

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -411,10 +411,11 @@ func (scope *Scope) fieldFromStruct(fieldStruct reflect.StructField, withRelatio
 
 // Fields get value's fields
 func (scope *Scope) Fields(noRelations ...bool) map[string]*Field {
-	if scope.fields != nil {
+	var withRelation = len(noRelations) == 0
+
+	if withRelation && scope.fields != nil {
 		return scope.fields
 	}
-	var withRelation = len(noRelations) == 0
 
 	var fields = map[string]*Field{}
 	if scope.IndirectValue().IsValid() && scope.IndirectValue().Kind() == reflect.Struct {


### PR DESCRIPTION
The result of .Fields() is quite different with and without withRelation.
I assume that if you call it without withRelation, you don't want the
fields that were cached when withRelation was true.
