### PR TITLE
fixed belongs_to & has_one reversed if field same

### DIFF
--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jinzhu/inflection"
 	"gorm.io/gorm/clause"
+	"gorm.io/gorm/utils"
 )
 
 // RelationshipType relationship type
@@ -404,11 +405,14 @@ func (schema *Schema) guessRelation(relation *Relationship, field *Field, cgl gu
 
 	if len(relation.foreignKeys) > 0 {
 		for _, foreignKey := range relation.foreignKeys {
-			if f := foreignSchema.LookUpField(foreignKey); f != nil {
-				foreignFields = append(foreignFields, f)
-			} else {
+			ff := foreignSchema.LookUpField(foreignKey)
+			pf := primarySchema.LookUpField(foreignKey)
+			isKeySame := utils.ExistsIn(foreignKey, &relation.primaryKeys)
+			if ff == nil || (pf != nil && ff != nil && schema == primarySchema && primarySchema != foreignSchema && !isKeySame) {
 				reguessOrErr()
 				return
+			} else {
+				foreignFields = append(foreignFields, ff)
 			}
 		}
 	} else {

--- a/schema/relationship_test.go
+++ b/schema/relationship_test.go
@@ -482,3 +482,22 @@ func TestSameForeignKey(t *testing.T) {
 		},
 	)
 }
+
+func TestBelongsToWithSameForeignKey(t *testing.T) {
+	type Profile struct {
+		gorm.Model
+		Name         string
+		ProfileRefer int
+	}
+
+	type User struct {
+		gorm.Model
+		Profile      Profile `gorm:"ForeignKey:ProfileRefer"`
+		ProfileRefer int
+	}
+
+	checkStructRelation(t, &User{}, Relation{
+		Name: "Profile", Type: schema.BelongsTo, Schema: "User", FieldSchema: "Profile",
+		References: []Reference{{"ID", "Profile", "ProfileRefer", "User", "", false}},
+	})
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -111,3 +111,15 @@ func ToString(value interface{}) string {
 	}
 	return ""
 }
+
+func ExistsIn(a string, list *[]string) bool {
+	if list == nil {
+		return false
+	}
+	for _, b := range *list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR is for the issue  #4316 (belongs_to and has_one reversed if field names are identical). 
It fixes the issue which was introduced in [`628a0ae`](https://github.com/go-gorm/gorm/commit/628a0ae707f230c67bca2e632fb302037c707705) commit.

- Added the correct conditions necessary to `reguessOrErr`.
- Added New Test case which handles the use-case that was failing.
- Added a utility function needed.