### PR TITLE
Added utility functions for setting and extracting *DB from context.Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,27 @@
+package gorm
+
+import (
+	"context"
+)
+
+// contextKeyType is an unexported type so that the context key never
+// collides with any other context keys.
+type contextKeyType struct{}
+
+// contextKey is the key used for the context to store the DB object.
+var contextKey = contextKeyType{}
+
+// WithContext inserts a DB into the context and is retrievable using FromContext().
+func WithContext(ctx context.Context, db *DB) context.Context {
+	return context.WithValue(ctx, contextKey, db)
+}
+
+// FromContext extracts a DB from the context. An error is returned if
+// the context does not contain a DB object.
+func FromContext(ctx context.Context) (*DB, error) {
+	db, _ := ctx.Value(contextKey).(*DB)
+	if db == nil {
+		return nil, ErrDBNotFoundInContext
+	}
+	return db, nil
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,34 @@
+package gorm
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestContext_success(t *testing.T) {
+	db := &DB{}
+
+	ctx := WithContext(context.Background(), db)
+	extractedDB, err := FromContext(ctx)
+
+	if err != nil {
+		t.Errorf("expected err to be nil. Got: %v", err)
+	}
+
+	if !reflect.DeepEqual(db, extractedDB) {
+		t.Errorf("db and extractedDB are not the same")
+	}
+}
+
+func TestContext_failure(t *testing.T) {
+	extractedDB, err := FromContext(context.Background())
+
+	if extractedDB != nil {
+		t.Errorf("expected extractedDB to nil. Got: %v", extractedDB)
+	}
+
+	if err != ErrDBNotFoundInContext {
+		t.Errorf("expected err to be ErrDBNotFoundInContext. Got: %v", err)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -37,4 +37,6 @@ var (
 	ErrInvalidValue = errors.New("invalid value")
 	// ErrInvalidValueOfLength invalid values do not match length
 	ErrInvalidValueOfLength = errors.New("invalid association values, length doesn't match")
+	// ErrDBNotFoundInContext when gorm.DB not found in the context
+	ErrDBNotFoundInContext = errors.New("DB not found in context")
 )


### PR DESCRIPTION
### Checklist

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What does this pull request do?

This PR adds 2 simple utility functions for working with `*DB` and `context.Context`. `WithContext()` can be used to add a `*DB` to the context and `FromContext()` can be used to extract the `*DB` from the context.

### Use Case Description

An example use case is storing the `*DB` in the base context of a `http.Server` and getting access to it within handler functions:

```go
package main

import (
	"context"
	"encoding/json"
	"log"
	"net"
	"net/http"

	"github.com/gorilla/mux"
	"gorm.io/driver/sqlite"
	"gorm.io/gorm"
)

type Product struct {
	gorm.Model
	Code  string
	Price uint
}

func main() {
	db, err := gorm.Open(sqlite.Open("test.db"), &gorm.Config{})
	if err != nil {
		panic("failed to connect database")
	}

	db.AutoMigrate(&Product{})
	db.Create(&Product{Code: "D42", Price: 100})

	m := mux.NewRouter()
	m.Handle("/product/{id}", http.HandlerFunc(GetProduct))

	ctx := gorm.WithContext(context.Background(), db)

	httpServer := &http.Server{
		Addr:    ":8000",
		Handler: m,
		BaseContext: func(listener net.Listener) context.Context {
			return ctx
		},
	}

	log.Fatal(httpServer.ListenAndServe())
}

func GetProduct(w http.ResponseWriter, r *http.Request) {
	db, err := gorm.FromContext(r.Context())
	if err != nil {
		w.WriteHeader(http.StatusInternalServerError)
		return
	}

	productID := mux.Vars(r)["id"]

	var product Product
	db.First(&product, productID)

	w.WriteHeader(http.StatusOK)
	json.NewEncoder(w).Encode(product)
}

```
