### PR TITLE
fix migrator

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -134,7 +134,7 @@ func (m Migrator) CreateTable(values ...interface{}) error {
 		if err := m.RunWithValue(value, func(stmt *gorm.Statement) (errr error) {
 			var (
 				createTableSQL          = "CREATE TABLE ? ("
-				values                  = []interface{}{clause.Table{Name: stmt.Table}}
+				values                  = []interface{}{clause.Table{Name: stmt.Schema.Table}}
 				hasPrimaryKeyInDataType bool
 			)
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

The AutoMigrate didn't implement the schema name of the New-Created table 
For example : 
```
//  database test : 
type User struct {
	Code string
}

func (t *User) TableName() string {
	return "s1.useraasdd"
}

// The actual 
// The AutoMigrate will still create table useraasdd and ignore the schema s1 instead of create table s1.useraasdd
// And this API is working in v1 
// The actual SQL is "CREATE TABLE "useraasdd" ("code" text)"
// The expect SQL should be "CREATE TABLE "s1.useraasdd" ("code" text)"
db.AutoMigrate(&User{})

```

### User Case Description

```
package main

import (
	"fmt"
	"log"
	"os"
	"time"

	"gorm.io/driver/postgres"
	"gorm.io/gorm"
	"gorm.io/gorm/logger"
	"gorm.io/gorm/schema"
)

type User struct {
	Code string
}

func (t *User) TableName() string {
	return "s1.useraasdd"
}

// CREATE USER test WITH PASSWORD '123456';
// CREATE DATABASE test OWNER test encoding='UTF8';
// GRANT ALL PRIVILEGES ON DATABASE test to test;
//  psql -U test
// \c test 
// create schema s1
func main() {
	newLogger := logger.New(
		log.New(os.Stdout, "\r\n", log.LstdFlags), // io writer
		logger.Config{
			SlowThreshold: time.Second, // Slow SQL threshold
			LogLevel:      logger.Info, // Log level
			Colorful:      false,       // Disable color
		},
	)
	dsn := "user=test password=123456 dbname=test port=5432 sslmode=disable TimeZone=Asia/Shanghai"
	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
		NamingStrategy: schema.NamingStrategy{
			//TablePrefix:   "t_", // table name prefix, table for `User` would be `t_users`
			SingularTable: true, // use singular table name, table for `User` would be `user` with this option enabled
		},
		Logger: newLogger,
	})
	if err != nil {
		log.Fatal(err)
	}
	if err := db.AutoMigrate(&User{}); err != nil {
		fmt.Println(err)
	}

	var t []User
	// if err := db.Clauses(hints.CommentBefore("select", "node2")).Find(&t).Error; err != nil {
	if err := db.Find(&t).Error; err != nil {
		log.Fatal(err)
	}
	fmt.Println(t)

}

```
