### PR TITLE
Fix Association.Replace() error returning

### DIFF
--- a/association.go
+++ b/association.go
@@ -118,7 +118,7 @@ func (association *Association) Replace(values ...interface{}) error {
 
 			if _, pvs := schema.GetIdentityFieldValuesMap(reflectValue, primaryFields); len(pvs) > 0 {
 				column, values := schema.ToQueryValues(rel.FieldSchema.Table, foreignKeys, pvs)
-				tx.Where(clause.IN{Column: column, Values: values}).UpdateColumns(updateMap)
+				association.Error = tx.Where(clause.IN{Column: column, Values: values}).UpdateColumns(updateMap).Error
 			}
 		case schema.Many2Many:
 			var (
@@ -154,7 +154,7 @@ func (association *Association) Replace(values ...interface{}) error {
 				tx.Where(clause.Not(clause.IN{Column: relColumn, Values: relValues}))
 			}
 
-			tx.Delete(modelValue)
+			association.Error = tx.Delete(modelValue).Error
 		}
 	}
 	return association.Error


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

`Assocoation.Replace()` does not correctly returns error in some switch branches: `schema.HasOne, schema.HasMany and schema.Many2Many`

### User Case Description

Create such database structure:

```
type Profile struct {
	ID       uint
	Number   string
	MemberID uint `gorm:"not null"`
}

type Member struct {
	ID       uint
	Profiles []Profile
}
```

Insert some data:

```
member := &Member{
	Profiles: []Profile{{
		Number: "1",
	}, {
		Number: "2",
	}},
}
DB.Create(&member)
```

And try to `DB.Model(member).Association("Profiles").Clear()`. No error will be returned but the error actually occurs if you enable the logger
