### PR TITLE
bugfix: Select can't handle `AS` statement.

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -97,7 +97,7 @@ func (db *DB) Select(query interface{}, args ...interface{}) (tx *DB) {
 
 		// normal field names
 		if len(fields) == 1 || (len(fields) == 3 && strings.ToUpper(fields[1]) == "AS") {
-			tx.Statement.Selects = fields
+            tx.Statement.Selects = []string{strings.Join(fields, " ")}
 
 			for _, arg := range args {
 				switch arg := arg.(type) {

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -475,6 +475,16 @@ func TestSelect(t *testing.T) {
 		t.Errorf("Should have user Name when selected it")
 	}
 
+	var resultAlias User
+	DB.Where("name = ?", user.Name).Select("name as name").Find(&resultAlias)
+	if resultAlias.ID != 0 {
+		t.Errorf("Should not have ID because only selected name, %+v", resultAlias.ID)
+	}
+
+	if user.Name != resultAlias.Name {
+		t.Errorf("Should have user Name when selected it")
+	}
+
 	dryDB := DB.Session(&gorm.Session{DryRun: true})
 	r := dryDB.Select("name", "age").Find(&User{})
 	if !regexp.MustCompile("SELECT .*name.*,.*age.* FROM .*users.*").MatchString(r.Statement.SQL.String()) {


### PR DESCRIPTION
close: https://github.com/go-gorm/gorm/issues/3567

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
If there is only one "select x as y" statement, it will be treated as normal fields, then explained to SQL like `x,as,y`. I believe there is a bug when checking with 3 fields in select.

### User Case Description

<!-- Your use case -->
