### PR TITLE
gorm log增强、升级, 开发者集成gorm到自己的项目之后很简单地拦截、重写日志格式

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -64,7 +64,7 @@ var (
 		LogLevel:      Warn,
 		Colorful:      true,
 	})
-	Recorder = traceRecorder{Interface: Default}
+	Recorder = traceRecorder{Interface: Default, BeginAt: time.Now()}
 )
 
 func New(writer Writer, config Config) Interface {
@@ -173,7 +173,7 @@ type traceRecorder struct {
 }
 
 func (l traceRecorder) New() *traceRecorder {
-	return &traceRecorder{Interface: l.Interface}
+	return &traceRecorder{Interface: l.Interface, BeginAt: time.Now()}
 }
 
 func (l *traceRecorder) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -69,12 +69,12 @@ var (
 
 func New(writer Writer, config Config) Interface {
 	var (
-		infoStr      = "%s\n[info] "
-		warnStr      = "%s\n[warn] "
-		errStr       = "%s\n[error] "
-		traceStr     = "%s\n[%.3fms] [rows:%v] %s"
-		traceWarnStr = "%s %s\n[%.3fms] [rows:%v] %s"
-		traceErrStr  = "%s %s\n[%.3fms] [rows:%v] %s"
+		infoStr      = "[info] %s\n "
+		warnStr      = "[warn] %s\n"
+		errStr       = "[error] %s\n"
+		traceStr     = "[traceStr] %s [%.3fms] [rows:%v] %s\n"
+		traceWarnStr = "[traceWarn] %s %s [%.3fms] [rows:%v] %s\n"
+		traceErrStr  = "[traceErr] %s %s [%.3fms] [rows:%v] %s\n"
 	)
 
 	if config.Colorful {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -67,14 +67,14 @@ var (
 	Recorder = traceRecorder{Interface: Default, BeginAt: time.Now()}
 )
 
-func New(writer Writer, config Config) Interface {
+func New(writer Writer, config Config, v ...Options) Interface {
 	var (
-		infoStr      = "[info] %s\n "
-		warnStr      = "[warn] %s\n"
-		errStr       = "[error] %s\n"
-		traceStr     = "[traceStr] %s [%.3fms] [rows:%v] %s\n"
-		traceWarnStr = "[traceWarn] %s %s [%.3fms] [rows:%v] %s\n"
-		traceErrStr  = "[traceErr] %s %s [%.3fms] [rows:%v] %s\n"
+		infoStr      = "%s\n[info] "
+		warnStr      = "%s\n[warn] "
+		errStr       = "%s\n[error] "
+		traceStr     = "%s\n[%.3fms] [rows:%v] %s"
+		traceWarnStr = "%s %s\n[%.3fms] [rows:%v] %s"
+		traceErrStr  = "%s %s\n[%.3fms] [rows:%v] %s"
 	)
 
 	if config.Colorful {
@@ -180,4 +180,53 @@ func (l *traceRecorder) Trace(ctx context.Context, begin time.Time, fc func() (s
 	l.BeginAt = begin
 	l.SQL, l.RowsAffected = fc()
 	l.Err = err
+}
+
+// The developer can modify the log format through the following functions
+// so easy to integrate gorm into their  project
+
+type Options interface {
+	apply(*logger)
+}
+type OptionFunc func(log *logger)
+
+func (f OptionFunc) apply(log *logger) {
+	f(log)
+}
+
+// remodify
+func SetInfoStrFormat(format string) Options {
+	return OptionFunc(func(log *logger) {
+		log.infoStr = format
+	})
+}
+
+func SetWarnStrFormat(format string) Options {
+	return OptionFunc(func(log *logger) {
+		log.warnStr = format
+	})
+}
+
+func SetErrStrFormat(format string) Options {
+	return OptionFunc(func(log *logger) {
+		log.errStr = format
+	})
+}
+
+func SetTraceStrFormat(format string) Options {
+	return OptionFunc(func(log *logger) {
+		log.traceStr = format
+	})
+}
+
+func SetTracWarnStrFormat(format string) Options {
+	return OptionFunc(func(log *logger) {
+		log.traceWarnStr = format
+	})
+}
+
+func SetTracErrStrFormat(format string) Options {
+	return OptionFunc(func(log *logger) {
+		log.traceErrStr = format
+	})
 }


### PR DESCRIPTION
###  为什么要提交这个PR  
>
目前 `gormv2` 集成到自己的项目之后，执行sql出错、警告，打印的日志都是通过默认的方式输出到终端，很不方便. 
基本上绝大部分开发者的日志都会基于统一的日志管理包在进行，例如：zaplog，那么如果快速重写日志？
官方文档给出的建议： https://www.kancloud.cn/sliver_horn/gorm/1861178  
```code

// 自定义 Logger
// 您可用参考 GORM 的 默认 logger 来定义您自己的 logger

Logger 需要实现以下接口，它接受 context，所以你可以用它来追踪日志

type Interface interface {
    LogMode(LogLevel) Interface
    Info(context.Context, string, ...interface{})
    Warn(context.Context, string, ...interface{})
    Error(context.Context, string, ...interface{})
    Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error)
}

```
以上代码经过分析，在输出日志的时候全部调用了以下变量和函数：
```code
// 日志格式变量
	var (
		infoStr      = "%s\n[info] "
		warnStr      = "%s\n[warn] "
		errStr       = "%s\n[error] "
		traceStr     = "%s\n[%.3fms] [rows:%v] %s"
		traceWarnStr = "%s %s\n[%.3fms] [rows:%v] %s"
		traceErrStr  = "%s %s\n[%.3fms] [rows:%v] %s"
	)

// 最终的日志输出函数
type Writer interface {
	Printf(string, ...interface{})
}

```
整个逻辑写的挺完整, 在我看来，基本没有重新实现的必要，那么如何使用最少的代码重新定义 gorm log？
1. 增加 `New` 函数的可变参数，通过外部修改有内部变量定义的日志格式字符串,只要保证与原字符串拥有相同的占位符即可.
2. 开发者如何拦截(重写)原始日志格式？可以参考如下代码：
```code

 // gorm v2 初始化数据库驱动，摘取官方部分代码
newLogger= New(log.New(os.Stdout, "\r\n", log.LstdFlags), Config{
		SlowThreshold: 200 * time.Millisecond,
		LogLevel:      Warn,
		Colorful:      false,
})

db, err := gorm.Open(sqlite.Open("test.db"), &gorm.Config{
  Logger: newLogger,
})


// gorm v2 集成到自己的项目快速重写日志，例如：所有日志我们都是通过 zaplog 来管理的

type LogOutPut struct{}
// 只需要实现 Printf 函数就可以作为 New 的第一个参数
func (l logOutPut) Printf(strFormat string, args ...interface{}) {
	logRes := fmt.Sprintf(strFormat, args...)
	if strings.HasPrefix(strFormat, "[info]") {
		variable.ZapLog.Info("gorm_v2 日志:", zap.String("详情：", logRes))
	} else if   strings.HasPrefix(strFormat, "[warn]")   {
          // 省略....
        }

}

// 自定义相关日志格式字符串，自己继续在 Printf 函数判断, 非常方便地支持日志拦截、输出, 后续的处理完全交给开发者.

newLogger= New(
                LogOutPut{}, 
               Config{
		SlowThreshold: 200 * time.Millisecond,
		LogLevel:      Warn,
		Colorful:      false},

               SetInfoStrFormat("[info] %s\n"), 
                SetWarnStrFormat("[warn] %s\n"), 
               SetErrStrFormat("[error] %s\n"),
               SetTraceStrFormat("[traceStr] %s [%.3fms] [rows:%v] %s\n"), 
               SetTracWarnStrFormat("[traceWarn] %s %s [%.3fms] [rows:%v] %s\n"), 
              SetTracErrStrFormat("[traceErr] %s %s [%.3fms] [rows:%v] %s\n"),
)

db, err := gorm.Open(sqlite.Open("test.db"), &gorm.Config{
  Logger: newLogger,
})

```

