### PR TITLE
adjust Preload fmt.Errorf

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -209,7 +209,7 @@ func Preload(db *gorm.DB) {
 			if rel := db.Statement.Schema.Relationships.Relations[name]; rel != nil {
 				preload(db, rel, db.Statement.Preloads[name], preloadMap[name])
 			} else {
-				db.AddError(fmt.Errorf("%v: %w for schema %v", name, gorm.ErrUnsupportedRelation, db.Statement.Schema.Name))
+				db.AddError(fmt.Errorf("%s: %w for schema %s", name, gorm.ErrUnsupportedRelation, db.Statement.Schema.Name))
 			}
 		}
 	}

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -608,7 +608,7 @@ func (m Migrator) CreateIndex(value interface{}, name string) error {
 			return m.DB.Exec(createIndexSQL, values...).Error
 		}
 
-		return fmt.Errorf("failed to create index with name %v", name)
+		return fmt.Errorf("failed to create index with name %s", name)
 	})
 }
 


### PR DESCRIPTION
adjust Preload fmt.Errorf for db.AddError(fmt.Errorf("%v: %w for schema %v", name, gorm.ErrUnsupportedRelation, db.Statement.Schema.Name))
chage it to:
db.AddError(fmt.Errorf("%s: %w for schema %s", name, gorm.ErrUnsupportedRelation, db.Statement.Schema.Name))