### PR TITLE
Fix spelling errors in test method names

### DIFF
--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -190,7 +190,7 @@ func TestPolymorphicHasOne(t *testing.T) {
 	})
 }
 
-func TestCreateEmptyStrut(t *testing.T) {
+func TestCreateEmptyStruct(t *testing.T) {
 	type EmptyStruct struct {
 		ID uint
 	}
@@ -244,7 +244,7 @@ func TestCreateWithNowFuncOverride(t *testing.T) {
 	AssertEqual(t, newUser.UpdatedAt, curTime)
 }
 
-func TestCreateWithNoGORMPrimayKey(t *testing.T) {
+func TestCreateWithNoGORMPrimaryKey(t *testing.T) {
 	type JoinTable struct {
 		UserID   uint
 		FriendID uint


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [ ] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

This PR fixes typos in test method names in `create_test.go`. `PrimayKey` -> `PrimaryKey` and `Strut` -> `Struct`.