### PR TITLE
WIP: feat: support complexity field with special tag saved as string.

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -315,7 +315,8 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) (c
 				switch reflectValue.Kind() {
 				case reflect.Struct:
 					for _, field := range s.Fields {
-						if field.Readable {
+						// NOTE: xjson doesn't support where with object
+						if field.Readable && !field.XJSON {
 							if v, isZero := field.ValueOf(reflectValue); !isZero {
 								if field.DBName != "" {
 									conds = append(conds, clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: field.DBName}, Value: v})
@@ -328,7 +329,7 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) (c
 				case reflect.Slice, reflect.Array:
 					for i := 0; i < reflectValue.Len(); i++ {
 						for _, field := range s.Fields {
-							if field.Readable {
+							if field.Readable && !field.XJSON {
 								if v, isZero := field.ValueOf(reflectValue.Index(i)); !isZero {
 									if field.DBName != "" {
 										conds = append(conds, clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: field.DBName}, Value: v})

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -371,7 +371,7 @@ func TestCreateWithNoGORMPrimaryKey(t *testing.T) {
 
 func TestSelectWithCreate(t *testing.T) {
 	user := *GetUser("select_create", Config{Account: true, Pets: 3, Toys: 3, Company: true, Manager: true, Team: 3, Languages: 3, Friends: 4})
-	DB.Select("Account", "Toys", "Manager", "ManagerID", "Languages", "Name", "CreatedAt", "Age", "Active").Create(&user)
+	DB.Select("Account", "Toys", "Manager", "ManagerID", "Languages", "Name", "CreatedAt", "Age", "Active", "Phones").Create(&user)
 
 	var user2 User
 	DB.Preload("Account").Preload("Pets").Preload("Toys").Preload("Company").Preload("Manager").Preload("Team").Preload("Languages").Preload("Friends").First(&user2, user.ID)

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/jinzhu/now v1.1.1
 	github.com/lib/pq v1.6.0
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v2 v2.2.4 // indirect
 	gorm.io/driver/mysql v1.0.1
-	gorm.io/driver/postgres v1.0.0
+	gorm.io/driver/postgres v1.0.1
 	gorm.io/driver/sqlite v1.1.3
 	gorm.io/driver/sqlserver v1.0.4
 	gorm.io/gorm v1.20.1

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -19,6 +19,7 @@ type Config struct {
 	Team      int
 	Languages int
 	Friends   int
+	Phones    int
 }
 
 func GetUser(name string, config Config) *User {
@@ -65,6 +66,11 @@ func GetUser(name string, config Config) *User {
 		user.Friends = append(user.Friends, GetUser(name+"_friend_"+strconv.Itoa(i+1), Config{}))
 	}
 
+	user.Phones = append(user.Phones, "phone_"+strconv.Itoa(10086))
+	for i := 0; i < config.Phones; i++ {
+		user.Phones = append(user.Phones, "phone_"+strconv.Itoa(i+1))
+	}
+
 	return &user
 }
 
@@ -93,11 +99,11 @@ func CheckUser(t *testing.T, user User, expect User) {
 		if err := DB.Where("id = ?", user.ID).First(&newUser).Error; err != nil {
 			t.Fatalf("errors happened when query: %v", err)
 		} else {
-			AssertObjEqual(t, newUser, user, "ID", "CreatedAt", "UpdatedAt", "DeletedAt", "Name", "Age", "Birthday", "CompanyID", "ManagerID", "Active")
+			AssertObjEqual(t, newUser, user, "ID", "CreatedAt", "UpdatedAt", "DeletedAt", "Name", "Age", "Birthday", "CompanyID", "ManagerID", "Active", "Phones")
 		}
 	}
 
-	AssertObjEqual(t, user, expect, "ID", "CreatedAt", "UpdatedAt", "DeletedAt", "Name", "Age", "Birthday", "CompanyID", "ManagerID", "Active")
+	AssertObjEqual(t, user, expect, "ID", "CreatedAt", "UpdatedAt", "DeletedAt", "Name", "Age", "Birthday", "CompanyID", "ManagerID", "Active", "Phones")
 
 	t.Run("Account", func(t *testing.T) {
 		AssertObjEqual(t, user.Account, expect.Account, "ID", "CreatedAt", "UpdatedAt", "DeletedAt", "UserID", "Number")

--- a/tests/sql_builder_test.go
+++ b/tests/sql_builder_test.go
@@ -156,7 +156,7 @@ func TestDryRun(t *testing.T) {
 	dryRunDB := DB.Session(&gorm.Session{DryRun: true})
 
 	stmt := dryRunDB.Create(&user).Statement
-	if stmt.SQL.String() == "" || len(stmt.Vars) != 9 {
+	if stmt.SQL.String() == "" || len(stmt.Vars) != 10 {
 		t.Errorf("Failed to generate sql, got %v", stmt.SQL.String())
 	}
 

--- a/utils/tests/models.go
+++ b/utils/tests/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak;"`
 	Friends   []*User    `gorm:"many2many:user_friends;"`
 	Active    bool
+	Phones    []string `gorm:"type:json;xjson"`
 }
 
 type Account struct {


### PR DESCRIPTION
This is one pr in WIPS, and want to get some advice.

### What did this pull request do?
With a special tag "xjson":
- before create/update, field will be json.marshaled to bytes
- before query, field will be assigned with json.unmarshaled

### User Case Description
With [GraphQL](https://graphql.org/) or [Thrift](http://thrift.apache.org/), tools can generated model by api definition.
However, i can't use these golang struct with gorm. Field type like: ``[]string``, ``[]int`` is common.

#### One Example:
I have a simple application to save my url links. The main object is ``Link``, the definition in graphql and generated model:
```graphql
type Link {
  id: ID!
  name: String!
  url: String!
  desc: String
  tags: [Tag!]
  createdAt: Time
  updatedAt: Time
}

scalar Tag
```
```golang
type Link struct {
	ID        string     `json:"id"`
	Name      string     `json:"name"`
	URL       string     `json:"url"`
	Desc      *string    `json:"desc"`
	Tags      []string   `json:"tags" gorm:"type:golang;xjson"`
	CreatedAt *time.Time `json:"createdAt"`
	UpdatedAt *time.Time `json:"updatedAt"`
}
```

Now, i want to save link in one table, and save tags as json.
And i don't want to do type alias, like: ``type TagsType []string``.
