### PR TITLE
Create supports Array / ArrayPtr

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -73,7 +73,7 @@ type Tabler interface {
 // get data type from dialector
 func Parse(dest interface{}, cacheStore *sync.Map, namer Namer) (*Schema, error) {
 	modelType := reflect.ValueOf(dest).Type()
-	for modelType.Kind() == reflect.Slice || modelType.Kind() == reflect.Ptr {
+	for modelType.Kind() == reflect.Slice || modelType.Kind() == reflect.Array || modelType.Kind() == reflect.Ptr {
 		modelType = modelType.Elem()
 	}
 

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -189,6 +189,48 @@ func TestPolymorphicHasOne(t *testing.T) {
 			CheckPet(t, *pet, *pet)
 		}
 	})
+
+	t.Run("Array", func(t *testing.T) {
+		var pets = [...]Pet{{
+			Name: "PolymorphicHasOne-Array-1",
+			Toy:  Toy{Name: "Toy-PolymorphicHasOne-Array-1"},
+		}, {
+			Name: "PolymorphicHasOne-Array-2",
+			Toy:  Toy{Name: "Toy-PolymorphicHasOne-Array-2"},
+		}, {
+			Name: "PolymorphicHasOne-Array-3",
+			Toy:  Toy{Name: "Toy-PolymorphicHasOne-Array-3"},
+		}}
+
+		if err := DB.Create(&pets).Error; err != nil {
+			t.Fatalf("errors happened when create: %v", err)
+		}
+
+		for _, pet := range pets {
+			CheckPet(t, pet, pet)
+		}
+	})
+
+	t.Run("ArrayPtr", func(t *testing.T) {
+		var pets = [...]*Pet{{
+			Name: "PolymorphicHasOne-Array-1",
+			Toy:  Toy{Name: "Toy-PolymorphicHasOne-Array-1"},
+		}, {
+			Name: "PolymorphicHasOne-Array-2",
+			Toy:  Toy{Name: "Toy-PolymorphicHasOne-Array-2"},
+		}, {
+			Name: "PolymorphicHasOne-Array-3",
+			Toy:  Toy{Name: "Toy-PolymorphicHasOne-Array-3"},
+		}}
+
+		if err := DB.Create(&pets).Error; err != nil {
+			t.Fatalf("errors happened when create: %v", err)
+		}
+
+		for _, pet := range pets {
+			CheckPet(t, *pet, *pet)
+		}
+	})
 }
 
 func TestCreateEmptyStruct(t *testing.T) {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

Create function supports batch create, but only Slice is supported.
There are cases where it would be desirable if Array could be used in some cases.
For example, when using faker to create a fixed number of records.

This change supports it.

-----

By the way, in my local PC the other test failed than before the PR, but I ignored it.
It seems that the return value of test script is always 0 (it means success)

Please use the patch below.

```diff
diff --git a/tests/tests_all.sh b/tests/tests_all.sh
index a321fe3..f85a7a4 100755
--- a/tests/tests_all.sh
+++ b/tests/tests_all.sh
@@ -1,3 +1,4 @@
+#!/bin/sh -e
 dialects=("sqlite" "mysql" "postgres" "sqlserver")
 
 if [[ $(pwd) == *"gorm/tests"* ]]; then
```
