### PR TITLE
Added return names to logger.Interface.Trace

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -58,7 +58,7 @@ type Interface interface {
 	Info(context.Context, string, ...interface{})
 	Warn(context.Context, string, ...interface{})
 	Error(context.Context, string, ...interface{})
-	Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error)
+	Trace(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error)
 }
 
 var (


### PR DESCRIPTION
I found it hard to understand what the `fc` argument was for in the `logger.Interface` type, so I added return value names.

If this gets merged, I'll open up yet another PR to the `go-gorm/gorm.io` repo
