### PR TITLE
Spelling fix for "condtion" -> "condition"

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -33,7 +33,7 @@ func (db *DB) Clauses(conds ...clause.Expression) (tx *DB) {
 	}
 
 	if len(whereConds) > 0 {
-		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondtion(whereConds[0], whereConds[1:]...)})
+		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondition(whereConds[0], whereConds[1:]...)})
 	}
 	return
 }
@@ -121,7 +121,7 @@ func (db *DB) Omit(columns ...string) (tx *DB) {
 // Where add conditions
 func (db *DB) Where(query interface{}, args ...interface{}) (tx *DB) {
 	tx = db.getInstance()
-	if conds := tx.Statement.BuildCondtion(query, args...); len(conds) > 0 {
+	if conds := tx.Statement.BuildCondition(query, args...); len(conds) > 0 {
 		tx.Statement.AddClause(clause.Where{Exprs: conds})
 	}
 	return
@@ -130,7 +130,7 @@ func (db *DB) Where(query interface{}, args ...interface{}) (tx *DB) {
 // Not add NOT conditions
 func (db *DB) Not(query interface{}, args ...interface{}) (tx *DB) {
 	tx = db.getInstance()
-	if conds := tx.Statement.BuildCondtion(query, args...); len(conds) > 0 {
+	if conds := tx.Statement.BuildCondition(query, args...); len(conds) > 0 {
 		tx.Statement.AddClause(clause.Where{Exprs: []clause.Expression{clause.Not(conds...)}})
 	}
 	return
@@ -139,7 +139,7 @@ func (db *DB) Not(query interface{}, args ...interface{}) (tx *DB) {
 // Or add OR conditions
 func (db *DB) Or(query interface{}, args ...interface{}) (tx *DB) {
 	tx = db.getInstance()
-	if conds := tx.Statement.BuildCondtion(query, args...); len(conds) > 0 {
+	if conds := tx.Statement.BuildCondition(query, args...); len(conds) > 0 {
 		tx.Statement.AddClause(clause.Where{Exprs: []clause.Expression{clause.Or(conds...)}})
 	}
 	return
@@ -170,7 +170,7 @@ func (db *DB) Group(name string) (tx *DB) {
 func (db *DB) Having(query interface{}, args ...interface{}) (tx *DB) {
 	tx = db.getInstance()
 	tx.Statement.AddClause(clause.GroupBy{
-		Having: tx.Statement.BuildCondtion(query, args...),
+		Having: tx.Statement.BuildCondition(query, args...),
 	})
 	return
 }

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -55,7 +55,7 @@ func (db *DB) First(dest interface{}, conds ...interface{}) (tx *DB) {
 		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey},
 	})
 	if len(conds) > 0 {
-		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondtion(conds[0], conds[1:]...)})
+		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondition(conds[0], conds[1:]...)})
 	}
 	tx.Statement.RaiseErrorOnNotFound = true
 	tx.Statement.Dest = dest
@@ -67,7 +67,7 @@ func (db *DB) First(dest interface{}, conds ...interface{}) (tx *DB) {
 func (db *DB) Take(dest interface{}, conds ...interface{}) (tx *DB) {
 	tx = db.getInstance().Limit(1)
 	if len(conds) > 0 {
-		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondtion(conds[0], conds[1:]...)})
+		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondition(conds[0], conds[1:]...)})
 	}
 	tx.Statement.RaiseErrorOnNotFound = true
 	tx.Statement.Dest = dest
@@ -82,7 +82,7 @@ func (db *DB) Last(dest interface{}, conds ...interface{}) (tx *DB) {
 		Desc:   true,
 	})
 	if len(conds) > 0 {
-		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondtion(conds[0], conds[1:]...)})
+		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondition(conds[0], conds[1:]...)})
 	}
 	tx.Statement.RaiseErrorOnNotFound = true
 	tx.Statement.Dest = dest
@@ -94,7 +94,7 @@ func (db *DB) Last(dest interface{}, conds ...interface{}) (tx *DB) {
 func (db *DB) Find(dest interface{}, conds ...interface{}) (tx *DB) {
 	tx = db.getInstance()
 	if len(conds) > 0 {
-		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondtion(conds[0], conds[1:]...)})
+		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondition(conds[0], conds[1:]...)})
 	}
 	tx.Statement.Dest = dest
 	tx.callbacks.Query().Execute(tx)
