### PR TITLE
fix return value and delete unused default

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -69,7 +69,7 @@ func (db *DB) Distinct(args ...interface{}) (tx *DB) {
 	if len(args) > 0 {
 		tx = tx.Select(args[0], args[1:]...)
 	}
-	return tx
+	return
 }
 
 // Select specify fields that you want when querying, creating, updating

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -148,7 +148,6 @@ func (tx *DB) assignInterfacesToValue(values ...interface{}) {
 						if field := tx.Statement.Schema.LookUpField(column.Name); field != nil {
 							tx.AddError(field.Set(tx.Statement.ReflectValue, eq.Value))
 						}
-					default:
 					}
 				}
 			}


### PR DESCRIPTION
Hi,
This PR is a minor change.

- delete unused default in case statement. 
- like any other function, Changed to not set variable in return statement.
`return tx`→`return`