### PR TITLE
Add placeholder field tags feature

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -341,6 +341,15 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		}
 	}
 
+	// placeholder; readonly without migration
+
+	if _, ok := field.TagSettings["<->"]; ok {
+		field.Readable = true
+		field.Creatable = false
+		field.Updatable = false
+		field.IgnoreMigration = true
+	}
+
 	if _, ok := field.TagSettings["EMBEDDED"]; ok || (fieldStruct.Anonymous && !isValuer && (field.Creatable || field.Updatable || field.Readable)) {
 		if reflect.Indirect(fieldValue).Kind() == reflect.Struct {
 			var err error

--- a/schema/field_test.go
+++ b/schema/field_test.go
@@ -235,6 +235,7 @@ type UserWithPermissionControl struct {
 	Name5 string `gorm:"<-:update"`
 	Name6 string `gorm:"<-:create,update"`
 	Name7 string `gorm:"->:false;<-:create,update"`
+	Ref   string `gorm:"<->"`
 }
 
 func TestParseFieldWithPermission(t *testing.T) {
@@ -252,6 +253,7 @@ func TestParseFieldWithPermission(t *testing.T) {
 		{Name: "Name5", DBName: "name5", BindNames: []string{"Name5"}, DataType: schema.String, Tag: `gorm:"<-:update"`, Creatable: false, Updatable: true, Readable: true},
 		{Name: "Name6", DBName: "name6", BindNames: []string{"Name6"}, DataType: schema.String, Tag: `gorm:"<-:create,update"`, Creatable: true, Updatable: true, Readable: true},
 		{Name: "Name7", DBName: "name7", BindNames: []string{"Name7"}, DataType: schema.String, Tag: `gorm:"->:false;<-:create,update"`, Creatable: true, Updatable: true, Readable: false},
+		{Name: "Ref", DBName: "ref", BindNames: []string{"Ref"}, DataType: schema.String, Tag: `gorm:"<->"`, Creatable: false, Updatable: false, Readable: true, IgnoreMigration: true},
 	}
 
 	for _, f := range fields {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
I have added a placeholder to the field tags which is for read-mode and ignore migration. It is very useful for auto field names generated by Raw query.

### User Case Description

<!-- Your use case -->

#4314 