### PR TITLE
Fix Scan int32, uint32

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -84,7 +84,7 @@ func Scan(rows *sql.Rows, db *DB, initialized bool) {
 			scanIntoMap(mapValue, values, columns)
 			*dest = append(*dest, mapValue)
 		}
-	case *int, *int64, *uint, *uint64, *float32, *float64, *string, *time.Time:
+	case *int, *int32, *int64, *uint, *uint32, *uint64, *float32, *float64, *string, *time.Time:
 		for initialized || rows.Next() {
 			initialized = false
 			db.RowsAffected++


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
int, int64 pointer was scanned correctly, but type int32 pointer was not scanned.

case int
```go
var i int
db.Raw("SELECT 1").Scan(&i)
fmt.Println(i) // <= Print 1
```

case int32
 it looks like something is wrong 🤔 
```go
var i int32
db.Raw("SELECT 1").Scan(&i)
fmt.Println(i) // <= Print 0
```

### User Case Description
i think, int32 and uint32 pointer would need to be scanned correctly.
