### PR TITLE
Add field tag to ignore migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ TODO*
 documents
 coverage.txt
 _book
+.idea

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -396,7 +396,7 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 		}
 	}
 
-	if alterColumn {
+	if alterColumn && !field.IgnoreMigration {
 		return m.DB.Migrator().AlterColumn(value, field.Name)
 	}
 

--- a/schema/field.go
+++ b/schema/field.go
@@ -70,6 +70,7 @@ type Field struct {
 	ReflectValueOf         func(reflect.Value) reflect.Value
 	ValueOf                func(reflect.Value) (value interface{}, zero bool)
 	Set                    func(reflect.Value, interface{}) error
+	IgnoreMigration        bool
 }
 
 func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
@@ -186,6 +187,10 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 
 	if val, ok := field.TagSettings["COMMENT"]; ok {
 		field.Comment = val
+	}
+
+	if _, ok := field.TagSettings["IGNOREMIGRATION"]; ok {
+		field.IgnoreMigration = true
 	}
 
 	// default value is function or null or blank (primary keys)

--- a/schema/field.go
+++ b/schema/field.go
@@ -189,10 +189,6 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		field.Comment = val
 	}
 
-	if _, ok := field.TagSettings["IGNOREMIGRATION"]; ok {
-		field.IgnoreMigration = true
-	}
-
 	// default value is function or null or blank (primary keys)
 	field.DefaultValue = strings.TrimSpace(field.DefaultValue)
 	skipParseDefaultValue := strings.Contains(field.DefaultValue, "(") &&
@@ -301,11 +297,23 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 	}
 
 	// setup permission
-	if _, ok := field.TagSettings["-"]; ok {
-		field.Creatable = false
-		field.Updatable = false
-		field.Readable = false
-		field.DataType = ""
+	if val, ok := field.TagSettings["-"]; ok {
+		val = strings.ToLower(strings.TrimSpace(val))
+		switch val {
+		case "-":
+			field.Creatable = false
+			field.Updatable = false
+			field.Readable = false
+			field.DataType = ""
+		case "all":
+			field.Creatable = false
+			field.Updatable = false
+			field.Readable = false
+			field.DataType = ""
+			field.IgnoreMigration = true
+		case "migration":
+			field.IgnoreMigration = true
+		}
 	}
 
 	if v, ok := field.TagSettings["->"]; ok {

--- a/schema/field.go
+++ b/schema/field.go
@@ -194,6 +194,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 	}
 
 	// default value is function or null or blank (primary keys)
+	field.DefaultValue = strings.TrimSpace(field.DefaultValue)
 	skipParseDefaultValue := strings.Contains(field.DefaultValue, "(") &&
 		strings.Contains(field.DefaultValue, ")") || strings.ToLower(field.DefaultValue) == "null" || field.DefaultValue == ""
 	switch reflect.Indirect(fieldValue).Kind() {

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -62,10 +62,11 @@ func TestSmartMigrateColumn(t *testing.T) {
 	DB.AutoMigrate(&UserMigrateColumn{})
 
 	type UserMigrateColumn2 struct {
-		ID       uint
-		Name     string    `gorm:"size:128"`
-		Salary   float64   `gorm:"precision:2"`
-		Birthday time.Time `gorm:"precision:2"`
+		ID                  uint
+		Name                string    `gorm:"size:128"`
+		Salary              float64   `gorm:"precision:2"`
+		Birthday            time.Time `gorm:"precision:2"`
+		NameIgnoreMigration string    `gorm:"size:100"`
 	}
 
 	if err := DB.Table("user_migrate_columns").AutoMigrate(&UserMigrateColumn2{}); err != nil {
@@ -95,10 +96,11 @@ func TestSmartMigrateColumn(t *testing.T) {
 	}
 
 	type UserMigrateColumn3 struct {
-		ID       uint
-		Name     string    `gorm:"size:256"`
-		Salary   float64   `gorm:"precision:3"`
-		Birthday time.Time `gorm:"precision:3"`
+		ID                  uint
+		Name                string    `gorm:"size:256"`
+		Salary              float64   `gorm:"precision:3"`
+		Birthday            time.Time `gorm:"precision:3"`
+		NameIgnoreMigration string    `gorm:"size:128;-:migration"`
 	}
 
 	if err := DB.Table("user_migrate_columns").AutoMigrate(&UserMigrateColumn3{}); err != nil {
@@ -123,6 +125,10 @@ func TestSmartMigrateColumn(t *testing.T) {
 		case "birthday":
 			if precision, _, _ := columnType.DecimalSize(); (fullSupported || precision != 0) && precision != 3 {
 				t.Fatalf("birthday's precision should be 2, but got %v", precision)
+			}
+		case "name_ignore_migration":
+			if length, _ := columnType.Length(); (fullSupported || length != 0) && length != 100 {
+				t.Fatalf("name_ignore_migration's length should still be 100 but got %v", length)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
current migration does not work well so add field tag to avoid
-->

### User Case Description

<!-- Your use case -->
```
import (
	"github.com/shopspring/decimal"
       ...
)

type ChainExtrinsic struct {
Fee                decimal.Decimal `json:"fee" sql:"type:decimal(30,0);"`//v1
...
}
type ChainExtrinsic struct {
Fee                decimal.Decimal `json:"fee" gorm:"type:decimal(30,0);"`//v2
...
}
db.AutoMigrate()

/*Actually there is no field definition change between v1 and v2.
for mysql migration from gorm v1 to v2 the unnessary alter column ddl as following will be generated
the worst thing is after migrating to v2, will still generate ddl each time when run automigrate
---ALTER TABLE `chain_extrinsics` MODIFY COLUMN `fee` decimal(30,0)
*/

```
we can avoid by add field tag as following:

```
type ChainExtrinsic struct {
Fee                decimal.Decimal `json:"fee" gorm:"type:decimal(30,0);ignoreMigration"`
...
}
```