### PR TITLE
force tag to force zero when updates

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -401,17 +401,18 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 
 // create valuer, setter when parse struct
 func (field *Field) setupValuerAndSetter() {
+	_, force := field.TagSettings["FORCE"]
 	// ValueOf
 	switch {
 	case len(field.StructField.Index) == 1:
 		field.ValueOf = func(value reflect.Value) (interface{}, bool) {
 			fieldValue := reflect.Indirect(value).Field(field.StructField.Index[0])
-			return fieldValue.Interface(), fieldValue.IsZero()
+			return fieldValue.Interface(), !force && fieldValue.IsZero()
 		}
 	case len(field.StructField.Index) == 2 && field.StructField.Index[0] >= 0:
 		field.ValueOf = func(value reflect.Value) (interface{}, bool) {
 			fieldValue := reflect.Indirect(value).Field(field.StructField.Index[0]).Field(field.StructField.Index[1])
-			return fieldValue.Interface(), fieldValue.IsZero()
+			return fieldValue.Interface(), !force && fieldValue.IsZero()
 		}
 	default:
 		field.ValueOf = func(value reflect.Value) (interface{}, bool) {
@@ -424,17 +425,17 @@ func (field *Field) setupValuerAndSetter() {
 					v = v.Field(-idx - 1)
 
 					if v.Type().Elem().Kind() != reflect.Struct {
-						return nil, true
+						return nil, !force
 					}
 
 					if !v.IsNil() {
 						v = v.Elem()
 					} else {
-						return nil, true
+						return nil, !force
 					}
 				}
 			}
-			return v.Interface(), v.IsZero()
+			return v.Interface(), !force && v.IsZero()
 		}
 	}
 

--- a/tests/update_test.go
+++ b/tests/update_test.go
@@ -13,6 +13,18 @@ import (
 	. "gorm.io/gorm/utils/tests"
 )
 
+func TestUpdateZero(t *testing.T) {
+	c := &Company{
+		ID:      0,
+		Name:    "bingoo",
+		Foreign: true,
+	}
+
+	DB.Create(c)
+	c.Foreign = false
+	DB.Updates(c)
+}
+
 func TestUpdate(t *testing.T) {
 	var (
 		users = []*User{

--- a/utils/tests/models.go
+++ b/utils/tests/models.go
@@ -50,8 +50,9 @@ type Toy struct {
 }
 
 type Company struct {
-	ID   int
-	Name string
+	ID      int
+	Name    string
+	Foreign bool `gorm:"force"`
 }
 
 type Language struct {


### PR DESCRIPTION
### What did this pull request do?

allow to forcely update zero fields by tagging it as force like `gorm:"force"`

### User Case Description

I change a bool field of struct to false, and want to update it into db, I just want gorm force update it other than ignore it.
