### PR TITLE
Fix: FirstOrCreate slice out of bounds error when using 'Assign'

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -304,7 +304,7 @@ func (db *DB) FirstOrCreate(dest interface{}, conds ...interface{}) (tx *DB) {
 
 		return tx.Create(dest)
 	} else if len(db.Statement.assigns) > 0 {
-		exprs := tx.Statement.BuildCondition(tx.Statement.assigns[0], tx.Statement.assigns[1:]...)
+		exprs := tx.Statement.BuildCondition(db.Statement.assigns[0], db.Statement.assigns[1:]...)
 		assigns := map[string]interface{}{}
 		for _, expr := range exprs {
 			if eq, ok := expr.(clause.Eq); ok {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fixed a bug in finisher_api within the `FirstOrCreate` method. When `FirstOrCreate` was used in conjunction with `Assign` a slice out of bounds error was triggered due to the incorrect usage of the `tx` object.

### User Case Description

Using `FirstOrCreate` with `Assign` to handle updates triggered a slice out of bounds error.
