### PR TITLE
Tag `default` leads to the error `Error 1110: Column specified twice`…

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -210,13 +210,15 @@ func Parse(dest interface{}, cacheStore *sync.Map, namer Namer) (*Schema, error)
 	if field := schema.PrioritizedPrimaryField; field != nil {
 		switch field.GORMDataType {
 		case Int, Uint:
-			if _, ok := field.TagSettings["AUTOINCREMENT"]; !ok {
-				if !field.HasDefaultValue || field.DefaultValueInterface != nil {
-					schema.FieldsWithDefaultDBValue = append(schema.FieldsWithDefaultDBValue, field)
-				}
+			if _, ok := field.TagSettings["DEFAULT"]; !ok {
+				if _, ok := field.TagSettings["AUTOINCREMENT"]; !ok {
+					if !field.HasDefaultValue || field.DefaultValueInterface != nil {
+						schema.FieldsWithDefaultDBValue = append(schema.FieldsWithDefaultDBValue, field)
+					}
 
-				field.HasDefaultValue = true
-				field.AutoIncrement = true
+					field.HasDefaultValue = true
+					field.AutoIncrement = true
+				}
 			}
 		}
 	}

--- a/tests/default_value_test.go
+++ b/tests/default_value_test.go
@@ -37,3 +37,25 @@ func TestDefaultValue(t *testing.T) {
 		t.Fatalf("Failed to find created data with default data, got %+v", result)
 	}
 }
+
+func TestDefaultValueWithPrimaryKeyAndTypeInteger(t *testing.T) {
+	type Harumph struct {
+		ID int `gorm:"primaryKey;type:integer;default:1"`
+	}
+
+	DB.Migrator().DropTable(&Harumph{})
+
+	if err := DB.AutoMigrate(&Harumph{}); err != nil {
+		t.Fatalf("Failed to migrate with default value, got error: %v", err)
+	}
+
+	var harumph = Harumph{}
+	if err := DB.Create(&harumph).Error; err != nil {
+		t.Fatalf("Failed to create data with default value, got error: %v", err)
+	}
+
+	var result Harumph
+	if err := DB.First(&result, "id = ?", "1").Error; err != nil {
+		t.Fatalf("Failed to find created data, got error: %v", err)
+	}
+}


### PR DESCRIPTION
… (fix #3670)

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
When someone sets a field having default tag, the field will appear twice in the INSERT clause, which leads to the error mentioned above.

### User Case Description

<!-- Your use case -->
Sometimes I set a field actively and explicitly in a struct, but sometimes not. I want to make the field set with the default value specified by the `default` tag.