### PR TITLE
Select all fields in sql queries

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -83,7 +83,7 @@ func BuildQuerySQL(db *gorm.DB) {
 			if smallerStruct {
 				stmt := gorm.Statement{DB: db}
 				// smaller struct
-				if err := stmt.Parse(db.Statement.Dest); err == nil && stmt.Schema.ModelType != db.Statement.Schema.ModelType {
+				if err := stmt.Parse(db.Statement.Dest); err == nil {
 					clauseSelect.Columns = make([]clause.Column, len(stmt.Schema.DBNames))
 
 					for idx, dbName := range stmt.Schema.DBNames {

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -75,7 +75,7 @@ func BuildQuerySQL(db *gorm.DB) {
 			smallerStruct := false
 			switch db.Statement.ReflectValue.Kind() {
 			case reflect.Struct:
-				smallerStruct = db.Statement.ReflectValue.Type() != db.Statement.Schema.ModelType
+				smallerStruct = true
 			case reflect.Slice:
 				smallerStruct = db.Statement.ReflectValue.Type().Elem() != db.Statement.Schema.ModelType
 			}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Select all the fields of the structures to do the SQL query avoiding SELECT * FROM. It's always better to use the explicit column list in the SELECT query than a * wildcard, #3530
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
Queries for the `First`, `Take`, `Last`, `Find` methods:
```go
var users []*models.User
db.Debug().Model(&models.User{}).Find(&users)
// SELECT "id","first_name","last_name","email","password","created_at","updated_at" FROM "users"

db.Debug().Find(&users)
// SELECT "id","first_name","last_name","email","password","created_at","updated_at" FROM "users"
```
#### Smart Select Fields - Advanced Query
https://gorm.io/docs/advanced_query.html#Smart-Select-Fields

```go
type APIUser struct {
	FirstName string
	LastName  string
	Email     string
}

db.Debug().Model(&models.User{}).Find(&APIUser{})
// SELECT "first_name","last_name","email" FROM "users"
```

#### Special case

The `Find` method allows the result to be scanned to `map[string]interface{}` or `[]map[string]interface{}`, so the model fields are not selected for compatibility with the `Create From Map` option of the `Create` method.

```go
var results []map[string]interface{}
db.Debug().Model(&models.User{})Find(&results)
// SELECT * FROM "users"
```
<!-- Your use case -->
