### PR TITLE
Fixed InvalidDB error when creating a new connection with PrepareStmt

### DIFF
--- a/prepare_stmt.go
+++ b/prepare_stmt.go
@@ -30,6 +30,10 @@ func (db *PreparedStmtDB) GetDB() (*sql.DB, error) {
 	return nil, ErrInvaildDB
 }
 
+func (db *PreparedStmtDB) GetDBConn() (*sql.DB, error) {
+	return db.GetDB()
+}
+
 func (db *PreparedStmtDB) Close() {
 	db.Mux.Lock()
 	for _, query := range db.PreparedSQL {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

I was running into an issue using Goyave with the MySQL connector, it was always returning invalid db upon connection.

Here's a snippet from the Goyave database library
```golang
dsn := dialect.buildDSN()
db, err := gorm.Open(dialect.initializer(dsn), &gorm.Config{
    PrepareStmt: true,
    Logger:      logger.Default.LogMode(logLevel),
})
if err != nil {
    panic(err)
}

sql, err := db.DB()
if err != nil {
    panic(err)
}
```

This bug occurs on the call to `db.DB()` which should return a `*sql.DB` object.

The bug is caused by DB() trying to check if ConnPool implements the GetDBConnector interface. Goyave makes a call to gorm.Open and enables PrepareStmt. This set ConnPool to be a PrepareStmtDB. PrepareStmtDB does have a function for returning the repsonse that DB() is expecting, however it's named GetDB instead of GetDBConn so the check fails and the code returns invalid db which causes the Goyave app to panic.

I've added a wrapper around GetDB called GetDBConn so the check passes and returns the expected result. Since I'm not renaming the function, it remains backwards compatible with any code that uses the GetDB method.

### User Case Description

Bug fix
