### PR TITLE
Fix rows affected log for Pluck, and remove rows affected log uncountable case and getting single row case

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -50,7 +50,7 @@ func updateTimeStampForCreateCallback(scope *Scope) {
 // createCallback the callback used to insert data into database
 func createCallback(scope *Scope) {
 	if !scope.HasError() {
-		defer scope.trace(NowFunc())
+		defer scope.trace(NowFunc(), true)
 
 		var (
 			columns, placeholders        []string

--- a/callback_query.go
+++ b/callback_query.go
@@ -24,7 +24,7 @@ func queryCallback(scope *Scope) {
 		return
 	}
 
-	defer scope.trace(NowFunc())
+	defer scope.trace(NowFunc(), true)
 
 	var (
 		isSlice, isPtr bool

--- a/logger.go
+++ b/logger.go
@@ -106,7 +106,9 @@ var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 			}
 
 			messages = append(messages, sql)
-			messages = append(messages, fmt.Sprintf(" \n\033[36;31m[%v]\033[0m ", strconv.FormatInt(values[5].(int64), 10)+" rows affected or returned "))
+			if len(values) > 5 {
+				messages = append(messages, fmt.Sprintf(" \n\033[36;31m[%v]\033[0m ", strconv.FormatInt(values[5].(int64), 10)+" rows affected or returned "))
+			}
 		} else {
 			messages = append(messages, "\033[31;1m")
 			messages = append(messages, values[2:]...)

--- a/main.go
+++ b/main.go
@@ -366,12 +366,16 @@ func (s *DB) Scan(dest interface{}) *DB {
 
 // Row return `*sql.Row` with given conditions
 func (s *DB) Row() *sql.Row {
-	return s.NewScope(s.Value).row()
+	scope := s.NewScope(s.Value)
+	defer scope.trace(NowFunc(), false)
+	return scope.row()
 }
 
 // Rows return `*sql.Rows` with given conditions
 func (s *DB) Rows() (*sql.Rows, error) {
-	return s.NewScope(s.Value).rows()
+	scope := s.NewScope(s.Value)
+	defer scope.trace(NowFunc(), false)
+	return scope.rows()
 }
 
 // ScanRows scan `*sql.Rows` to give struct
@@ -874,8 +878,12 @@ func (s *DB) log(v ...interface{}) {
 	}
 }
 
-func (s *DB) slog(sql string, t time.Time, vars ...interface{}) {
+func (s *DB) slog(sql string, t time.Time, showRowsAffected bool, vars ...interface{}) {
 	if s.logMode == detailedLogMode {
-		s.print("sql", fileWithLineNum(), NowFunc().Sub(t), sql, vars, s.RowsAffected)
+		if showRowsAffected {
+			s.print("sql", fileWithLineNum(), NowFunc().Sub(t), sql, vars, s.RowsAffected)
+		} else {
+			s.print("sql", fileWithLineNum(), NowFunc().Sub(t), sql, vars)
+		}
 	}
 }


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [ ] New code/logic commented & tested

### What did this pull request do?

* fixed: #2796
When use `Pluck` fix [n rows affected or returned ] log.
* https://github.com/jinzhu/gorm/pull/2143#issuecomment-435590448
remove it from log for `Row`

#### before
* use `Find`
```sql
[2019-12-08 23:59:45]  [1.22ms]  SELECT * FROM `users`  WHERE `users`.`deleted_at` IS NULL AND ((id IN (1,2)))
[2 rows affected or returned ]
```
* use `Pluck`
```sql
[2019-12-08 23:59:45]  [1.22ms]  SELECT name FROM `users`  WHERE (id IN (1,2))
[0 rows affected or returned ]
```
* use `Count`
```sql
[2019-12-08 23:59:45]  [1.17ms]  SELECT count(*) FROM `users`  WHERE (id IN (1,2))
[0 rows affected or returned ]
```

#### after
* use `Find`
```sql
[2019-12-09 00:00:24]  [1.34ms]  SELECT * FROM `users`  WHERE `users`.`deleted_at` IS NULL AND ((id IN (1,2)))
[2 rows affected or returned ]
```
* use `Pluck`
```sql
[2019-12-09 00:00:24]  [1.08ms]  SELECT name FROM `users`  WHERE (id IN (1,2))
[2 rows affected or returned ]
```
* use `Count`
```sql
[2019-12-09 00:00:24]  [1.25ms]  SELECT count(*) FROM `users`  WHERE (id IN (1,2))
```