### PR TITLE
processor.Execute() must use custom table if provided.

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -96,6 +96,12 @@ func (p *processor) Execute(db *DB) {
 		}
 	}
 
+	if nil != stmt.Schema {
+		if stmt.Table != stmt.Schema.Table {
+			stmt.Schema.Table = stmt.Table
+		}
+	}
+
 	for _, f := range p.fns {
 		f(db)
 	}

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -8,6 +8,19 @@ import (
 	. "gorm.io/gorm/utils/tests"
 )
 
+func TestDeleteWithCustomTable(t *testing.T) {
+	type Entity struct{ ID int }
+
+	stmt := DB.
+		Session(&gorm.Session{DryRun: true}).
+		Table("my_entity").
+		Delete(&Entity{ID: 123}).Statement
+
+	if "my_entity" != stmt.Schema.Table {
+		t.Errorf("wrong table used. Expecting: my_table, actual: %s", stmt.Schema.Table)
+	}
+}
+
 func TestDelete(t *testing.T) {
 	var users = []User{*GetUser("delete", Config{}), *GetUser("delete", Config{}), *GetUser("delete", Config{})}
 


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Error when I delete entity with custom table.

### User Case Description


```go
db.Table("my_entity").Delete(&entity)
```

Table used: entities, expecting: my_entity.
