### PR TITLE
fix return value for *schema.Check

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -466,7 +466,7 @@ func buildConstraint(constraint *schema.Constraint) (sql string, results []inter
 	return
 }
 
-func (m Migrator) GuessConstraintAndTable(stmt *gorm.Statement, name string) (_ *schema.Constraint, _ *schema.Check, table string) {
+func (m Migrator) GuessConstraintAndTable(stmt *gorm.Statement, name string) (*schema.Constraint, *schema.Check, string) {
 	if stmt.Schema == nil {
 		return nil, nil, stmt.Table
 	}
@@ -493,9 +493,11 @@ func (m Migrator) GuessConstraintAndTable(stmt *gorm.Statement, name string) (_ 
 	}
 
 	if field := stmt.Schema.LookUpField(name); field != nil {
-		for _, cc := range checkConstraints {
-			if cc.Field == field {
-				return nil, &cc, stmt.Table
+		// fix return value for *schema.Check
+		for k := range checkConstraints {
+			if checkConstraints[k].Field == field {
+				v := checkConstraints[k]
+				return nil, &v, stmt.Table
 			}
 		}
 

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -493,7 +493,6 @@ func (m Migrator) GuessConstraintAndTable(stmt *gorm.Statement, name string) (_ 
 	}
 
 	if field := stmt.Schema.LookUpField(name); field != nil {
-		// fix return value for *schema.Check
 		for k := range checkConstraints {
 			if checkConstraints[k].Field == field {
 				v := checkConstraints[k]

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -466,7 +466,7 @@ func buildConstraint(constraint *schema.Constraint) (sql string, results []inter
 	return
 }
 
-func (m Migrator) GuessConstraintAndTable(stmt *gorm.Statement, name string) (*schema.Constraint, *schema.Check, string) {
+func (m Migrator) GuessConstraintAndTable(stmt *gorm.Statement, name string) (_ *schema.Constraint, _ *schema.Check, table string) {
 	if stmt.Schema == nil {
 		return nil, nil, stmt.Table
 	}


### PR DESCRIPTION
fix return value for *schema.Check
checkConstraints := stmt.Schema.ParseCheckConstraints() The return value is a map[string]Check. If the for _,cc mode is applied to the map, it is not the address of the map element.
eg: 
``` go
type Check struct {
	name string
}
m := make(map[string]Check, 10)
	log.Println("===========for _,cc mode for m=========")
	m["a"] = Check{"a"}
	m["b"] = Check{"b"}
	m["c"] = Check{"c"}
	m["d"] = Check{"d"}
	for _, cc := range m {
		log.Printf("%p", &cc)
	}
```
output:
2021/06/17 21:28:34 ===========for _,cc mode for m=========
2021/06/17 21:28:34 0xc00019a370
2021/06/17 21:28:34 0xc00019a370
2021/06/17 21:28:34 0xc00019a370
2021/06/17 21:28:34 0xc00019a370

but use the following way:

``` go
for k := range m {
		v := m[k]
		log.Printf("%p", &v)
	}
```
output:
2021/06/17 21:28:34 0xc00019a380
2021/06/17 21:28:34 0xc00019a390
2021/06/17 21:28:34 0xc00019a3a0
2021/06/17 21:28:34 0xc00019a3b0
