### PR TITLE
[Relationship] Title Case schema name for many2many

### DIFF
--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -219,7 +219,7 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 	}
 
 	for idx, ownField := range ownForeignFields {
-		joinFieldName := schema.Name + ownField.Name
+		joinFieldName := strings.Title(schema.Name) + ownField.Name
 		if len(joinForeignKeys) > idx {
 			joinFieldName = strings.Title(joinForeignKeys[idx])
 		}
@@ -258,7 +258,7 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 	}
 
 	joinTableFields = append(joinTableFields, reflect.StructField{
-		Name: schema.Name + field.Name,
+		Name: strings.Title(schema.Name) + field.Name,
 		Type: schema.ModelType,
 		Tag:  `gorm:"-"`,
 	})


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?
Ensures that schema.Name is Title case before building references in buildMany2ManyRelation. 

### User Case Description
We were trying to make a many2many relation gorm tags for a field in our db model, and kept failing due to `"field" is unexported but missing PkgPath`. It seems the schema.Name for our fields were not title case, which blocked us from proceeding to build any further.


In the screenshot, the first 2 schema names already had .Title applied (from the first line of the fix), but as you can see, the 3rd is still lowercase, which lead to the error shown, once we got further along in the codepath.

<img width="1153" alt="Screen Shot 2021-01-12 at 12 08 48 PM" src="https://user-images.githubusercontent.com/16161767/104374281-88376b80-54d6-11eb-80ec-3b29dbbb7543.png">