### PR TITLE
add gorm ColumnType interface, remove sql one

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -1,8 +1,6 @@
 package gorm
 
 import (
-	"database/sql"
-
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
 )
@@ -24,6 +22,14 @@ type ViewOption struct {
 	Query       *DB
 }
 
+type ColumnType interface {
+	Name() string
+	DatabaseTypeName() string
+	Length() (length int64, ok bool)
+	DecimalSize() (precision int64, scale int64, ok bool)
+	Nullable() (nullable bool, ok bool)
+}
+
 type Migrator interface {
 	// AutoMigrate
 	AutoMigrate(dst ...interface{}) error
@@ -42,10 +48,10 @@ type Migrator interface {
 	AddColumn(dst interface{}, field string) error
 	DropColumn(dst interface{}, field string) error
 	AlterColumn(dst interface{}, field string) error
-	MigrateColumn(dst interface{}, field *schema.Field, columnType *sql.ColumnType) error
+	MigrateColumn(dst interface{}, field *schema.Field, columnType ColumnType) error
 	HasColumn(dst interface{}, field string) bool
 	RenameColumn(dst interface{}, oldName, field string) error
-	ColumnTypes(dst interface{}) ([]*sql.ColumnType, error)
+	ColumnTypes(dst interface{}) ([]ColumnType, error)
 
 	// Views
 	CreateView(name string, option ViewOption) error


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Updates the signature of `ColumnTypes` and `MigrateColumn` to rely on an interface (compatible with `sql.ColumnType`). This allows driver to override the `ColumnTypes` function and solve #3628.

Once this PR is merged, I will open two PRs on the `mysql` and `postgres` driver repo to implement a correct `ColumnTypes` method.

### User Case Description

`sql.ColumnType` does not always have all information required to automigrate correctly:

- `postgres` does not give nullability information
- `mysql` does not give size information for `char` and `varchar`

For `postgres` and `mysql` the missing information can be retrieved from the `information_schema` table.