### PR TITLE
fix: fix race issue in prepare method

### DIFF
--- a/prepare_stmt.go
+++ b/prepare_stmt.go
@@ -64,7 +64,7 @@ func (db *PreparedStmtDB) prepare(ctx context.Context, conn ConnPool, isTransact
 		db.Stmts[query] = Stmt{Stmt: stmt, Transaction: isTransaction}
 		db.PreparedSQL = append(db.PreparedSQL, query)
 	}
-	db.Mux.Unlock()
+	defer db.Mux.Unlock()
 
 	return db.Stmts[query], err
 }


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

Fixed a bug in prepare method. In the concurrency case, the mutex gets unlocked before reading the value from **Stmts** and the crash "fatal error: concurrent map read and map write" could appear randomly.

### User Case Description
When using PreparedStmtDB.prepare() with a query not cached before for several times at the same time.