@@ -130,7 +130,7 @@ func (db *DB) FirstOrInit(dest interface{}, conds ...interface{}) (tx *DB) {
 
 		// initialize with attrs, conds
 		if len(tx.Statement.attrs) > 0 {
-			exprs := tx.Statement.BuildCondtion(tx.Statement.attrs[0], tx.Statement.attrs[1:]...)
+			exprs := tx.Statement.BuildCondition(tx.Statement.attrs[0], tx.Statement.attrs[1:]...)
 			tx.assignExprsToValue(exprs)
 		}
 		tx.Error = nil
@@ -138,7 +138,7 @@ func (db *DB) FirstOrInit(dest interface{}, conds ...interface{}) (tx *DB) {
 
 	// initialize with attrs, conds
 	if len(tx.Statement.assigns) > 0 {
-		exprs := tx.Statement.BuildCondtion(tx.Statement.assigns[0], tx.Statement.assigns[1:]...)
+		exprs := tx.Statement.BuildCondition(tx.Statement.assigns[0], tx.Statement.assigns[1:]...)
 		tx.assignExprsToValue(exprs)
 	}
 	return
@@ -157,19 +157,19 @@ func (db *DB) FirstOrCreate(dest interface{}, conds ...interface{}) (tx *DB) {
 
 		// initialize with attrs, conds
 		if len(tx.Statement.attrs) > 0 {
-			exprs := tx.Statement.BuildCondtion(tx.Statement.attrs[0], tx.Statement.attrs[1:]...)
+			exprs := tx.Statement.BuildCondition(tx.Statement.attrs[0], tx.Statement.attrs[1:]...)
 			tx.assignExprsToValue(exprs)
 		}
 
 		// initialize with attrs, conds
 		if len(tx.Statement.assigns) > 0 {
-			exprs := tx.Statement.BuildCondtion(tx.Statement.assigns[0], tx.Statement.assigns[1:]...)
+			exprs := tx.Statement.BuildCondition(tx.Statement.assigns[0], tx.Statement.assigns[1:]...)
 			tx.assignExprsToValue(exprs)
 		}
 
 		return tx.Create(dest)
 	} else if len(tx.Statement.assigns) > 0 {
-		exprs := tx.Statement.BuildCondtion(tx.Statement.assigns[0], tx.Statement.assigns[1:]...)
+		exprs := tx.Statement.BuildCondition(tx.Statement.assigns[0], tx.Statement.assigns[1:]...)
 		assigns := map[string]interface{}{}
 		for _, expr := range exprs {
 			if eq, ok := expr.(clause.Eq); ok {
@@ -225,7 +225,7 @@ func (db *DB) UpdateColumns(values interface{}) (tx *DB) {
 func (db *DB) Delete(value interface{}, conds ...interface{}) (tx *DB) {
 	tx = db.getInstance()
 	if len(conds) > 0 {
-		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondtion(conds[0], conds[1:]...)})
+		tx.Statement.AddClause(clause.Where{Exprs: tx.Statement.BuildCondition(conds[0], conds[1:]...)})
 	}
 	tx.Statement.Dest = value
 	tx.callbacks.Delete().Execute(tx)

--- a/statement.go
+++ b/statement.go
@@ -218,8 +218,8 @@ func (stmt *Statement) AddClauseIfNotExists(v clause.Interface) {
 	}
 }
 
-// BuildCondtion build condition
-func (stmt Statement) BuildCondtion(query interface{}, args ...interface{}) (conds []clause.Expression) {
+// BuildCondition build condition
+func (stmt Statement) BuildCondition(query interface{}, args ...interface{}) (conds []clause.Expression) {
 	if sql, ok := query.(string); ok {
 		// if it is a number, then treats it as primary key
 		if _, err := strconv.Atoi(sql); err != nil {

--- a/statement_test.go
+++ b/statement_test.go
@@ -15,17 +15,17 @@ func TestWhereCloneCorruption(t *testing.T) {
 			for w := 0; w < whereCount; w++ {
 				s = s.clone()
 				s.AddClause(clause.Where{
-					Exprs: s.BuildCondtion(fmt.Sprintf("where%d", w)),
+					Exprs: s.BuildCondition(fmt.Sprintf("where%d", w)),
 				})
 			}
 
 			s1 := s.clone()
 			s1.AddClause(clause.Where{
-				Exprs: s.BuildCondtion("FINAL1"),
+				Exprs: s.BuildCondition("FINAL1"),
 			})
 			s2 := s.clone()
 			s2.AddClause(clause.Where{
-				Exprs: s.BuildCondtion("FINAL2"),
+				Exprs: s.BuildCondition("FINAL2"),
 			})
 
 			if reflect.DeepEqual(s1.Clauses["WHERE"], s2.Clauses["WHERE"]) {


### PR DESCRIPTION
This fixes a spelling error in the word "condition"; in particular,
the `BuildCondtion` function should be named `BuildCondition`.