### PR TITLE
FindInBatches using Offset instead of PrimaryKey iterations

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -167,7 +167,7 @@ func (db *DB) Find(dest interface{}, conds ...interface{}) (tx *DB) {
 }
 
 // FindInBatches find records in batches
-func (db *DB) FindInBatch(dest interface{}, batchSize int, fc func(tx *DB, batch int) error) *DB {
+func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, batch int) error) *DB {
 	var (
 		tx = db.Session(&Session{})
 		queryDB      = tx


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Actually find in Batches works using the primary key as an increment, so it assumes that the Batch is sorted with the PrimaryKey, which means that it will fail if the query contains any other Sort attribute.

I suggest to use the "offset" clause in order to iterate.

### User Case Description

The motivation is to get a more universal (and more simple function) working for every select, not only those sorted on PrimaryKey.

I probably miss out something, like Offset clause not being available on all SQL databases? 
