### PR TITLE
Fix panic on partially zero compound foreign keys

### DIFF
--- a/schema/utils.go
+++ b/schema/utils.go
@@ -109,9 +109,10 @@ func GetIdentityFieldValuesMap(reflectValue reflect.Value, fields []*Field) (map
 	case reflect.Struct:
 		results = [][]interface{}{make([]interface{}, len(fields))}
 
+		notZero = true
 		for idx, field := range fields {
 			results[0][idx], zero = field.ValueOf(reflectValue)
-			notZero = notZero || !zero
+			notZero = notZero && !zero
 		}
 
 		if !notZero {
@@ -133,10 +134,11 @@ func GetIdentityFieldValuesMap(reflectValue reflect.Value, fields []*Field) (map
 			loaded[elemKey] = true
 
 			fieldValues := make([]interface{}, len(fields))
-			notZero = false
+
+			notZero = true
 			for idx, field := range fields {
 				fieldValues[idx], zero = field.ValueOf(elem)
-				notZero = notZero || !zero
+				notZero = notZero && !zero
 			}
 
 			if notZero {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

Currently when one value of a compound foreign key is null or zero, preloading this association yields a panic ("reflect: call of
reflect.Value.Interface on zero Value") because we're attempting to look up the identity values when any one of the columns is non-zero.

The fix here is to require each of the values to be non-zero or we assume that the association is missing. This is not a very common scenario to have in practice, but it's an edge case that's easy to fix and resolves a use-case for me.

I attempted to add some tests for this, but it wasn't clear where the best spot for them would be—either `utils_test.go` or as an association test in the `tests` project. Let me know what you think and I'll give it another stab.