### PR TITLE
修复日志追踪traceRecorder初始化函数New没有赋予默认值导致的bug

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -64,7 +64,7 @@ var (
 		LogLevel:      Warn,
 		Colorful:      true,
 	})
-	Recorder = traceRecorder{Interface: Default}
+	Recorder = traceRecorder{Interface: Default, BeginAt: time.Now()}
 )
 
 func New(writer Writer, config Config) Interface {
@@ -173,7 +173,7 @@ type traceRecorder struct {
 }
 
 func (l traceRecorder) New() *traceRecorder {
-	return &traceRecorder{Interface: l.Interface}
+	return &traceRecorder{Interface: l.Interface, BeginAt: time.Now()}
 }
 
 func (l *traceRecorder) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {


### PR DESCRIPTION
bug所在文件：logger/logger.go， 167 行代码块
相关函数：New 没有初始化 BeginAt参数, 默认值 0001-00-00 00:00:00
```code
type traceRecorder struct {
	Interface
	BeginAt      time.Time
	SQL          string
	RowsAffected int64
	Err          error
}

func (l traceRecorder) New() *traceRecorder {
	return &traceRecorder{Interface: l.Interface}
}

func (l *traceRecorder) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
	l.BeginAt = begin
	l.SQL, l.RowsAffected = fc()
	l.Err = err
}

```

触发bug的条件：
相关文件：finisher_api.go ，358行代码段，
调用了函数： logger.Recorder.New()、	newLogger.BeginAt

```code
// Scan scan value to a struct
func (db *DB) Scan(dest interface{}) (tx *DB) {

	currentLogger, newLogger := db.Logger, logger.Recorder.New()
	tx = db.getInstance()
	tx.Logger = newLogger
	if rows, err := tx.Rows(); err != nil {
		tx.AddError(err)
	} else {
		defer rows.Close()
		if rows.Next() {
			tx.ScanRows(rows, dest)
		}
	}

	currentLogger.Trace(tx.Statement.Context, newLogger.BeginAt, func() (string, int64) {
		return newLogger.SQL, tx.RowsAffected
	}, tx.Error)
	tx.Logger = currentLogger
	return
}
```
如果sql执行时长超过默认的 100*time.Million, 就会触发 l.Printf(l.traceWarnStr ) 日志输出，日志输出时，显示的sql耗时为无限大
