### PR TITLE
Woraround for some database that returns capitalized letter for non-terminal column name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/jinzhu/inflection v1.0.0
 	github.com/jinzhu/now v1.1.1
+	github.com/thoas/go-funk v0.7.0
 )

--- a/gorm.go
+++ b/gorm.go
@@ -32,6 +32,10 @@ type Config struct {
 	DisableAutomaticPing bool
 	// DisableForeignKeyConstraintWhenMigrating
 	DisableForeignKeyConstraintWhenMigrating bool
+	// Workarounds this is for some exotic databases that requires internal changes rather than avoiding the problem by extending the dialects
+	Workarounds struct {
+		DoColumnLowerCasing bool
+	}
 
 	// ClauseBuilders clause builder
 	ClauseBuilders map[string]clause.ClauseBuilder

--- a/scan.go
+++ b/scan.go
@@ -5,12 +5,18 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/thoas/go-funk"
+
 	"gorm.io/gorm/schema"
 )
 
 func Scan(rows *sql.Rows, db *DB, initialized bool) {
 	columns, _ := rows.Columns()
 	values := make([]interface{}, len(columns))
+
+	columns = funk.Map(columns, func(s string) string {
+		return strings.ToLower(s)
+	}).([]string)
 
 	switch dest := db.Statement.Dest.(type) {
 	case map[string]interface{}, *map[string]interface{}:

--- a/scan.go
+++ b/scan.go
@@ -14,9 +14,11 @@ func Scan(rows *sql.Rows, db *DB, initialized bool) {
 	columns, _ := rows.Columns()
 	values := make([]interface{}, len(columns))
 
-	columns = funk.Map(columns, func(s string) string {
-		return strings.ToLower(s)
-	}).([]string)
+	if db.Workarounds.DoColumnLowerCasing {
+		columns = funk.Map(columns, func(s string) string {
+			return strings.ToLower(s)
+		}).([]string)
+	}
 
 	switch dest := db.Statement.Dest.(type) {
 	case map[string]interface{}, *map[string]interface{}:


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [ ] ~Non breaking API changes~ (potentially breaking)
- [ ] Tested

### What did this pull request do?
When scanning rows, just convert all the column names to lower case

### User Case Description
This is to remediate some database who actually returns capitalized name no matter what the name you specified in your table creation (Yes I mean you and perhaps only you Oracle)

But this also mean you might fuck up the namer because what if they do like capitalized name?