### PR TITLE
Issue #3007: Fix search clone array corruption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,10 @@ go 1.12
 require (
 	github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5
-	github.com/go-sql-driver/mysql v1.4.1
+	github.com/go-sql-driver/mysql v1.5.0
 	github.com/jinzhu/inflection v1.0.0
 	github.com/jinzhu/now v1.0.1
 	github.com/lib/pq v1.1.1
 	github.com/mattn/go-sqlite3 v2.0.1+incompatible
 	golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,10 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6RO
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
-github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
-github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
-github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.0.1 h1:HjfetcXq097iXP0uoPCdnM4Efp5/9MsM0/M+XOTeR3M=
@@ -20,10 +19,7 @@ golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0F
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd h1:GGJVjV8waZKRHrgwvtH66z9ZGVurTD1MT0n1Bb+q4aM=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
-google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/search.go
+++ b/search.go
@@ -32,7 +32,57 @@ type searchPreload struct {
 }
 
 func (s *search) clone() *search {
-	clone := *s
+	clone := search{
+		db:               s.db,
+		whereConditions:  make([]map[string]interface{}, len(s.whereConditions)),
+		orConditions:     make([]map[string]interface{}, len(s.orConditions)),
+		notConditions:    make([]map[string]interface{}, len(s.notConditions)),
+		havingConditions: make([]map[string]interface{}, len(s.havingConditions)),
+		joinConditions:   make([]map[string]interface{}, len(s.joinConditions)),
+		initAttrs:        make([]interface{}, len(s.initAttrs)),
+		assignAttrs:      make([]interface{}, len(s.assignAttrs)),
+		selects:          s.selects,
+		omits:            make([]string, len(s.omits)),
+		orders:           make([]interface{}, len(s.orders)),
+		preload:          make([]searchPreload, len(s.preload)),
+		offset:           s.offset,
+		limit:            s.limit,
+		group:            s.group,
+		tableName:        s.tableName,
+		raw:              s.raw,
+		Unscoped:         s.Unscoped,
+		ignoreOrderQuery: s.ignoreOrderQuery,
+	}
+	for i, value := range s.whereConditions {
+		clone.whereConditions[i] = value
+	}
+	for i, value := range s.orConditions {
+		clone.orConditions[i] = value
+	}
+	for i, value := range s.notConditions {
+		clone.notConditions[i] = value
+	}
+	for i, value := range s.havingConditions {
+		clone.havingConditions[i] = value
+	}
+	for i, value := range s.joinConditions {
+		clone.joinConditions[i] = value
+	}
+	for i, value := range s.initAttrs {
+		clone.initAttrs[i] = value
+	}
+	for i, value := range s.assignAttrs {
+		clone.assignAttrs[i] = value
+	}
+	for i, value := range s.omits {
+		clone.omits[i] = value
+	}
+	for i, value := range s.orders {
+		clone.orders[i] = value
+	}
+	for i, value := range s.preload {
+		clone.preload[i] = value
+	}
 	return &clone
 }
 


### PR DESCRIPTION
Method-chaining in gorm is predicated on `search`'s `clone` method
returning a copy of the `search` instance such that no change that
is made to the copy affects the original.

However, the original implementation copied the slices of the various
slice properties (such as `whereConditions`), with the incorrect
understanding that `append` would create a new slice each time that
it was called.  In some cases, this is true.  Practically, go
doubles the size of the slice once it gets full, so the following
slice `append` calls would result in a new slice:

* 0 -> 1
* 1 -> 2
* 2 -> 4
* 4 -> 8
* and so on.

So, when the number of "where" conditions (or any other slice
property) was 0, 1, 2, or 4, method-chaining would work as expected.
However, when it was 3, 5, 6, or 7, modifying the copy would modify
the original.

The solution is simply to create new slices in `clone`.

Make sure these boxes checked before submitting your pull request.

- [] Do only one thing
- [] No API-breaking changes
- [] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
