### PR TITLE
Fix building of `clause.Eq` and `clause.Neq` expressions that fail to handle `(*T)(nil)` use cases correctly

### DIFF
--- a/clause/expression.go
+++ b/clause/expression.go
@@ -203,7 +203,7 @@ type Eq struct {
 func (eq Eq) Build(builder Builder) {
 	builder.WriteQuoted(eq.Column)
 
-	if eq.Value == nil {
+	if eqNil(eq.Value) {
 		builder.WriteString(" IS NULL")
 	} else {
 		builder.WriteString(" = ")
@@ -221,7 +221,7 @@ type Neq Eq
 func (neq Neq) Build(builder Builder) {
 	builder.WriteQuoted(neq.Column)
 
-	if neq.Value == nil {
+	if eqNil(neq.Value) {
 		builder.WriteString(" IS NOT NULL")
 	} else {
 		builder.WriteString(" <> ")
@@ -298,4 +298,13 @@ func (like Like) NegationBuild(builder Builder) {
 	builder.WriteQuoted(like.Column)
 	builder.WriteString(" NOT LIKE ")
 	builder.AddVar(builder, like.Value)
+}
+
+func eqNil(value interface{}) bool {
+	return value == nil || eqNilReflect(value)
+}
+
+func eqNilReflect(value interface{}) bool {
+	reflectValue := reflect.ValueOf(value)
+	return reflectValue.Kind() == reflect.Ptr && reflectValue.IsNil()
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR fixes [`clause.Eq`](https://github.com/go-gorm/gorm/blob/e1952924e2a844eca52e5030f7b46b78de6ec135/clause/expression.go#L198) and [`clause.Neq`](https://github.com/go-gorm/gorm/blob/e1952924e2a844eca52e5030f7b46b78de6ec135/clause/expression.go#L219) expressions ability to identify `(*T)(nil)` as `nil` values.

The culprit lies in [./clause/expression.go#L206 `clause.Eq`](https://github.com/go-gorm/gorm/blob/e1952924e2a844eca52e5030f7b46b78de6ec135/clause/expression.go#L206) expression that fails to identify `(*T)(nil)` values as `nil` values.
The same problem is present for the [./clause/expression.go#L224 `clause.Neq`](https://github.com/go-gorm/gorm/blob/e1952924e2a844eca52e5030f7b46b78de6ec135/clause/expression.go#L224) expression.

The problem is discussed on [Stackoverflow: "Check for nil and nil interface in Go"](https://stackoverflow.com/questions/13476349/check-for-nil-and-nil-interface-in-go)

[Go Playground](https://play.golang.org/p/XW6DBEYAfaz) for the problem.

### User Case Description

Previously the following code produced an invalid SQL where clause:
```go
nilStringPtr := (*string)(nil)
DB.Model(SomeModel{}).
    .Where(map[string]interface{} {
        "field1": "some-value",
        "field2": nil,
        "field3": nilStringPtr, // It could be any (*T)(nil) type
    }).
    Update("field2", "some-other-value")
```
Expected: ```UPDATE `some_model` SET `field2` = ? WHERE `field1` = ? AND `field2` IS NULL AND `field3` IS NULL```
Actual: ```UPDATE `some_model` SET `field2` = ? WHERE `field1` = ? AND `field2` IS NULL AND `field3` = ?```
