### PR TITLE
fix: scan more base type and sql.NullXXX

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -84,7 +84,12 @@ func Scan(rows *sql.Rows, db *DB, initialized bool) {
 			scanIntoMap(mapValue, values, columns)
 			*dest = append(*dest, mapValue)
 		}
-	case *int, *int32, *int64, *uint, *uint32, *uint64, *float32, *float64, *string, *time.Time:
+	case *int, *int8, *int16, *int32, *int64,
+		*uint, *uint8, *uint16, *uint32, *uint64, *uintptr,
+		*float32, *float64,
+		*bool, *string, *time.Time,
+		*sql.NullInt32, *sql.NullInt64, *sql.NullFloat64,
+		*sql.NullBool, *sql.NullString, *sql.NullTime:
 		for initialized || rows.Next() {
 			initialized = false
 			db.RowsAffected++


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
More base type not support, such as `int8`. NOT support `sql.NullXXX` is fatal.

```sql
SELECT MAX(update_at) FROM tab; # if no any data in tab, will return null.
```
```go
var nullMaxUpdated sql.NullInt64
if err = qp.Raw("SELECT MAX(update_at) FROM tab").Scan(&nullMaxUpdated).Error; err != nil {
    return
}
maxUpdated = int(nullMaxUpdated.Int64) // maxUpdated always 0.
```


### User Case Description

<!-- Your use case -->
