### PR TITLE
Fix monocolor log output inconsist with colorful log

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -65,9 +65,9 @@ func New(writer Writer, config Config) Interface {
 		infoStr      = "%s\n[info] "
 		warnStr      = "%s\n[warn] "
 		errStr       = "%s\n[error] "
-		traceStr     = "%s\n[%v] [rows:%d] %s"
-		traceWarnStr = "%s\n[%v] [rows:%d] %s"
-		traceErrStr  = "%s %s\n[%v] [rows:%d] %s"
+		traceStr     = "%s\n[%.3fms] [rows:%d] %s"
+		traceWarnStr = "%s\n[%.3fms] [rows:%d] %s"
+		traceErrStr  = "%s %s\n[%.3fms] [rows:%d] %s"
 	)
 
 	if config.Colorful {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
This pull request fixed the logger output execution time format in mono color mode was different from colorful mode.

### User Case Description

<!-- Your use case -->
In mono color mode, the execution time output: [0]
In colorful mode, the execution time output: [0.001ms]

