### PR TITLE
Fix ErrInvalidTransaction error message

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -10,7 +10,7 @@ var (
 	// ErrRecordNotFound record not found error
 	ErrRecordNotFound = logger.ErrRecordNotFound
 	// ErrInvalidTransaction invalid transaction when you are trying to `Commit` or `Rollback`
-	ErrInvalidTransaction = errors.New("no valid transaction")
+	ErrInvalidTransaction = errors.New("invalid transaction")
 	// ErrNotImplemented not implemented
 	ErrNotImplemented = errors.New("not implemented")
 	// ErrMissingWhereClause missing where clause


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non-breaking API changes
- [ ] Tested

### What did this pull request do?

Fixed the error message for `ErrInvalidTransaction` to `invalid transaction` instead of `no valid transaction` because `no valid transaction` is a bit hard to understand and can be misleading sometimes.

For example, we could manually begin a transaction using `tx.Begin` and run `tx.Begin` again but the error message `no valid transaction` can be confusing because there is a transaction already in progress. 

### User Case Description

N/A
