### PR TITLE
Fix create with ignore migration

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -166,10 +166,12 @@ func (m Migrator) CreateTable(values ...interface{}) error {
 
 			for _, dbName := range stmt.Schema.DBNames {
 				field := stmt.Schema.FieldsByDBName[dbName]
-				createTableSQL += "? ?"
-				hasPrimaryKeyInDataType = hasPrimaryKeyInDataType || strings.Contains(strings.ToUpper(string(field.DataType)), "PRIMARY KEY")
-				values = append(values, clause.Column{Name: dbName}, m.DB.Migrator().FullDataTypeOf(field))
-				createTableSQL += ","
+				if !field.IgnoreMigration {
+					createTableSQL += "? ?"
+					hasPrimaryKeyInDataType = hasPrimaryKeyInDataType || strings.Contains(strings.ToUpper(string(field.DataType)), "PRIMARY KEY")
+					values = append(values, clause.Column{Name: dbName}, m.DB.Migrator().FullDataTypeOf(field))
+					createTableSQL += ","
+				}
 			}
 
 			if !hasPrimaryKeyInDataType && len(stmt.Schema.PrimaryFields) > 0 {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

The field tag contains `-:migration` and will still be created in AutoMigrate. I think this is a bug.

### User Case Description

```go
type testModel struct {
	gorm.Model
	Name string
	Info string `gorm:"-:migration"`
}

if err := db.AutoMigrate(
	&testModel{},
); err != nil {
	panic(err)
}
```

gorm log before fix:
```sql
CREATE TABLE `test_models`
(
    `id`         bigint unsigned AUTO_INCREMENT,
    `created_at` datetime(3) NULL,
    `updated_at` datetime(3) NULL,
    `deleted_at` datetime(3) NULL,
    `name`       longtext,
    `info`       longtext,
    PRIMARY KEY (`id`),
    INDEX idx_test_models_deleted_at (`deleted_at`)
)
```

gorm log after fix:
```sql
CREATE TABLE `test_models`
(
    `id`         bigint unsigned AUTO_INCREMENT,
    `created_at` datetime(3) NULL,
    `updated_at` datetime(3) NULL,
    `deleted_at` datetime(3) NULL,
    `name`       longtext,
    PRIMARY KEY (`id`),
    INDEX idx_test_models_deleted_at (`deleted_at`)
)
```


