### PR TITLE
feature: using default limite and offset query for count

### DIFF
--- a/clause/limit.go
+++ b/clause/limit.go
@@ -6,6 +6,7 @@ import "strconv"
 type Limit struct {
 	Limit  int
 	Offset int
+	Ignore bool
 }
 
 // Name where clause name
@@ -15,6 +16,9 @@ func (limit Limit) Name() string {
 
 // Build build where clause
 func (limit Limit) Build(builder Builder) {
+	if limit.Ignore {
+		return
+	}
 	if limit.Limit > 0 {
 		builder.WriteString("LIMIT ")
 		builder.WriteString(strconv.Itoa(limit.Limit))

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -322,6 +322,9 @@ func (db *DB) Count(count *int64) (tx *DB) {
 		defer tx.Statement.AddClause(clause.Select{})
 	}
 
+	tx.Statement.AddClause(clause.Limit{Ignore: true})
+	defer tx.Statement.AddClause(clause.Limit{Ignore: false})
+
 	tx.Statement.Dest = count
 	tx.callbacks.Query().Execute(tx)
 	if tx.RowsAffected != 1 {

--- a/tests/count_test.go
+++ b/tests/count_test.go
@@ -72,4 +72,10 @@ func TestCount(t *testing.T) {
 	if err := DB.Debug().Table("users").Joins("LEFT JOIN companies on companies.name = users.name").Where("users.name = ?", user1.Name).Count(&count4).Error; err != nil || count4 != 1 {
 		t.Errorf("count with join, got error: %v, count %v", err, count)
 	}
+
+	var count5 int64
+	DB.Where("name in ?", []string{user2.Name, user3.Name}).Limit(1).Offset(1).Find(&users).Count(&count5)
+	if len(users) != 1 || count5 != 2 {
+		t.Errorf("count for pagination should works")
+	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Get `count` more convenient for pagination.

### User Case Description



Sometime we want to paginate convenient, we will write like below, but we will get a `0` for `count`: 

```golang
var (
    user []User
    count int
)

if err := DB.Where("name=?", "john").Limit(10).Offset(20).Find(&users).Count(&count).Error; err != nil {
       t.Errorf("Not error should happen, but got %v", err)
}
```

It is because if we run `Count` with `Offset`, we will get an empty data set.

After my attempts, this can achieve the `count`

```golang
var (
    user []User
    count int
)

db := DB.Where("name=?", "john")
if err := db.Limit(10).Offset(20).Find(&users).Error; err != nil {
       t.Errorf("Not error should happen, but got %v", err)
}

if err := db.Count(&count).Error; err != nil {
       t.Errorf("Not error should happen, but got %v", err)
}
```

or


```golang
var (
    user []User
    count int
)

if err := DB.Where("name=?", "john").Limit(10).Offset(20).Find(&users).Offset(0).Count(&count).Error; err != nil {
       t.Errorf("Not error should happen, but got %v", err)
}
```
**But the code will be more verbose. I think more people hope to complete the goal in one chain call, like** [here](https://jasperxu.github.io/gorm-zh/crud.html#count)
