### PR TITLE
CanZero specifies fields that you can be set to zero value when creating and updating.

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -142,6 +142,19 @@ func (db *DB) Omit(columns ...string) (tx *DB) {
 	return
 }
 
+// CanZero specifies fields that you can be set to zero value when creating and updating.
+// Priority is lower than Select and Omit
+func (db *DB) CanZero(columns ...string) (tx *DB) {
+	tx = db.getInstance()
+
+	if len(columns) == 1 && strings.ContainsRune(columns[0], ',') {
+		tx.Statement.CanZeros = strings.FieldsFunc(columns[0], utils.IsValidDBNameChar)
+	} else {
+		tx.Statement.CanZeros = columns
+	}
+	return
+}
+
 // Where add conditions
 func (db *DB) Where(query interface{}, args ...interface{}) (tx *DB) {
 	tx = db.getInstance()

--- a/tests/update_test.go
+++ b/tests/update_test.go
@@ -685,3 +685,32 @@ func TestSaveWithPrimaryValue(t *testing.T) {
 		t.Errorf("failed to find created record, got error: %v, result: %+v", err, result4)
 	}
 }
+
+func TestCanZeroWithUpdate(t *testing.T) {
+	user := *GetUser("can_zero_update", Config{})
+	user.Active = true
+	DB.Create(&user)
+
+	var result User
+	DB.First(&result, user.ID)
+
+	user2 := *GetUser("can_zero_update_new", Config{})
+	result.Name = user2.Name
+	result.Active = false
+	result.Age = 0
+
+	DB.Model(User{}).Where("ID", user.ID).CanZero("Age").Updates(User{
+		Name:   user2.Name,
+		Active: false,
+		Age:    0,
+	})
+
+	var result2 User
+	DB.First(&result2, user.ID)
+
+	AssertObjEqual(t, result2, result, "Name", "Age")
+
+	if !result2.Active || result.Active {
+		t.Fatalf("Update struct should only update can zero columns, was %+v, got %+v", result2.Active, result.Active)
+	}
+}


### PR DESCRIPTION
CanZero specifies fields that you can be set to zero value when creating and updating.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Add CanZero() specifies fields that you can be set to zero value when creating and updating.

### User Case Description

<!-- Your use case -->

https://github.com/go-gorm/gorm/issues/4297
