### PR TITLE
for Config.cacheStore store PreparedStmtDB key

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -13,6 +13,9 @@ import (
 	"gorm.io/gorm/schema"
 )
 
+// for Config.cacheStore store PreparedStmtDB key
+const preparedStmtDBKey = "preparedStmt"
+
 // Config GORM config
 type Config struct {
 	// GORM perform single create, update, delete operations in transactions by default to ensure database data integrity
@@ -162,7 +165,7 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 		Mux:         &sync.RWMutex{},
 		PreparedSQL: make([]string, 0, 100),
 	}
-	db.cacheStore.Store("preparedStmt", preparedStmt)
+	db.cacheStore.Store(preparedStmtDBKey, preparedStmt)
 
 	if config.PrepareStmt {
 		db.ConnPool = preparedStmt
@@ -225,7 +228,7 @@ func (db *DB) Session(config *Session) *DB {
 	}
 
 	if config.PrepareStmt {
-		if v, ok := db.cacheStore.Load("preparedStmt"); ok {
+		if v, ok := db.cacheStore.Load(preparedStmtDBKey); ok {
 			preparedStmt := v.(*PreparedStmtDB)
 			tx.Statement.ConnPool = &PreparedStmtDB{
 				ConnPool: db.Config.ConnPool,


### PR DESCRIPTION
It is used to store the key stored in Config.cacheStore. It is recommended to use a constant. If you need to change, you can use var to modify.