### PR TITLE
support to preload all children in multiple levels associations

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -185,12 +185,26 @@ func Preload(db *gorm.DB) {
 				}
 			} else {
 				preloadFields := strings.Split(name, ".")
-				if _, ok := preloadMap[preloadFields[0]]; !ok {
-					preloadMap[preloadFields[0]] = map[string][]interface{}{}
-				}
+				if preloadFields[0] == clause.Associations {
+					for _, rel := range db.Statement.Schema.Relationships.Relations {
+						if rel.Schema == db.Statement.Schema {
+							if _, ok := preloadMap[rel.Name]; !ok {
+								preloadMap[rel.Name] = map[string][]interface{}{}
+							}
 
-				if value := strings.TrimPrefix(strings.TrimPrefix(name, preloadFields[0]), "."); value != "" {
-					preloadMap[preloadFields[0]][value] = db.Statement.Preloads[name]
+							if value := strings.TrimPrefix(strings.TrimPrefix(name, preloadFields[0]), "."); value != "" {
+								preloadMap[rel.Name][value] = db.Statement.Preloads[name]
+							}
+						}
+					}
+				} else {
+					if _, ok := preloadMap[preloadFields[0]]; !ok {
+						preloadMap[preloadFields[0]] = map[string][]interface{}{}
+					}
+
+					if value := strings.TrimPrefix(strings.TrimPrefix(name, preloadFields[0]), "."); value != "" {
+						preloadMap[preloadFields[0]][value] = db.Statement.Preloads[name]
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

-  Do only one thing

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Combine "clause.Associations" with "Whatever" in preload, even itself.
This can help to preload all model's children in multiple levels associations.


### User Case Description

<!-- Your use case -->

```
type Person struct {
	ID             int      `gorm:"primaryKey"`
	FamilySourceID *int
	FriendSourceID *int
	Family         []Person `gorm:"foreignKey:FamilySourceID"`
	Friend         []Person `gorm:"foreignKey:FriendSourceID"`
}
```

if we want to preload all of Person model's children in 4 levels associations, we have to write it as:
```
db.Preload("Family.Family.Family." + clause.Associations).
	Preload("Family.Family.Friend."  + clause.Associations).
	Preload("Family.Friend.Family."  + clause.Associations).
	Preload("Friend.Family.Family."  + clause.Associations).
        ...
        ...
	Preload("Family.Friend.Friend."  + clause.Associations).
	Preload("Friend.Friend.Friend."  + clause.Associations).
	Find(&person)
```

This commit help the combination of "clause.Associations" and "Whatever", anywhere.
Now, we can do it like this:
```
db.Preload(clause.Associations + "." + clause.Associations + "." + clause.Associations + "." + clause.Associations).
	Find(&person)
```