### PR TITLE
Release the connection when discovering the column types in the migrator

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -388,9 +388,10 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 
 func (m Migrator) ColumnTypes(value interface{}) (columnTypes []*sql.ColumnType, err error) {
 	err = m.RunWithValue(value, func(stmt *gorm.Statement) error {
-		rows, err := m.DB.Session(&gorm.Session{}).Raw("select * from ?", clause.Table{Name: stmt.Table}).Rows()
+		rows, err := m.DB.Session(&gorm.Session{}).Raw("select * from ? limit 1", clause.Table{Name: stmt.Table}).Rows()
 		if err == nil {
 			columnTypes, err = rows.ColumnTypes()
+			_ = rows.Close()
 		}
 		return err
 	})


### PR DESCRIPTION
When the migrator is used to discover the column types, such as when
used with `AutoMigrate()`, it does not close the query result. This
changes the migrator to close the query result and it also changes the
query to use `LIMIT 1` to prevent additional work against the database
when only discovering the schema.

Fixes #3432.