### PR TITLE
Use count(*) instead of count(1) include NULL and non-NULL rows(SQL-92).

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -383,9 +383,9 @@ func (db *DB) Count(count *int64) (tx *DB) {
 	}
 
 	if len(tx.Statement.Selects) == 0 {
-		tx.Statement.AddClause(clause.Select{Expression: clause.Expr{SQL: "count(1)"}})
+		tx.Statement.AddClause(clause.Select{Expression: clause.Expr{SQL: "count(*)"}})
 	} else if !strings.HasPrefix(strings.TrimSpace(strings.ToLower(tx.Statement.Selects[0])), "count(") {
-		expr := clause.Expr{SQL: "count(1)"}
+		expr := clause.Expr{SQL: "count(*)"}
 
 		if len(tx.Statement.Selects) == 1 {
 			dbName := tx.Statement.Selects[0]


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [v] Do only one thing
- [v] Non breaking API changes
- [v] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Use count(*) instead of count(1) include NULL and non-NULL rows, confirm to [SQL-92](https://en.wikipedia.org/wiki/SQL-92).

不使用 `COUNT(col)` 或 `COUNT(常量)` 来替代 `COUNT(*)`, `COUNT(*)` 是 SQL92 定义的标准统计行数的方法，跟数据无关，跟 NULL 和非 NULL 也无关。


### User Case Description

<!-- Your use case -->

see also
- https://dba.stackexchange.com/questions/2511/what-is-the-difference-between-select-count-and-select-countany-non-null-col/2512
- https://stackoverflow.com/questions/1221559/count-vs-count1-sql-server