### PR TITLE
Makes order of values deterministic for IN(?, ?..) style query

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -1324,7 +1324,7 @@ func (scope *Scope) autoIndex() *Scope {
 }
 
 func (scope *Scope) getColumnAsArray(columns []string, values ...interface{}) (results [][]interface{}) {
-	resultMap := make(map[string][]interface{})
+	resultMap := make(map[string]bool)
 	for _, value := range values {
 		indirectValue := indirect(reflect.ValueOf(value))
 
@@ -1345,7 +1345,8 @@ func (scope *Scope) getColumnAsArray(columns []string, values ...interface{}) (r
 				if hasValue {
 					h := fmt.Sprint(result...)
 					if _, exist := resultMap[h]; !exist {
-						resultMap[h] = result
+						resultMap[h] = true
+						results = append(results, result)
 					}
 				}
 			}
@@ -1363,13 +1364,11 @@ func (scope *Scope) getColumnAsArray(columns []string, values ...interface{}) (r
 			if hasValue {
 				h := fmt.Sprint(result...)
 				if _, exist := resultMap[h]; !exist {
-					resultMap[h] = result
+					resultMap[h] = true
+					results = append(results, result)
 				}
 			}
 		}
-	}
-	for _, v := range resultMap {
-		results = append(results, v)
 	}
 	return
 }

--- a/scope.go
+++ b/scope.go
@@ -1324,7 +1324,8 @@ func (scope *Scope) autoIndex() *Scope {
 }
 
 func (scope *Scope) getColumnAsArray(columns []string, values ...interface{}) (results [][]interface{}) {
-	resultMap := make(map[string]bool)
+	keyExists := struct{}{}
+	resultsKeys := make(map[string]struct{})
 	for _, value := range values {
 		indirectValue := indirect(reflect.ValueOf(value))
 
@@ -1344,8 +1345,8 @@ func (scope *Scope) getColumnAsArray(columns []string, values ...interface{}) (r
 
 				if hasValue {
 					h := fmt.Sprint(result...)
-					if _, exist := resultMap[h]; !exist {
-						resultMap[h] = true
+					if _, exist := resultsKeys[h]; !exist {
+						resultsKeys[h] = keyExists
 						results = append(results, result)
 					}
 				}
@@ -1363,8 +1364,8 @@ func (scope *Scope) getColumnAsArray(columns []string, values ...interface{}) (r
 
 			if hasValue {
 				h := fmt.Sprint(result...)
-				if _, exist := resultMap[h]; !exist {
-					resultMap[h] = true
+				if _, exist := resultsKeys[h]; !exist {
+					resultsKeys[h] = keyExists
 					results = append(results, result)
 				}
 			}


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [ ] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

#### What did this pull request do?

- [x] Makes order of values deterministic for IN(?, ?..) style query

  Currently during preloads of associations the order of parameterized/comma-
separated values for IN(?, ?..) style query is not deterministic. This commit
fixes that which removes random failure when writing tests which asserts exact
queries run (e.g. using DATA-DOG/go-sqlmock library or such).
