### PR TITLE
add RollbackUnlessComitted, to make it easy to defer a Rollback.

### DIFF
--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -366,3 +366,25 @@ func TestTransactionOnClosedConn(t *testing.T) {
 		t.Errorf("should returns error when commit with closed conn, got error %v", err)
 	}
 }
+
+func TestTransactionRollbackUnlessComitted(t *testing.T) {
+	{
+		tx := DB.Begin()
+		tx.Commit()
+
+		tx.Rollback()
+		if tx.Error == nil {
+			t.Fatalf("Expected error")
+		}
+	}
+
+	{
+		tx := DB.Begin()
+		tx.Commit()
+
+		tx.RollbackUnlessComitted()
+		if tx.Error != nil {
+			t.Fatalf("Did not expect error, got: %v", tx.Error)
+		}
+	}
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Adding `RollbackUnlessComitted` back in (which was also in gorm 1), so you can defer a call to that and don't have to worry about not rolling back a TX and if you do commit the TX then you won't get a weird error being logged about the TX already being comitted.

People are also asking for it on the docs page; https://gorm.io/docs/transactions.html

### User Case Description

```go
func MyAction() error {
    tx := DB.Begin()
    defer tx.RollbackUnlessComitted()

    if something {
        return errors.New()
    }

    if somethingElse {
        return errors.New()
    }

    if anotherThing {
        return errors.New()
    }

    tx.Commit()

    return nil 
}
```