### PR TITLE
Add option to detect unique constraint errors

### DIFF
--- a/callbacks/create.go
+++ b/callbacks/create.go
@@ -92,12 +92,12 @@ func Create(config *Config) func(db *gorm.DB) {
 										}
 									}
 								} else {
-									db.AddError(err)
+									db.AddErrorFromDB(err)
 								}
 							}
 						}
 					} else {
-						db.AddError(err)
+						db.AddErrorFromDB(err)
 					}
 				}
 			}
@@ -187,14 +187,14 @@ func CreateWithReturning(db *gorm.DB) {
 						}
 					}
 				} else {
-					db.AddError(err)
+					db.AddErrorFromDB(err)
 				}
 			}
 		} else if !db.DryRun && db.Error == nil {
 			if result, err := db.Statement.ConnPool.ExecContext(db.Statement.Context, db.Statement.SQL.String(), db.Statement.Vars...); err == nil {
 				db.RowsAffected, _ = result.RowsAffected()
 			} else {
-				db.AddError(err)
+				db.AddErrorFromDB(err)
 			}
 		}
 	}

--- a/callbacks/raw.go
+++ b/callbacks/raw.go
@@ -8,7 +8,7 @@ func RawExec(db *gorm.DB) {
 	if db.Error == nil && !db.DryRun {
 		result, err := db.Statement.ConnPool.ExecContext(db.Statement.Context, db.Statement.SQL.String(), db.Statement.Vars...)
 		if err != nil {
-			db.AddError(err)
+			db.AddErrorFromDB(err)
 		} else {
 			db.RowsAffected, _ = result.RowsAffected()
 		}

--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -80,7 +80,7 @@ func Update(db *gorm.DB) {
 			if err == nil {
 				db.RowsAffected, _ = result.RowsAffected()
 			} else {
-				db.AddError(err)
+				db.AddErrorFromDB(err)
 			}
 		}
 	}

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,8 @@ package gorm
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 )
 
 var (
@@ -32,3 +34,21 @@ var (
 	// ErrDryRunModeUnsupported dry run mode unsupported
 	ErrDryRunModeUnsupported = errors.New("dry run mode unsupported")
 )
+
+// ErrUniqueConstraint unique constraint error
+type ErrUniqueConstraint struct {
+	ConstraintName string
+	Columns        []string
+}
+
+func (e *ErrUniqueConstraint) Error() string {
+	if len(e.ConstraintName) > 0 {
+		return fmt.Sprintf("unique constraint '%s' error", e.ConstraintName)
+	}
+
+	if len(e.Columns) > 0 {
+		return fmt.Sprintf("unique constraint on columns '%s' error", strings.Join(e.Columns, ", "))
+	}
+
+	return "unique constraint error"
+}

--- a/schema/model_test.go
+++ b/schema/model_test.go
@@ -23,6 +23,7 @@ type User struct {
 	Team      []*User           `gorm:"foreignkey:ManagerID"`
 	Languages []*tests.Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User           `gorm:"many2many:user_friends"`
+	Contacts  []*tests.Contact
 	Active    *bool
 }
 

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -108,6 +108,10 @@ func checkUserSchema(t *testing.T, user *schema.Schema) {
 			}},
 			References: []Reference{{"ID", "User", "UserID", "user_friends", "", true}, {"ID", "User", "FriendID", "user_friends", "", false}},
 		},
+		{
+			Name: "Contacts", Type: schema.HasMany, Schema: "User", FieldSchema: "Contact",
+			References: []Reference{{"ID", "User", "UserID", "Contact", "", true}},
+		},
 	}
 
 	for _, relation := range relations {

--- a/tests/create_unique_test.go
+++ b/tests/create_unique_test.go
@@ -1,0 +1,43 @@
+package tests_test
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+	. "gorm.io/gorm/utils/tests"
+)
+
+func TestCreateUniqueConstraint(t *testing.T) {
+	user1 := GetUser("create-unique-constraint", Config{})
+	if err := DB.Create(user1).Error; err != nil {
+		t.Fatalf("errors happened when create: %v", err)
+	}
+
+	user1Contact := &Contact{UserID: &user1.ID, Email: "create-unique-constraint@email"}
+	if err := DB.Create(user1Contact).Error; err != nil {
+		t.Fatalf("errors happened when create cotract: %v", err)
+	}
+
+	user2 := GetUser("create-unique-constraint2", Config{})
+	if err := DB.Create(user2).Error; err != nil {
+		t.Fatalf("errors happened when create: %v", err)
+	}
+
+	user2Contact := &Contact{UserID: &user2.ID, Email: "create-unique-constraint@email"}
+	err := DB.Create(user2Contact).Error
+	if err == nil {
+		t.Fatal("should return unique constraint error")
+	}
+	e, ok := err.(*gorm.ErrUniqueConstraint)
+	if !ok {
+		t.Fatalf("should return unique constraint error, got err %v", err)
+	}
+
+	if len(e.ConstraintName) > 0 {
+		AssertEqual(t, e.ConstraintName, "idx_email")
+	}
+
+	if len(e.Columns) > 0 {
+		AssertEqual(t, e.Columns[0], "contacts.email")
+	}
+}

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMigrate(t *testing.T) {
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Contact{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -87,7 +87,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Contact{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/utils/tests/models.go
+++ b/utils/tests/models.go
@@ -26,6 +26,7 @@ type User struct {
 	Team      []User     `gorm:"foreignkey:ManagerID"`
 	Languages []Language `gorm:"many2many:UserSpeak;"`
 	Friends   []*User    `gorm:"many2many:user_friends;"`
+	Contacts  []*Contact
 	Active    bool
 }
 
@@ -57,4 +58,10 @@ type Company struct {
 type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
+}
+
+type Contact struct {
+	gorm.Model
+	UserID *uint
+	Email  string `gorm:"index:idx_email,unique"`
 }


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add new error `ErrUniqueConstraint`

### User Case Description

To allow detect unique constraint errors independently of used database

Fixes #3499
