### PR TITLE
Select all fields in SQL queries avoiding the SELECT * FROM

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -78,7 +78,7 @@ func BuildQuerySQL(db *gorm.DB) {
 				clauseSelect.Columns = make([]clause.Column, len(stmt.Schema.DBNames))
 
 				for idx, dbName := range stmt.Schema.DBNames {
-					clauseSelect.Columns[idx] = clause.Column{Name: dbName}
+					clauseSelect.Columns[idx] = clause.Column{Table: db.Statement.Table, Name: dbName}
 				}
 			}
 		}

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -72,23 +72,13 @@ func BuildQuerySQL(db *gorm.DB) {
 				}
 			}
 		} else if db.Statement.Schema != nil && db.Statement.ReflectValue.IsValid() {
-			smallerStruct := false
-			switch db.Statement.ReflectValue.Kind() {
-			case reflect.Struct:
-				smallerStruct = db.Statement.ReflectValue.Type() != db.Statement.Schema.ModelType
-			case reflect.Slice:
-				smallerStruct = db.Statement.ReflectValue.Type().Elem() != db.Statement.Schema.ModelType
-			}
+			stmt := gorm.Statement{DB: db}
+			// smaller struct
+			if err := stmt.Parse(db.Statement.Dest); err == nil {
+				clauseSelect.Columns = make([]clause.Column, len(stmt.Schema.DBNames))
 
-			if smallerStruct {
-				stmt := gorm.Statement{DB: db}
-				// smaller struct
-				if err := stmt.Parse(db.Statement.Dest); err == nil && stmt.Schema.ModelType != db.Statement.Schema.ModelType {
-					clauseSelect.Columns = make([]clause.Column, len(stmt.Schema.DBNames))
-
-					for idx, dbName := range stmt.Schema.DBNames {
-						clauseSelect.Columns[idx] = clause.Column{Name: dbName}
-					}
+				for idx, dbName := range stmt.Schema.DBNames {
+					clauseSelect.Columns[idx] = clause.Column{Name: dbName}
 				}
 			}
 		}

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -68,17 +68,40 @@ func BuildQuerySQL(db *gorm.DB) {
 			clauseSelect.Columns = make([]clause.Column, 0, len(db.Statement.Schema.DBNames))
 			for _, dbName := range db.Statement.Schema.DBNames {
 				if v, ok := selectColumns[dbName]; (ok && v) || !ok {
-					clauseSelect.Columns = append(clauseSelect.Columns, clause.Column{Name: dbName})
+					clauseSelect.Columns = append(clauseSelect.Columns, clause.Column{Table: db.Statement.Table, Name: dbName})
 				}
 			}
 		} else if db.Statement.Schema != nil && db.Statement.ReflectValue.IsValid() {
-			stmt := gorm.Statement{DB: db}
-			// smaller struct
-			if err := stmt.Parse(db.Statement.Dest); err == nil {
-				clauseSelect.Columns = make([]clause.Column, len(stmt.Schema.DBNames))
+			if !db.QueryFields {
+				smallerStruct := false
+				switch db.Statement.ReflectValue.Kind() {
+				case reflect.Struct:
+					smallerStruct = db.Statement.ReflectValue.Type() != db.Statement.Schema.ModelType
+				case reflect.Slice:
+					smallerStruct = db.Statement.ReflectValue.Type().Elem() != db.Statement.Schema.ModelType
+				}
 
-				for idx, dbName := range stmt.Schema.DBNames {
-					clauseSelect.Columns[idx] = clause.Column{Table: db.Statement.Table, Name: dbName}
+				if smallerStruct {
+					stmt := gorm.Statement{DB: db}
+					// smaller struct
+					if err := stmt.Parse(db.Statement.Dest); err == nil && stmt.Schema.ModelType != db.Statement.Schema.ModelType {
+						clauseSelect.Columns = make([]clause.Column, len(stmt.Schema.DBNames))
+
+						for idx, dbName := range stmt.Schema.DBNames {
+							clauseSelect.Columns[idx] = clause.Column{Name: dbName}
+						}
+					}
+				}
+			} else {
+				// Execute the query with all the fields of the table
+				stmt := gorm.Statement{DB: db}
+				// smaller struct
+				if err := stmt.Parse(db.Statement.Dest); err == nil {
+					clauseSelect.Columns = make([]clause.Column, len(stmt.Schema.DBNames))
+
+					for idx, dbName := range stmt.Schema.DBNames {
+						clauseSelect.Columns[idx] = clause.Column{Table: db.Statement.Table, Name: dbName}
+					}
 				}
 			}
 		}

--- a/gorm.go
+++ b/gorm.go
@@ -36,6 +36,8 @@ type Config struct {
 	DisableForeignKeyConstraintWhenMigrating bool
 	// AllowGlobalUpdate allow global update
 	AllowGlobalUpdate bool
+	// QueryFields executes the SQL query with all fields of the table
+	QueryFields bool
 
 	// ClauseBuilders clause builder
 	ClauseBuilders map[string]clause.ClauseBuilder
@@ -67,6 +69,7 @@ type Session struct {
 	SkipDefaultTransaction bool
 	AllowGlobalUpdate      bool
 	FullSaveAssociations   bool
+	QueryFields            bool
 	Context                context.Context
 	Logger                 logger.Interface
 	NowFunc                func() time.Time
@@ -195,6 +198,10 @@ func (db *DB) Session(config *Session) *DB {
 
 	if config.DryRun {
 		tx.Config.DryRun = true
+	}
+
+	if config.QueryFields {
+		tx.Config.QueryFields = true
 	}
 
 	if config.Logger != nil {

--- a/tests/multi_primary_keys_test.go
+++ b/tests/multi_primary_keys_test.go
@@ -140,7 +140,7 @@ func TestManyToManyWithCustomizedForeignKeys(t *testing.T) {
 	}
 
 	if name := DB.Dialector.Name(); name == "postgres" {
-		t.Skip("skip postgers due to it only allow unique constraint matching given keys")
+		t.Skip("skip postgres due to it only allow unique constraint matching given keys")
 	}
 
 	DB.Migrator().DropTable(&Blog{}, &Tag{}, "blog_tags", "locale_blog_tags", "shared_blog_tags")
@@ -265,7 +265,7 @@ func TestManyToManyWithCustomizedForeignKeys2(t *testing.T) {
 	}
 
 	if name := DB.Dialector.Name(); name == "postgres" {
-		t.Skip("skip postgers due to it only allow unique constraint matching given keys")
+		t.Skip("skip postgres due to it only allow unique constraint matching given keys")
 	}
 
 	DB.Migrator().DropTable(&Blog{}, &Tag{}, "blog_tags", "locale_blog_tags", "shared_blog_tags")

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -19,7 +19,60 @@ func (UserWithTable) TableName() string {
 
 func TestTable(t *testing.T) {
 	dryDB := DB.Session(&gorm.Session{DryRun: true})
-	userQuery := "SELECT .*id.*created_at.*updated_at.*deleted_at.*name.*age.*birthday.*company_id.*manager_id.*active.* "
+
+	r := dryDB.Table("`user`").Find(&User{}).Statement
+	if !regexp.MustCompile("SELECT \\* FROM `user`").MatchString(r.Statement.SQL.String()) {
+		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
+	}
+
+	r = dryDB.Table("user as u").Select("name").Find(&User{}).Statement
+	if !regexp.MustCompile("SELECT .name. FROM user as u WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
+	}
+
+	r = dryDB.Table("gorm.user").Select("name").Find(&User{}).Statement
+	if !regexp.MustCompile("SELECT .name. FROM .gorm.\\..user. WHERE .user.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
+	}
+
+	r = dryDB.Select("name").Find(&UserWithTable{}).Statement
+	if !regexp.MustCompile("SELECT .name. FROM .gorm.\\..user. WHERE .user.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
+	}
+
+	r = dryDB.Create(&UserWithTable{}).Statement
+	if DB.Dialector.Name() != "sqlite" {
+		if !regexp.MustCompile(`INSERT INTO .gorm.\..user. (.*name.*) VALUES (.*)`).MatchString(r.Statement.SQL.String()) {
+			t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
+		}
+	} else {
+		if !regexp.MustCompile(`INSERT INTO .user. (.*name.*) VALUES (.*)`).MatchString(r.Statement.SQL.String()) {
+			t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
+		}
+	}
+
+	r = dryDB.Table("(?) as u", DB.Model(&User{}).Select("name")).Find(&User{}).Statement
+	if !regexp.MustCompile("SELECT \\* FROM \\(SELECT .name. FROM .users. WHERE .users.\\..deleted_at. IS NULL\\) as u WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
+	}
+
+	r = dryDB.Table("(?) as u, (?) as p", DB.Model(&User{}).Select("name"), DB.Model(&Pet{}).Select("name")).Find(&User{}).Statement
+	if !regexp.MustCompile("SELECT \\* FROM \\(SELECT .name. FROM .users. WHERE .users.\\..deleted_at. IS NULL\\) as u, \\(SELECT .name. FROM .pets. WHERE .pets.\\..deleted_at. IS NULL\\) as p WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
+	}
+
+	r = dryDB.Where("name = ?", 1).Table("(?) as u, (?) as p", DB.Model(&User{}).Select("name").Where("name = ?", 2), DB.Model(&Pet{}).Where("name = ?", 4).Select("name")).Where("name = ?", 3).Find(&User{}).Statement
+	if !regexp.MustCompile("SELECT \\* FROM \\(SELECT .name. FROM .users. WHERE name = .+ AND .users.\\..deleted_at. IS NULL\\) as u, \\(SELECT .name. FROM .pets. WHERE name = .+ AND .pets.\\..deleted_at. IS NULL\\) as p WHERE name = .+ AND name = .+ AND .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
+	}
+
+	AssertEqual(t, r.Statement.Vars, []interface{}{2, 4, 1, 3})
+}
+
+func TestTableWithAllFields(t *testing.T) {
+	dryDB := DB.Session(&gorm.Session{DryRun: true, QueryFields: true})
+	userQuery := "SELECT .*user.*id.*user.*created_at.*user.*updated_at.*user.*deleted_at.*user.*name.*user.*age" +
+		".*user.*birthday.*user.*company_id.*user.*manager_id.*user.*active.* "
 
 	r := dryDB.Table("`user`").Find(&User{}).Statement
 	if !regexp.MustCompile(userQuery + "FROM `user`").MatchString(r.Statement.SQL.String()) {
@@ -52,18 +105,21 @@ func TestTable(t *testing.T) {
 		}
 	}
 
+	userQueryCharacter := "SELECT .*u.*id.*u.*created_at.*u.*updated_at.*u.*deleted_at.*u.*name.*u.*age.*u.*birthday" +
+		".*u.*company_id.*u.*manager_id.*u.*active.* "
+
 	r = dryDB.Table("(?) as u", DB.Model(&User{}).Select("name")).Find(&User{}).Statement
-	if !regexp.MustCompile(userQuery + "FROM \\(SELECT .name. FROM .users. WHERE .users.\\..deleted_at. IS NULL\\) as u WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+	if !regexp.MustCompile(userQueryCharacter + "FROM \\(SELECT .name. FROM .users. WHERE .users.\\..deleted_at. IS NULL\\) as u WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
 		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 	}
 
 	r = dryDB.Table("(?) as u, (?) as p", DB.Model(&User{}).Select("name"), DB.Model(&Pet{}).Select("name")).Find(&User{}).Statement
-	if !regexp.MustCompile(userQuery + "FROM \\(SELECT .name. FROM .users. WHERE .users.\\..deleted_at. IS NULL\\) as u, \\(SELECT .name. FROM .pets. WHERE .pets.\\..deleted_at. IS NULL\\) as p WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+	if !regexp.MustCompile(userQueryCharacter + "FROM \\(SELECT .name. FROM .users. WHERE .users.\\..deleted_at. IS NULL\\) as u, \\(SELECT .name. FROM .pets. WHERE .pets.\\..deleted_at. IS NULL\\) as p WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
 		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 	}
 
 	r = dryDB.Where("name = ?", 1).Table("(?) as u, (?) as p", DB.Model(&User{}).Select("name").Where("name = ?", 2), DB.Model(&Pet{}).Where("name = ?", 4).Select("name")).Where("name = ?", 3).Find(&User{}).Statement
-	if !regexp.MustCompile(userQuery + "FROM \\(SELECT .name. FROM .users. WHERE name = .+ AND .users.\\..deleted_at. IS NULL\\) as u, \\(SELECT .name. FROM .pets. WHERE name = .+ AND .pets.\\..deleted_at. IS NULL\\) as p WHERE name = .+ AND name = .+ AND .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+	if !regexp.MustCompile(userQueryCharacter + "FROM \\(SELECT .name. FROM .users. WHERE name = .+ AND .users.\\..deleted_at. IS NULL\\) as u, \\(SELECT .name. FROM .pets. WHERE name = .+ AND .pets.\\..deleted_at. IS NULL\\) as p WHERE name = .+ AND name = .+ AND .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
 		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 	}
 

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -19,9 +19,10 @@ func (UserWithTable) TableName() string {
 
 func TestTable(t *testing.T) {
 	dryDB := DB.Session(&gorm.Session{DryRun: true})
+	userQuery := "SELECT .*id.*created_at.*updated_at.*deleted_at.*name.*age.*birthday.*company_id.*manager_id.*active.* "
 
 	r := dryDB.Table("`user`").Find(&User{}).Statement
-	if !regexp.MustCompile("SELECT \\* FROM `user`").MatchString(r.Statement.SQL.String()) {
+	if !regexp.MustCompile(userQuery + "FROM `user`").MatchString(r.Statement.SQL.String()) {
 		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 	}
 
@@ -52,17 +53,17 @@ func TestTable(t *testing.T) {
 	}
 
 	r = dryDB.Table("(?) as u", DB.Model(&User{}).Select("name")).Find(&User{}).Statement
-	if !regexp.MustCompile("SELECT \\* FROM \\(SELECT .name. FROM .users. WHERE .users.\\..deleted_at. IS NULL\\) as u WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+	if !regexp.MustCompile(userQuery + "FROM \\(SELECT .name. FROM .users. WHERE .users.\\..deleted_at. IS NULL\\) as u WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
 		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 	}
 
 	r = dryDB.Table("(?) as u, (?) as p", DB.Model(&User{}).Select("name"), DB.Model(&Pet{}).Select("name")).Find(&User{}).Statement
-	if !regexp.MustCompile("SELECT \\* FROM \\(SELECT .name. FROM .users. WHERE .users.\\..deleted_at. IS NULL\\) as u, \\(SELECT .name. FROM .pets. WHERE .pets.\\..deleted_at. IS NULL\\) as p WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+	if !regexp.MustCompile(userQuery + "FROM \\(SELECT .name. FROM .users. WHERE .users.\\..deleted_at. IS NULL\\) as u, \\(SELECT .name. FROM .pets. WHERE .pets.\\..deleted_at. IS NULL\\) as p WHERE .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
 		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 	}
 
 	r = dryDB.Where("name = ?", 1).Table("(?) as u, (?) as p", DB.Model(&User{}).Select("name").Where("name = ?", 2), DB.Model(&Pet{}).Where("name = ?", 4).Select("name")).Where("name = ?", 3).Find(&User{}).Statement
-	if !regexp.MustCompile("SELECT \\* FROM \\(SELECT .name. FROM .users. WHERE name = .+ AND .users.\\..deleted_at. IS NULL\\) as u, \\(SELECT .name. FROM .pets. WHERE name = .+ AND .pets.\\..deleted_at. IS NULL\\) as p WHERE name = .+ AND name = .+ AND .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
+	if !regexp.MustCompile(userQuery + "FROM \\(SELECT .name. FROM .users. WHERE name = .+ AND .users.\\..deleted_at. IS NULL\\) as u, \\(SELECT .name. FROM .pets. WHERE name = .+ AND .pets.\\..deleted_at. IS NULL\\) as p WHERE name = .+ AND name = .+ AND .u.\\..deleted_at. IS NULL").MatchString(r.Statement.SQL.String()) {
 		t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 	}
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Select all the fields of the structures to do the SQL query avoiding SELECT * FROM. It's always better to use the explicit column list in the SELECT query than a * wildcard, #3530
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
Queries for the `First`, `Take`, `Last`, `Find` methods:
```go
var users []*models.User
db.Debug().Model(&models.User{}).Find(&users)
// SELECT "id","first_name","last_name","email","password","created_at","updated_at" FROM "users"

db.Debug().Find(&users)
// SELECT "id","first_name","last_name","email","password","created_at","updated_at" FROM "users"
```
#### Smart Select Fields - Advanced Query
https://gorm.io/docs/advanced_query.html#Smart-Select-Fields

```go
type APIUser struct {
	FirstName string
	LastName  string
	Email     string
}

db.Debug().Model(&models.User{}).Find(&APIUser{})
// SELECT "first_name","last_name","email" FROM "users"
```

#### Special case

The `Find` method allows the result to be scanned to `map[string]interface{}` or `[]map[string]interface{}`, so the model fields are not selected for compatibility with the `Create From Map` option of the `Create` method.

```go
var results []map[string]interface{}
db.Debug().Model(&models.User{})Find(&results)
// SELECT * FROM "users"
```
<!-- Your use case -->
