### PR TITLE
Add 2 public functions to get SqlExpr.expr and SqlExpr.args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jinzhu/gorm
+module github.com/aalfadhila/gorm
 
 go 1.12
 

--- a/utils.go
+++ b/utils.go
@@ -63,6 +63,16 @@ type SqlExpr struct {
 	args []interface{}
 }
 
+// GetExpr get SqlExpr expr
+func (s *SqlExpr) GetExpr() string {
+	return s.expr
+}
+
+// GetArgs get SqlExpr args
+func (s *SqlExpr) GetArgs() []interface{} {
+	return s.args
+}
+
 // Expr generate raw SQL expression, for example:
 //     DB.Model(&product).Update("price", gorm.Expr("price * ? + ?", 2, 100))
 func Expr(expression string, args ...interface{}) *SqlExpr {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

Add 2 functions to get `SqlExpr.expr` and `SqlExpr.args` to make it easier when building raw query from `gorm.DB`