### PR TITLE
Fix Association.Replace() error returning

### DIFF
--- a/association.go
+++ b/association.go
@@ -118,7 +118,7 @@ func (association *Association) Replace(values ...interface{}) error {
 
 			if _, pvs := schema.GetIdentityFieldValuesMap(reflectValue, primaryFields); len(pvs) > 0 {
 				column, values := schema.ToQueryValues(rel.FieldSchema.Table, foreignKeys, pvs)
-				tx.Where(clause.IN{Column: column, Values: values}).UpdateColumns(updateMap)
+				association.Error = tx.Where(clause.IN{Column: column, Values: values}).UpdateColumns(updateMap).Error
 			}
 		case schema.Many2Many:
 			var (
@@ -154,7 +154,7 @@ func (association *Association) Replace(values ...interface{}) error {
 				tx.Where(clause.Not(clause.IN{Column: relColumn, Values: relValues}))
 			}
 
-			tx.Delete(modelValue)
+			association.Error = tx.Delete(modelValue).Error
 		}
 	}
 	return association.Error

--- a/tests/associations_test.go
+++ b/tests/associations_test.go
@@ -3,6 +3,7 @@ package tests_test
 import (
 	"testing"
 
+	"gorm.io/gorm"
 	. "gorm.io/gorm/utils/tests"
 )
 
@@ -34,13 +35,13 @@ func TestInvalidAssociation(t *testing.T) {
 
 func TestAssociationNotNullClear(t *testing.T) {
 	type Profile struct {
-		ID       uint
+		gorm.Model
 		Number   string
 		MemberID uint `gorm:"not null"`
 	}
 
 	type Member struct {
-		ID       uint
+		gorm.Model
 		Profiles []Profile
 	}
 

--- a/tests/associations_test.go
+++ b/tests/associations_test.go
@@ -32,6 +32,41 @@ func TestInvalidAssociation(t *testing.T) {
 	}
 }
 
+func TestAssociationNotNullClear(t *testing.T) {
+	type Profile struct {
+		ID       uint
+		Number   string
+		MemberID uint `gorm:"not null"`
+	}
+
+	type Member struct {
+		ID       uint
+		Profiles []Profile
+	}
+
+	DB.Migrator().DropTable(&Member{}, &Profile{})
+
+	if err := DB.AutoMigrate(&Member{}, &Profile{}); err != nil {
+		t.Fatalf("Failed to migrate, got error: %v", err)
+	}
+
+	member := &Member{
+		Profiles: []Profile{{
+			Number: "1",
+		}, {
+			Number: "2",
+		}},
+	}
+
+	if err := DB.Create(&member).Error; err != nil {
+		t.Fatalf("Failed to create test data, got error: %v", err)
+	}
+
+	if err := DB.Model(member).Association("Profiles").Clear(); err == nil {
+		t.Fatalf("No error occured during clearind not null association")
+	}
+}
+
 func TestForeignKeyConstraints(t *testing.T) {
 	type Profile struct {
 		ID       uint


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

`Assocoation.Replace()` does not correctly returns error in some switch branches: `schema.HasOne, schema.HasMany and schema.Many2Many`

### User Case Description

Create such database structure:

```
type Profile struct {
	ID       uint
	Number   string
	MemberID uint `gorm:"not null"`
}

type Member struct {
	ID       uint
	Profiles []Profile
}
```

Insert some data:

```
member := &Member{
	Profiles: []Profile{{
		Number: "1",
	}, {
		Number: "2",
	}},
}
DB.Create(&member)
```

And try to `DB.Model(member).Association("Profiles").Clear()`. No error will be returned but the error actually occurs if you enable the logger
