### PR TITLE
Fix FindInBatches to return errors when Find fails

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -190,6 +190,8 @@ func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, bat
 
 		if result.Error == nil && result.RowsAffected != 0 {
 			tx.AddError(fc(result, batch))
+		} else if result.Error != nil {
+			tx.AddError(result.Error)
 		}
 
 		if tx.Error != nil || int(result.RowsAffected) < batchSize {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
I fixed a bug where there is no way to handle errors inside `FindInBatches` becauses `FindInBatches` ignores errors returned from `Find`.

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
This is just a bug fix.
<!-- Your use case -->
