### PR TITLE
allow `Schema` and `Field` json marshal

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -64,12 +64,12 @@ type Field struct {
 	StructField            reflect.StructField
 	Tag                    reflect.StructTag
 	TagSettings            map[string]string
-	Schema                 *Schema
-	EmbeddedSchema         *Schema
-	OwnerSchema            *Schema
-	ReflectValueOf         func(reflect.Value) reflect.Value
-	ValueOf                func(reflect.Value) (value interface{}, zero bool)
-	Set                    func(reflect.Value, interface{}) error
+	Schema                 *Schema                                            `json:"-"`
+	EmbeddedSchema         *Schema                                            `json:"-"`
+	OwnerSchema            *Schema                                            `json:"-"`
+	ReflectValueOf         func(reflect.Value) reflect.Value                  `json:"-"`
+	ValueOf                func(reflect.Value) (value interface{}, zero bool) `json:"-"`
+	Set                    func(reflect.Value, interface{}) error             `json:"-"`
 	IgnoreMigration        bool
 }
 

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
@@ -295,5 +296,22 @@ func TestEmbeddedStructForCustomizedNamingStrategy(t *testing.T) {
 				f.Readable = true
 			}
 		})
+	}
+}
+
+
+func TestSchemaParseMarshalJson(t *testing.T) {
+	type model struct {
+		gorm.Model
+		Title string
+	}
+	v := &model{Title: "test"}
+	schema, err := schema.Parse(v, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("error while parsing schema %v", err)
+	}
+	_, err = json.MarshalIndent(schema, "", "\t")
+	if err != nil {
+		t.Fatalf("error while json marshaling schema %v", err)
 	}
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -299,7 +299,6 @@ func TestEmbeddedStructForCustomizedNamingStrategy(t *testing.T) {
 	}
 }
 
-
 func TestSchemaParseMarshalJson(t *testing.T) {
 	type model struct {
 		gorm.Model


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
This allows marshaling `schema.Schema` and `schema.Field` by adding json tags to fields that cannot be marshaled:
````
schema_test.go:314: error while json marshaling schema json: unsupported type: func(reflect.Value, interface {}) error
schema_test.go:314: error while json marshaling schema json: unsupported type: func(reflect.Value) (interface {}, bool)
schema_test.go:314: error while json marshaling schema json: unsupported type: func(reflect.Value) reflect.Value
schema_test.go:314: error while json marshaling schema json: unsupported value: encountered a cycle via *schema.Schema
````

### User Case Description
By marshaling `Schema` and `Field` we make it possible to create structured data in json format about our models. This can be (maybe) used for generating some API to interact with your models.