### PR TITLE
Optimize parse constraint

### DIFF
--- a/association.go
+++ b/association.go
@@ -1,7 +1,6 @@
 package gorm
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -441,7 +440,7 @@ func (association *Association) saveAssociation(clear bool, values ...interface{
 				break
 			}
 
-			association.Error = errors.New("invalid association values, length doesn't match")
+			association.Error = ErrInvalidValueOfLength
 			return
 		}
 

--- a/callbacks.go
+++ b/callbacks.go
@@ -104,7 +104,7 @@ func (p *processor) Execute(db *DB) {
 			stmt.ReflectValue = stmt.ReflectValue.Elem()
 		}
 		if !stmt.ReflectValue.IsValid() {
-			db.AddError(fmt.Errorf("invalid value"))
+			db.AddError(ErrInvalidValue)
 		}
 	}
 

--- a/chainable_api.go
+++ b/chainable_api.go
@@ -98,7 +98,12 @@ func (db *DB) Select(query interface{}, args ...interface{}) (tx *DB) {
 				Distinct:   db.Statement.Distinct,
 				Expression: clause.Expr{SQL: v, Vars: args},
 			})
-		} else {
+		} else if strings.Count(v, "@") > 0 && len(args) > 0 {
+			tx.Statement.AddClause(clause.Select{
+				Distinct:   db.Statement.Distinct,
+				Expression: clause.NamedExpr{SQL: v, Vars: args},
+			})
+		}  else {
 			tx.Statement.Selects = []string{v}
 
 			for _, arg := range args {

--- a/clause/clause.go
+++ b/clause/clause.go
@@ -62,9 +62,9 @@ func (c Clause) Build(builder Builder) {
 }
 
 const (
-	PrimaryKey   string = "@@@py@@@" // primary key
-	CurrentTable string = "@@@ct@@@" // current table
-	Associations string = "@@@as@@@" // associations
+	PrimaryKey   string = "~~~py~~~" // primary key
+	CurrentTable string = "~~~ct~~~" // current table
+	Associations string = "~~~as~~~" // associations
 )
 
 var (

--- a/errors.go
+++ b/errors.go
@@ -31,4 +31,10 @@ var (
 	ErrEmptySlice = errors.New("empty slice found")
 	// ErrDryRunModeUnsupported dry run mode unsupported
 	ErrDryRunModeUnsupported = errors.New("dry run mode unsupported")
+	// ErrInvaildDB invalid db
+	ErrInvaildDB = errors.New("invalid db")
+	// ErrInvalidValue invalid value
+	ErrInvalidValue = errors.New("invalid value")
+	// ErrInvalidValueOfLength invalid values do not match length
+	ErrInvalidValueOfLength = errors.New("invalid association values, length doesn't match")
 )

--- a/gorm.go
+++ b/gorm.go
@@ -3,7 +3,6 @@ package gorm
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -334,7 +333,7 @@ func (db *DB) DB() (*sql.DB, error) {
 		return sqldb, nil
 	}
 
-	return nil, errors.New("invalid db")
+	return nil, ErrInvaildDB
 }
 
 func (db *DB) getInstance() *DB {

--- a/gorm.go
+++ b/gorm.go
@@ -13,6 +13,9 @@ import (
 	"gorm.io/gorm/schema"
 )
 
+// for Config.cacheStore store PreparedStmtDB key
+const preparedStmtDBKey = "preparedStmt"
+
 // Config GORM config
 type Config struct {
 	// GORM perform single create, update, delete operations in transactions by default to ensure database data integrity
@@ -162,7 +165,7 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 		Mux:         &sync.RWMutex{},
 		PreparedSQL: make([]string, 0, 100),
 	}
-	db.cacheStore.Store("preparedStmt", preparedStmt)
+	db.cacheStore.Store(preparedStmtDBKey, preparedStmt)
 
 	if config.PrepareStmt {
 		db.ConnPool = preparedStmt
@@ -225,7 +228,7 @@ func (db *DB) Session(config *Session) *DB {
 	}
 
 	if config.PrepareStmt {
-		if v, ok := db.cacheStore.Load("preparedStmt"); ok {
+		if v, ok := db.cacheStore.Load(preparedStmtDBKey); ok {
 			preparedStmt := v.(*PreparedStmtDB)
 			tx.Statement.ConnPool = &PreparedStmtDB{
 				ConnPool: db.Config.ConnPool,

--- a/schema/check.go
+++ b/schema/check.go
@@ -6,8 +6,8 @@ import (
 )
 
 var (
-	// match English letters and midline
-	regEnLetterAndmidline = regexp.MustCompile("^[A-Za-z-_]+$")
+	// reg match english letters and midline
+	regEnLetterAndMidline = regexp.MustCompile("^[A-Za-z-_]+$")
 )
 
 type Check struct {
@@ -22,7 +22,7 @@ func (schema *Schema) ParseCheckConstraints() map[string]Check {
 	for _, field := range schema.FieldsByDBName {
 		if chk := field.TagSettings["CHECK"]; chk != "" {
 			names := strings.Split(chk, ",")
-			if len(names) > 1 && regEnLetterAndmidline.MatchString(names[0]) {
+			if len(names) > 1 && regEnLetterAndMidline.MatchString(names[0]) {
 				checks[names[0]] = Check{Name: names[0], Constraint: strings.Join(names[1:], ","), Field: field}
 			} else {
 				if names[0] == "" {

--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 	"strings"
 
 	"github.com/jinzhu/inflection"
@@ -536,7 +535,11 @@ func (rel *Relationship) ParseConstraint() *Constraint {
 		settings = ParseTagSetting(str, ",")
 	)
 
-	if idx != -1 && regexp.MustCompile("^[A-Za-z-_]+$").MatchString(str[0:idx]) {
+	// optimize match english letters and midline
+	// The following code is basically called in for.
+	// In order to avoid the performance problems caused by repeated compilation of regular expressions,
+	// it only needs to be done once outside, so optimization is done here.
+	if idx != -1 && regEnLetterAndMidline.MatchString(str[0:idx]) {
 		name = str[0:idx]
 	} else {
 		name = rel.Schema.namer.RelationshipFKName(*rel)

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -628,6 +628,12 @@ func TestSelect(t *testing.T) {
 		t.Fatalf("Build Select with func, but got %v", r.Statement.SQL.String())
 	}
 
+	// named arguments
+	r = dryDB.Table("users").Select("COALESCE(age, @default)", sql.Named("default", 42)).Find(&User{})
+	if !regexp.MustCompile(`SELECT COALESCE\(age,.*\) FROM .*users.*`).MatchString(r.Statement.SQL.String()) {
+		t.Fatalf("Build Select with func, but got %v", r.Statement.SQL.String())
+	}
+
 	if _, err := DB.Table("users").Select("COALESCE(age,?)", "42").Rows(); err != nil {
 		t.Fatalf("Failed, got error: %v", err)
 	}


### PR DESCRIPTION
gorm/schema/relationship.go ParseConstraint method optimization.
The following code is basically called in for. In order to avoid the performance problems caused by repeated compilation of regular expressions, it only needs to be done once outside, so optimization is done here. 