### PR TITLE
fmt.Sprint() to strconv.Format

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -671,7 +671,7 @@ func (field *Field) setupValuerAndSetter() {
 			case []byte:
 				field.ReflectValueOf(value).SetString(string(data))
 			case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-				field.ReflectValueOf(value).SetString(fmt.Sprint(data))
+				field.ReflectValueOf(value).SetString(utils.ToString(data))
 			case float64, float32:
 				field.ReflectValueOf(value).SetString(fmt.Sprintf("%."+strconv.Itoa(field.Precision)+"f", data))
 			default:

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -83,3 +83,31 @@ func AssertEqual(src, dst interface{}) bool {
 	}
 	return true
 }
+
+func ToString(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case int:
+		return strconv.FormatInt(int64(v), 10)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	}
+	return ""
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

strconv.Format comparison fmt.Sprint () has better performance and occupancy


### User Case Description

<!-- Your use case -->
