### PR TITLE
Allow declared settings through .Set and .Get to be accessed in preload queries

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -316,6 +316,12 @@ func (db *DB) getInstance() *DB {
 				Clauses:  map[string]clause.Clause{},
 				Vars:     make([]interface{}, 0, 8),
 			}
+			
+			// Carry over the settings previously defined so that you can access them in the preload callbacks
+			db.Statement.Settings.Range(func(k, v interface{}) bool {
+				tx.Statement.Settings.Store(k, v)
+				return true
+			})
 		} else {
 			// with clone statement
 			tx.Statement = db.Statement.clone()


### PR DESCRIPTION
- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?
Previously on v1, we were able to call a `.Set` method inside of a callback on a parent query. This would subsequently be available via another callback inside a preload calling `.Get`. This is currently not exposed when the statement is redeclared in the identified block of code. It is passed through on the `Statement.clone()` but that is not invoked here:

```
// preload.go
// Line 21
tx = db.Session(&gorm.Session{NewDB: true}).Model(nil).Session(&gorm.Session{SkipHooks: db.Statement.SkipHooks})
```

This invokes with `NewDB: true` which internally sets the `clone` as 1.

When calling `Model(nil)` this invokes `db.GetInstance()` on `chainable_api.go` which creates a new DB statement without any of the previous settings passed over.	

### User Case Description
We have added a caching overlay that relies on the callback methods. It is critical that from a child query, we're able to identify whether we did or did not cache the parent query and also to be able to retrieve its unique hash.

For example if we had
```
db.Preload("User").Preload("Data")
```

We would invoke a `beforeQuery` that calls `.Set("key", "some/identifiable/key")` which we use to determine a hit / miss from the caching service. This should then be passed down to the children preload queries in order to identify their own subsequent hashed key e.g. `some/identifiable/key/user` using the name of the preload.
