### PR TITLE
Add hooks after completion of Migrate Value

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -33,6 +33,7 @@ type ColumnType interface {
 type Migrator interface {
 	// AutoMigrate
 	AutoMigrate(dst ...interface{}) error
+	After(dst interface{}) error
 
 	// Database
 	CurrentDatabase() string

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -147,8 +147,15 @@ func (m Migrator) AutoMigrate(values ...interface{}) error {
 				return err
 			}
 		}
+		if err := tx.Migrator().After(value); err != nil {
+			return err
+		}
 	}
 
+	return nil
+}
+
+func (m Migrator) After(dst interface{}) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Increase the dialect of the driver, add hooks after completion of Migrate Value

### User Case Description

for example in the column comment of postgresql

```golang
func (m Migrator) After(value interface{}) error {
	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
		for _, field := range stmt.Schema.FieldsByDBName {
			if field.Comment != "" {
				if err := m.DB.Exec(
					"COMMENT ON COLUMN " + stmt.Table + "." + field.DBName + " is " + field.Comment,
				).Error; err != nil {
					return err
				}
			}
		}
		return nil
	})
}
```


