### PR TITLE
Fixed naming longer than 64 characters

### DIFF
--- a/schema/naming.go
+++ b/schema/naming.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"unicode/utf8"
@@ -80,7 +81,7 @@ func (ns NamingStrategy) formatName(prefix, table, name string) string {
 		h.Write([]byte(formattedName))
 		bs := h.Sum(nil)
 
-		formattedName = fmt.Sprintf("%v%v%v", prefix, table, name)[0:56] + string(bs)[:8]
+		formattedName = fmt.Sprintf("%v%v%v", prefix, table, name)[0:56] + hex.EncodeToString(bs)[:8]
 	}
 	return formattedName
 }

--- a/schema/naming_test.go
+++ b/schema/naming_test.go
@@ -168,3 +168,12 @@ func TestCustomReplacerWithNoLowerCase(t *testing.T) {
 		t.Errorf("invalid column name generated, got %v", columdName)
 	}
 }
+
+func TestFormatNameWithStringLongerThan64Characters(t *testing.T) {
+	var ns = NamingStrategy{}
+
+	formattedName := ns.formatName("prefix", "table", "thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString")
+	if formattedName != "prefixtablethisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryLo180f2c67" {
+		t.Errorf("invalid formatted name generated, got %v", formattedName)
+	}
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fix naming for a string longer than 64 characters, we need to call hex.EncodeToString in order to get the correct sha1 string.

Actual error:
`
ALTER TABLE "user_accepted_contract_document_versions" ADD CONSTRAINT "fkuser_accepted_contract_document_versionscontract_docum=����)�" FOREIGN KEY ("contract_document_version_refer") REFERENCES "contract_document_versions"("id")
`

`ERROR: invalid byte sequence for encoding "UTF8": 0xb2 (SQLSTATE 22021)`
