### PR TITLE
Ensure association fields aren't updated when blank

### DIFF
--- a/callback_update.go
+++ b/callback_update.go
@@ -76,7 +76,7 @@ func updateCallback(scope *Scope) {
 			for _, field := range scope.Fields() {
 				if scope.changeableField(field) {
 					if !field.IsPrimaryKey && field.IsNormal && (field.Name != "CreatedAt" || !field.IsBlank) {
-						if !field.IsForeignKey || !field.IsBlank || !field.HasDefaultValue {
+						if !field.IsBlank || field.HasDefaultValue {
 							sqls = append(sqls, fmt.Sprintf("%v = %v", scope.Quote(field.DBName), scope.AddToVars(field.Field.Interface())))
 						}
 					} else if relationship := field.Relationship; relationship != nil && relationship.Kind == "belongs_to" {

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -98,12 +98,12 @@ func TestRunCallbacks(t *testing.T) {
 	}
 
 	DB.Where("Code = ?", "unique_code").First(&p)
-	if !reflect.DeepEqual(p.GetCallTimes(), []int64{1, 2, 1, 1, 0, 0, 0, 0, 2}) {
+	if !reflect.DeepEqual(p.GetCallTimes(), []int64{1, 2, 0, 1, 0, 0, 0, 0, 2}) {
 		t.Errorf("After update callbacks values are not saved, %v", p.GetCallTimes())
 	}
 
 	DB.Delete(&p)
-	if !reflect.DeepEqual(p.GetCallTimes(), []int64{1, 2, 1, 1, 0, 0, 1, 1, 2}) {
+	if !reflect.DeepEqual(p.GetCallTimes(), []int64{1, 2, 0, 1, 0, 0, 1, 1, 2}) {
 		t.Errorf("After delete callbacks should be invoked successfully, %v", p.GetCallTimes())
 	}
 

--- a/migration_test.go
+++ b/migration_test.go
@@ -292,7 +292,7 @@ func runMigration() {
 		DB.Exec(fmt.Sprintf("drop table %v;", table))
 	}
 
-	values := []interface{}{&Short{}, &ReallyLongThingThatReferencesShort{}, &ReallyLongTableNameToTestMySQLNameLengthLimit{}, &NotSoLongTableName{}, &Product{}, &Email{}, &Address{}, &CreditCard{}, &Company{}, &Role{}, &Language{}, &HNPost{}, &EngadgetPost{}, &Animal{}, &User{}, &JoinTable{}, &Post{}, &Category{}, &Comment{}, &Cat{}, &Dog{}, &Hamster{}, &Toy{}, &ElementWithIgnoredField{}, &Place{}}
+	values := []interface{}{&Short{}, &ReallyLongThingThatReferencesShort{}, &ReallyLongTableNameToTestMySQLNameLengthLimit{}, &NotSoLongTableName{}, &Product{}, &Email{}, &Address{}, &CreditCard{}, &Company{}, &Role{}, &Language{}, &HNPost{}, &EngadgetPost{}, &Animal{}, &User{}, &JoinTable{}, &Post{}, &Category{}, &Comment{}, &Cat{}, &Dog{}, &Hamster{}, &Toy{}, &ElementWithIgnoredField{}, &Place{}, &NewPerson{}, &NewAddress{}}
 	for _, value := range values {
 		DB.DropTable(value)
 	}

--- a/update_test.go
+++ b/update_test.go
@@ -434,8 +434,7 @@ type NewPerson struct {
 }
 
 func TestAssociatedBlankValues(t *testing.T) {
-	DB.LogMode(true)
-
+	// Create person
 	person1 := NewPerson{
 		ID:   1,
 		Name: "Person",
@@ -448,6 +447,7 @@ func TestAssociatedBlankValues(t *testing.T) {
 
 	DB.Save(&person1)
 
+	// Update person only updating house number
 	person1Update := NewPerson{
 		ID: 1,
 		NewAddress: NewAddress{
@@ -457,17 +457,21 @@ func TestAssociatedBlankValues(t *testing.T) {
 	}
 	DB.Model(&person1Update).Update(person1Update)
 
+	// Get person back from database
 	var personGet NewPerson
 	DB.Preload("NewAddress").Find(&personGet)
 
+	// Check that LineOne hasn't changed
 	if personGet.NewAddress.LineOne != "Street One" {
 		t.Errorf("line one should be 'Street One' as it was updated with a blank value. Value is %s", personGet.NewAddress.LineOne)
 	}
 
+	// Ensure house number has updated
 	if personGet.NewAddress.HouseNumber != 2 {
 		t.Errorf("house number should be 2 following the update. Value is %d", personGet.NewAddress.HouseNumber)
 	}
 
+	// Check that Person is still the original value
 	if personGet.Name != "Person" {
 		t.Errorf("name should be 'Person' as it was updated with a blank value. Value is %s", personGet.Name)
 	}

--- a/update_test.go
+++ b/update_test.go
@@ -419,6 +419,60 @@ func TestUpdatesWithBlankValues(t *testing.T) {
 	}
 }
 
+type NewAddress struct {
+	ID int
+	HouseNumber int
+	LineOne string
+}
+
+type NewPerson struct {
+	ID int
+	Name string
+	NewAddress NewAddress
+
+	NewAddressID int
+}
+
+func TestAssociatedBlankValues(t *testing.T) {
+	DB.LogMode(true)
+
+	person1 := NewPerson{
+		ID:   1,
+		Name: "Person",
+		NewAddress: NewAddress{
+			ID:          1,
+			HouseNumber: 1,
+			LineOne:     "Street One",
+		},
+	}
+
+	DB.Save(&person1)
+
+	person1Update := NewPerson{
+		ID: 1,
+		NewAddress: NewAddress{
+			ID:          1,
+			HouseNumber: 2,
+		},
+	}
+	DB.Model(&person1Update).Update(person1Update)
+
+	var personGet NewPerson
+	DB.Preload("NewAddress").Find(&personGet)
+
+	if personGet.NewAddress.LineOne != "Street One" {
+		t.Errorf("line one should be 'Street One' as it was updated with a blank value. Value is %s", personGet.NewAddress.LineOne)
+	}
+
+	if personGet.NewAddress.HouseNumber != 2 {
+		t.Errorf("house number should be 2 following the update. Value is %d", personGet.NewAddress.HouseNumber)
+	}
+
+	if personGet.Name != "Person" {
+		t.Errorf("name should be 'Person' as it was updated with a blank value. Value is %s", personGet.Name)
+	}
+}
+
 type ElementWithIgnoredField struct {
 	Id           int64
 	Value        string


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [X] Do only one thing
- [X] No API-breaking changes
- [X] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

This pull request ensures that fields aren't updated when blank. Previously this was not true for associated fields and I believe this was a bug. This fixes a number of issues:

https://github.com/jinzhu/gorm/issues/2675
https://github.com/jinzhu/gorm/issues/2275
https://github.com/jinzhu/gorm/issues/1838