### PR TITLE
feat(Model) : add JSON formatter tag in gorm Model

### DIFF
--- a/model.go
+++ b/model.go
@@ -8,8 +8,8 @@ import "time"
 //      gorm.Model
 //    }
 type Model struct {
-	ID        uint `gorm:"primarykey"`
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt DeletedAt `gorm:"index"`
+	ID        uint      `json:"id" gorm:"primarykey"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	DeletedAt DeletedAt `json:"deleted_at" gorm:"index"`
 }


### PR DESCRIPTION
- [x] Do only one thing
- [] Non breaking API changes
- [x] Tested

### What did this pull request do?

While using Gorm in one of my api, I realized that the gorm.Model struct didn't handle snake_case formatting in Json. 
So I added in the Model struct the `json` tags in order to format JSON responses for models using Gorm :

```
`json:"id"`
`json:"created_at"`
`json:"updated_at"`
`json:"deleted_at"`
```

### User Case Description

Go is starting to be used more and more in professional APIs and Gorm too. Therefore it seems important to me to respect some standards like json:api and to allow to display json field names in snake_case and not in PascalCase. 

Most API designers will put the name of their JSON fields in snake_case. But using Gorm, half of these fields will be in PascalCase and this is not front-end-friendly.

It would obviously be possible to customize the struct Model defined in your own application. But it seems to me that for such a simple and used formatting, it makes more sense to do this customization at the source.
