### PR TITLE
nil point transfer '<nil>' not transfer NULL #3604

### DIFF
--- a/logger/sql.go
+++ b/logger/sql.go
@@ -48,8 +48,6 @@ func ExplainSQL(sql string, numericPlaceholder *regexp.Regexp, escaper string, a
 			} else {
 				vars[idx] = "NULL"
 			}
-		case fmt.Stringer:
-			vars[idx] = escaper + strings.Replace(fmt.Sprintf("%v", v), escaper, "\\"+escaper, -1) + escaper
 		case driver.Valuer:
 			reflectValue := reflect.ValueOf(v)
 			if v != nil && reflectValue.IsValid() && ((reflectValue.Kind() == reflect.Ptr && !reflectValue.IsNil()) || reflectValue.Kind() != reflect.Ptr) {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
if the field is null, then  not "<nil>",  but "NULL" is written.

if type is fmt.Stringer() and fmt.Sprintf("%v", v) is used , it does not trigger the Stringer() function of the object.That is why it gives '' not NULL as we wanted. The case fmt.Stringer is removed from the switch and pushed.
<!---->

### User Case Description
```
type UserWithUUID struct {
	ID        uint `gorm:"primarykey"`
	CreatedAt time.Time
	UpdatedAt time.Time

	TestID     *uuid.UUID `gorm:"type:uuid"`
}

value := UserWithUUID{}

createErr := DB.Save(&value).Error

```
Before :
INSERT INTO "user_with_uuids" ("created_at","updated_at","test_id") VALUES ('2020-10-14 02:20:47.3','2020-10-14 02:20:47.3','<nil>') 
Now
INSERT INTO `user_with_uuids` (`created_at`,`updated_at`,`test_id`) VALUES ("2020-10-18 00:20:22.765","2020-10-18 00:20:22.765",NULL)