### PR TITLE
Auto creating/updating time with unix (milli) second

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -19,8 +19,9 @@ type DataType string
 type TimeType int64
 
 const (
-	UnixSecond     TimeType = 1
-	UnixNanosecond TimeType = 2
+	UnixSecond      TimeType = 1
+	UnixMillisecond TimeType = 2
+	UnixNanosecond  TimeType = 3
 )
 
 const (
@@ -231,6 +232,8 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 	if v, ok := field.TagSettings["AUTOCREATETIME"]; ok || (field.Name == "CreatedAt" && (field.DataType == Time || field.DataType == Int || field.DataType == Uint)) {
 		if strings.ToUpper(v) == "NANO" {
 			field.AutoCreateTime = UnixNanosecond
+		} else if strings.ToUpper(v) == "MILLI" {
+			field.AutoCreateTime = UnixMillisecond
 		} else {
 			field.AutoCreateTime = UnixSecond
 		}
@@ -239,6 +242,8 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 	if v, ok := field.TagSettings["AUTOUPDATETIME"]; ok || (field.Name == "UpdatedAt" && (field.DataType == Time || field.DataType == Int || field.DataType == Uint)) {
 		if strings.ToUpper(v) == "NANO" {
 			field.AutoUpdateTime = UnixNanosecond
+		} else if strings.ToUpper(v) == "MILLI" {
+			field.AutoUpdateTime = UnixMillisecond
 		} else {
 			field.AutoUpdateTime = UnixSecond
 		}
@@ -549,6 +554,8 @@ func (field *Field) setupValuerAndSetter() {
 			case time.Time:
 				if field.AutoCreateTime == UnixNanosecond || field.AutoUpdateTime == UnixNanosecond {
 					field.ReflectValueOf(value).SetInt(data.UnixNano())
+				} else if field.AutoCreateTime == UnixMillisecond || field.AutoUpdateTime == UnixMillisecond {
+					field.ReflectValueOf(value).SetInt(data.UnixNano() / 1e6)
 				} else {
 					field.ReflectValueOf(value).SetInt(data.Unix())
 				}
@@ -556,6 +563,8 @@ func (field *Field) setupValuerAndSetter() {
 				if data != nil {
 					if field.AutoCreateTime == UnixNanosecond || field.AutoUpdateTime == UnixNanosecond {
 						field.ReflectValueOf(value).SetInt(data.UnixNano())
+					} else if field.AutoCreateTime == UnixMillisecond || field.AutoUpdateTime == UnixMillisecond {
+						field.ReflectValueOf(value).SetInt(data.UnixNano() / 1e6)
 					} else {
 						field.ReflectValueOf(value).SetInt(data.Unix())
 					}

--- a/tests/customize_field_test.go
+++ b/tests/customize_field_test.go
@@ -61,18 +61,20 @@ func TestCustomColumnAndIgnoredFieldClash(t *testing.T) {
 func TestCustomizeField(t *testing.T) {
 	type CustomizeFieldStruct struct {
 		gorm.Model
-		Name                   string
-		FieldAllowCreate       string `gorm:"<-:create"`
-		FieldAllowUpdate       string `gorm:"<-:update"`
-		FieldAllowSave         string `gorm:"<-"`
-		FieldAllowSave2        string `gorm:"<-:create,update"`
-		FieldAllowSave3        string `gorm:"->:false;<-:create"`
-		FieldReadonly          string `gorm:"->"`
-		FieldIgnore            string `gorm:"-"`
-		AutoUnixCreateTime     int64  `gorm:"autocreatetime"`
-		AutoUnixNanoCreateTime int64  `gorm:"autocreatetime:nano"`
-		AutoUnixUpdateTime     int64  `gorm:"autoupdatetime"`
-		AutoUnixNanoUpdateTime int64  `gorm:"autoupdatetime:nano"`
+		Name                    string
+		FieldAllowCreate        string `gorm:"<-:create"`
+		FieldAllowUpdate        string `gorm:"<-:update"`
+		FieldAllowSave          string `gorm:"<-"`
+		FieldAllowSave2         string `gorm:"<-:create,update"`
+		FieldAllowSave3         string `gorm:"->:false;<-:create"`
+		FieldReadonly           string `gorm:"->"`
+		FieldIgnore             string `gorm:"-"`
+		AutoUnixCreateTime      int64  `gorm:"autocreatetime"`
+		AutoUnixMilliCreateTime int64  `gorm:"autocreatetime:milli"`
+		AutoUnixNanoCreateTime  int64  `gorm:"autocreatetime:nano"`
+		AutoUnixUpdateTime      int64  `gorm:"autoupdatetime"`
+		AutoUnixMilliUpdateTime int64  `gorm:"autoupdatetime:milli"`
+		AutoUnixNanoUpdateTime  int64  `gorm:"autoupdatetime:nano"`
 	}
 
 	DB.Migrator().DropTable(&CustomizeFieldStruct{})
@@ -116,6 +118,10 @@ func TestCustomizeField(t *testing.T) {
 
 	if result.AutoUnixCreateTime != result.AutoUnixUpdateTime || result.AutoUnixCreateTime == 0 {
 		t.Fatalf("invalid create/update unix time: %#v", result)
+	}
+
+	if result.AutoUnixMilliCreateTime != result.AutoUnixMilliUpdateTime || result.AutoUnixMilliCreateTime == 0 || result.AutoUnixMilliCreateTime/result.AutoUnixCreateTime < 1e3 {
+		t.Fatalf("invalid create/update unix milli time: %#v", result)
 	}
 
 	if result.AutoUnixNanoCreateTime != result.AutoUnixNanoUpdateTime || result.AutoUnixNanoCreateTime == 0 || result.AutoUnixNanoCreateTime/result.AutoUnixCreateTime < 1e6 {
@@ -163,6 +169,8 @@ func TestCustomizeField(t *testing.T) {
 	createWithDefaultTime := generateStruct("create_with_default_time")
 	createWithDefaultTime.AutoUnixCreateTime = 100
 	createWithDefaultTime.AutoUnixUpdateTime = 100
+	createWithDefaultTime.AutoUnixMilliCreateTime = 100
+	createWithDefaultTime.AutoUnixMilliUpdateTime = 100
 	createWithDefaultTime.AutoUnixNanoCreateTime = 100
 	createWithDefaultTime.AutoUnixNanoUpdateTime = 100
 	DB.Create(&createWithDefaultTime)
@@ -172,6 +180,10 @@ func TestCustomizeField(t *testing.T) {
 
 	if createWithDefaultTimeResult.AutoUnixCreateTime != createWithDefaultTimeResult.AutoUnixUpdateTime || createWithDefaultTimeResult.AutoUnixCreateTime != 100 {
 		t.Fatalf("invalid create/update unix time: %#v", createWithDefaultTimeResult)
+	}
+
+	if createWithDefaultTimeResult.AutoUnixMilliCreateTime != createWithDefaultTimeResult.AutoUnixMilliUpdateTime || createWithDefaultTimeResult.AutoUnixMilliCreateTime != 100 {
+		t.Fatalf("invalid create/update unix milli time: %#v", createWithDefaultTimeResult)
 	}
 
 	if createWithDefaultTimeResult.AutoUnixNanoCreateTime != createWithDefaultTimeResult.AutoUnixNanoUpdateTime || createWithDefaultTimeResult.AutoUnixNanoCreateTime != 100 {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

`
type User struct {
  CreatedAt time.Time // Set to current time if it is zero on creating
  UpdatedAt int       // Set to current unix seconds on updaing or if it is zero on creating
  Updated   int64 `gorm:"autoUpdateTime:milli"` // Use unix MILLI seconds as updating time
  Created   int64 `gorm:"autoCreateTime"`      // Use unix seconds as creating time
}
`
