### PR TITLE
optimize value of reflection length

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -35,10 +35,12 @@ func (db *DB) CreateInBatches(value interface{}, batchSize int) (tx *DB) {
 		tx = db.getInstance()
 
 		callFc := func(tx *DB) error {
-			for i := 0; i < reflectValue.Len(); i += batchSize {
+			// the reflection length judgment of the optimized value
+			reflectLen := reflectValue.Len()
+			for i := 0; i < reflectLen; i += batchSize {
 				ends := i + batchSize
-				if ends > reflectValue.Len() {
-					ends = reflectValue.Len()
+				if ends > reflectLen {
+					ends = reflectLen
 				}
 
 				subtx := tx.getInstance()


### PR DESCRIPTION
To judge the reflection length of the optimized value, the switch operation is performed every time in reflect/value.go in the reflection source code of go. Doing such an operation in for here is actually very performance-consuming. It is recommended to perform it once outside. It's okay.