### PR TITLE
replace parser cached interface with dest interface

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -97,7 +97,8 @@ func Parse(dest interface{}, cacheStore *sync.Map, namer Namer) (*Schema, error)
 
 	modelValue := reflect.New(modelType)
 	tableName := namer.TableName(modelType.Name())
-	if tabler, ok := modelValue.Interface().(Tabler); ok {
+	//if tabler, ok := modelValue.Interface().(Tabler); ok {
+	if tabler, ok := dest.(Tabler); ok {
 		tableName = tabler.TableName()
 	}
 	if en, ok := namer.(embeddedNamer); ok {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -297,3 +298,27 @@ func TestEmbeddedStructForCustomizedNamingStrategy(t *testing.T) {
 		})
 	}
 }
+
+
+type DynamicTable struct {
+	ID int
+}
+
+func (d *DynamicTable) TableName() string {
+	return fmt.Sprintf("dynamic_%d",d.ID)
+}
+
+func TestDynamicTableName(t *testing.T) {
+	for i:=0;i<=10;i++ {
+		dt := &DynamicTable{ID:i}
+		dynamic, err := schema.Parse(dt, &sync.Map{}, schema.NamingStrategy{})
+		if err != nil {
+			t.Fatalf("failed to parse pointer user, got error %v", err)
+		}
+
+		if dynamic.Table != dt.TableName(){
+			t.Errorf("Failed to customize table with TableName method")
+		}
+	}
+}
+


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
This pull request allows schema.Parse supporting reflect.Value.TableName instead of reflect.Type.TableName. This change works well with CustomizeTable.TableName, furthermore it supports tablename related to params of the current struct. This change is a simlpe alternative to https://gorm.io/docs/v2_release_note.html#Table-Name `Scopes ` in which case programers should be aware of using `db.Table` or `db.Scope` in dynamic tablename gorm struct.

The origin way only support the custom struct tablename, this change supports both custom and dynamic struct tablename

```go
//origin
if tabler, ok := modelValue.Interface().(Tabler); ok {
  tableName = tabler.TableName()
}
//modified
if tabler, ok := dest.(Tabler); ok {
  tableName = tabler.TableName()
}
```



### User Case Description

<!-- Your use case -->

```go

type DynamicTable struct {
	ID int
}

func (d *DynamicTable) TableName() string {
	return fmt.Sprintf("dynamic_%d",d.ID)
}

func TestDynamicTableName(t *testing.T) {
	for i:=0;i<=10;i++ {
		dt := &DynamicTable{ID:i}
		dynamic, err := schema.Parse(dt, &sync.Map{}, schema.NamingStrategy{})
		if err != nil {
			t.Fatalf("failed to parse pointer user, got error %v", err)
		}

		if dynamic.Table != dt.TableName(){
			t.Errorf("Failed to customize table with TableName method")
		}
	}
}


```