### PR TITLE
Add ActivatedAt for scheduling future events.

### DIFF
--- a/model.go
+++ b/model.go
@@ -8,8 +8,10 @@ import "time"
 //      gorm.Model
 //    }
 type Model struct {
-	ID        uint `gorm:"primarykey"`
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt DeletedAt `gorm:"index"`
+	ID          uint      `gorm:"primarykey"`
+	ActivatedAt time.Time `gorm:"not null"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	DeletedAt   gorm.DeletedAt `gorm:"index"`
 }
+


### PR DESCRIPTION
- [v] Do only one thing
- [v] Non breaking API changes
- [v] Tested

### What did this pull request do?
Add ActivatedAt for scheduling future events.

### User Case Description
Sometimes we hope to prepare partial or full information before it goes online. 
By default, gorm fills in a timestamp in the past. if you assigned a timestamp in the future, then it gets activated in the future .