### PR TITLE
Add Specific on for Joins queries

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -125,7 +125,19 @@ func BuildQuerySQL(db *gorm.DB) {
 						})
 					}
 
-					if join.On == nil {
+					if join.On != nil {
+						primaryFields := make([]clause.Column, len(relation.FieldSchema.PrimaryFieldDBNames))
+						for idx, ref := range relation.FieldSchema.PrimaryFieldDBNames {
+							primaryFields[idx] = clause.Column{Table: tableAliasName, Name: ref}
+						}
+
+						exprs := db.Statement.BuildCondition("(?) = (?)", primaryFields, join.On)
+						joins = append(joins, clause.Join{
+							Type:  clause.LeftJoin,
+							Table: clause.Table{Name: relation.FieldSchema.Table, Alias: tableAliasName},
+							ON:    clause.Where{Exprs: exprs},
+						})
+					} else {
 						exprs := make([]clause.Expression, len(relation.References))
 						for idx, ref := range relation.References {
 							if ref.OwnPrimaryKey {
@@ -147,18 +159,7 @@ func BuildQuerySQL(db *gorm.DB) {
 								}
 							}
 						}
-						joins = append(joins, clause.Join{
-							Type:  clause.LeftJoin,
-							Table: clause.Table{Name: relation.FieldSchema.Table, Alias: tableAliasName},
-							ON:    clause.Where{Exprs: exprs},
-						})
-					} else {
-						primaryFields := make([]clause.Column, len(relation.FieldSchema.PrimaryFieldDBNames))
-						for idx, ref := range relation.FieldSchema.PrimaryFieldDBNames {
-							primaryFields[idx] = clause.Column{Table: tableAliasName, Name: ref}
-						}
 
-						exprs := db.Statement.BuildCondition("(?) = (?)", primaryFields, join.On)
 						joins = append(joins, clause.Join{
 							Type:  clause.LeftJoin,
 							Table: clause.Table{Name: relation.FieldSchema.Table, Alias: tableAliasName},

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -125,33 +125,40 @@ func BuildQuerySQL(db *gorm.DB) {
 						})
 					}
 
-					exprs := make([]clause.Expression, len(relation.References))
-					for idx, ref := range relation.References {
-						if ref.OwnPrimaryKey {
-							exprs[idx] = clause.Eq{
-								Column: clause.Column{Table: clause.CurrentTable, Name: ref.PrimaryKey.DBName},
-								Value:  clause.Column{Table: tableAliasName, Name: ref.ForeignKey.DBName},
-							}
-						} else {
-							if ref.PrimaryValue == "" {
+					if join.On != nil {
+						exprs := make([]clause.Expression, len(relation.References))
+						for idx, ref := range relation.References {
+							if ref.OwnPrimaryKey {
 								exprs[idx] = clause.Eq{
-									Column: clause.Column{Table: clause.CurrentTable, Name: ref.ForeignKey.DBName},
-									Value:  clause.Column{Table: tableAliasName, Name: ref.PrimaryKey.DBName},
+									Column: clause.Column{Table: clause.CurrentTable, Name: ref.PrimaryKey.DBName},
+									Value:  clause.Column{Table: tableAliasName, Name: ref.ForeignKey.DBName},
 								}
 							} else {
-								exprs[idx] = clause.Eq{
-									Column: clause.Column{Table: tableAliasName, Name: ref.ForeignKey.DBName},
-									Value:  ref.PrimaryValue,
+								if ref.PrimaryValue == "" {
+									exprs[idx] = clause.Eq{
+										Column: clause.Column{Table: clause.CurrentTable, Name: ref.ForeignKey.DBName},
+										Value:  clause.Column{Table: tableAliasName, Name: ref.PrimaryKey.DBName},
+									}
+								} else {
+									exprs[idx] = clause.Eq{
+										Column: clause.Column{Table: tableAliasName, Name: ref.ForeignKey.DBName},
+										Value:  ref.PrimaryValue,
+									}
 								}
 							}
 						}
+						joins = append(joins, clause.Join{
+							Type:  clause.LeftJoin,
+							Table: clause.Table{Name: relation.FieldSchema.Table, Alias: tableAliasName},
+							ON:    clause.Where{Exprs: exprs},
+						})
+					} else {
+						joins = append(joins, clause.Join{
+							Type:  clause.LeftJoin,
+							Table: clause.Table{Name: relation.FieldSchema.Table, Alias: tableAliasName},
+							ON:    clause.Where{Exprs: []clause.Expression{join.On}},
+						})
 					}
-
-					joins = append(joins, clause.Join{
-						Type:  clause.LeftJoin,
-						Table: clause.Table{Name: relation.FieldSchema.Table, Alias: tableAliasName},
-						ON:    clause.Where{Exprs: exprs},
-					})
 				} else {
 					joins = append(joins, clause.Join{
 						Expression: clause.NamedExpr{SQL: join.Name, Vars: join.Conds},

--- a/chainable_api.go
+++ b/chainable_api.go
@@ -172,15 +172,18 @@ func (db *DB) Or(query interface{}, args ...interface{}) (tx *DB) {
 // Joins specify Joins conditions
 //     db.Joins("Account").Find(&user)
 //     db.Joins("JOIN emails ON emails.user_id = users.id AND emails.email = ?", "jinzhu@example.org").Find(&user)
+//     db.Joins("Account", DB.Select("id").Where("user_id = users.id AND name = ?", "someName").Model(&Account{}))
 func (db *DB) Joins(query string, args ...interface{}) (tx *DB) {
 	tx = db.getInstance()
-	tx.Statement.Joins = append(tx.Statement.Joins, join{Name: query, Conds: args})
-	return
-}
 
-func (db *DB) JoinsOn(query string, on interface{}, args ...interface{}) (tx *DB) {
-	tx = db.getInstance()
-	tx.Statement.Joins = append(tx.Statement.Joins, join{Name: query, Conds: args, On: on})
+	if len(args) > 0 {
+		if db, ok := args[0].(*DB); ok {
+			tx.Statement.Joins = append(tx.Statement.Joins, join{Name: query, Conds: args[1:], On: db})
+			return
+		}
+	}
+
+	tx.Statement.Joins = append(tx.Statement.Joins, join{Name: query, Conds: args})
 	return
 }
 

--- a/chainable_api.go
+++ b/chainable_api.go
@@ -178,6 +178,12 @@ func (db *DB) Joins(query string, args ...interface{}) (tx *DB) {
 	return
 }
 
+func (db *DB) JoinsOn(query string, on clause.Expression, args ...interface{}) (tx *DB) {
+	tx = db.getInstance()
+	tx.Statement.Joins = append(tx.Statement.Joins, join{Name: query, Conds: args, On: on})
+	return
+}
+
 // Group specify the group method on the find
 func (db *DB) Group(name string) (tx *DB) {
 	tx = db.getInstance()

--- a/chainable_api.go
+++ b/chainable_api.go
@@ -178,7 +178,7 @@ func (db *DB) Joins(query string, args ...interface{}) (tx *DB) {
 	return
 }
 
-func (db *DB) JoinsOn(query string, on clause.Expression, args ...interface{}) (tx *DB) {
+func (db *DB) JoinsOn(query string, on interface{}, args ...interface{}) (tx *DB) {
 	tx = db.getInstance()
 	tx.Statement.Joins = append(tx.Statement.Joins, join{Name: query, Conds: args, On: on})
 	return

--- a/statement.go
+++ b/statement.go
@@ -50,7 +50,7 @@ type Statement struct {
 type join struct {
 	Name  string
 	Conds []interface{}
-	On    clause.Expression
+	On    interface{}
 }
 
 // StatementModifier statement modifier interface

--- a/statement.go
+++ b/statement.go
@@ -50,6 +50,7 @@ type Statement struct {
 type join struct {
 	Name  string
 	Conds []interface{}
+	On    clause.Expression
 }
 
 // StatementModifier statement modifier interface

--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -111,14 +111,14 @@ func TestJoinOn(t *testing.T) {
 	var user1 User
 	onQuery := DB.Select("id").Where("user_id = users.id AND name = ?", "joins-on_pet_1").Model(&Pet{})
 
-	if err := DB.JoinsOn("NamedPet", onQuery).Where("users.name = ?", user.Name).First(&user1).Error; err != nil {
+	if err := DB.Joins("NamedPet", onQuery).Where("users.name = ?", user.Name).First(&user1).Error; err != nil {
 		t.Fatalf("Failed to load with joins on, got error: %v", err)
 	}
 	AssertEqual(t, user1.NamedPet.Name, "joins-on_pet_1")
 
 	onQuery2 := DB.Select("id").Where("user_id = users.id AND name = ?", "joins-on_pet_2").Model(&Pet{})
 	var user2 User
-	if err := DB.JoinsOn("NamedPet", onQuery2).Where("users.name = ?", user.Name).First(&user2).Error; err != nil {
+	if err := DB.Joins("NamedPet", onQuery2).Where("users.name = ?", user.Name).First(&user2).Error; err != nil {
 		t.Fatalf("Failed to load with joins on, got error: %v", err)
 	}
 	AssertEqual(t, user2.NamedPet.Name, "joins-on_pet_2")

--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -104,6 +104,26 @@ func TestJoinConds(t *testing.T) {
 	}
 }
 
+func TestJoinOn(t *testing.T) {
+	var user = *GetUser("joins-on", Config{Pets: 2})
+	DB.Save(&user)
+
+	var user1 User
+	onQuery := DB.Select("id").Where("user_id = users.id AND name = ?", "joins-on_pet_1").Model(&Pet{})
+
+	if err := DB.JoinsOn("NamedPet", onQuery).Where("users.name = ?", user.Name).First(&user1).Error; err != nil {
+		t.Fatalf("Failed to load with joins on, got error: %v", err)
+	}
+	AssertEqual(t, user1.NamedPet.Name, "joins-on_pet_1")
+
+	onQuery2 := DB.Select("id").Where("user_id = users.id AND name = ?", "joins-on_pet_2").Model(&Pet{})
+	var user2 User
+	if err := DB.JoinsOn("NamedPet", onQuery2).Where("users.name = ?", user.Name).First(&user2).Error; err != nil {
+		t.Fatalf("Failed to load with joins on, got error: %v", err)
+	}
+	AssertEqual(t, user2.NamedPet.Name, "joins-on_pet_2")
+}
+
 func TestJoinsWithSelect(t *testing.T) {
 	type result struct {
 		ID    uint

--- a/utils/tests/models.go
+++ b/utils/tests/models.go
@@ -11,6 +11,7 @@ import (
 // He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
+// NamedPet is a reference to a Named `Pets` (has many)
 type User struct {
 	gorm.Model
 	Name      string
@@ -18,6 +19,7 @@ type User struct {
 	Birthday  *time.Time
 	Account   Account
 	Pets      []*Pet
+	NamedPet  *Pet
 	Toys      []Toy `gorm:"polymorphic:Owner"`
 	CompanyID *int
 	Company   Company


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add a specific `On` Expression for Joins

### User Case Description

We have an use case where we have a relation like

```go
type A struct {
        uuid uuid.uuid
	LastB *B `json:"-" gorm:"foreignKey:a_uuid"`
}

type B struct {
	uuid uuid.uuid
	AUUID uuid.UUID `gorm:"a_uuid"`
}
```

And we only want to have the last B on the DB.
So we built a join query like:

```go
db.Joins("LEFT JOIN B \"LastB\" ON (SELECT b.uuid FROM b as b WHERE b.a_uuid = a.uuid ORDER BY created_at DESC LIMIT 1) = \"LastB\".uuid")
```

The generated query works, but fields are not populated.

I have add the select clause manually

```go
for _, s := range relation.FieldSchema.DBNames {
	tableAliasName := relation.Name

	clauseSelect.Columns = append(clauseSelect.Columns, clause.Column{
		Table: tableAliasName,
		Name:  s,
		Alias: tableAliasName + "__" + s,
	})
}
```

So my proposal, is to accept a On query for Joins and generate the right select.

Usage
```go
var user User
onQuery := DB.Select("id").Where("user_id = users.id AND name = ?", "joins-on_pet_1").Model(&Pet{})
DB.JoinsOn("NamedPet", onQuery).First(&user)
```