### PR TITLE
Do not emit ORDER BY for empty values

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -209,12 +209,14 @@ func (db *DB) Order(value interface{}) (tx *DB) {
 		tx.Statement.AddClause(clause.OrderBy{
 			Columns: []clause.OrderByColumn{v},
 		})
-	default:
-		tx.Statement.AddClause(clause.OrderBy{
-			Columns: []clause.OrderByColumn{{
-				Column: clause.Column{Name: fmt.Sprint(value), Raw: true},
-			}},
-		})
+	case string:
+		if v != "" {
+			tx.Statement.AddClause(clause.OrderBy{
+				Columns: []clause.OrderByColumn{{
+					Column: clause.Column{Name: v, Raw: true},
+				}},
+			})
+		}
 	}
 	return
 }

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -842,7 +842,17 @@ func TestSearchWithEmptyChain(t *testing.T) {
 func TestOrder(t *testing.T) {
 	dryDB := DB.Session(&gorm.Session{DryRun: true})
 
-	result := dryDB.Order("age desc, name").Find(&User{})
+	result := dryDB.Order("").Find(&User{})
+	if !regexp.MustCompile("SELECT \\* FROM .*users.* IS NULL$").MatchString(result.Statement.SQL.String()) {
+		t.Fatalf("Build Order condition, but got %v", result.Statement.SQL.String())
+	}
+
+	result = dryDB.Order(nil).Find(&User{})
+	if !regexp.MustCompile("SELECT \\* FROM .*users.* IS NULL$").MatchString(result.Statement.SQL.String()) {
+		t.Fatalf("Build Order condition, but got %v", result.Statement.SQL.String())
+	}
+
+	result = dryDB.Order("age desc, name").Find(&User{})
 	if !regexp.MustCompile("SELECT \\* FROM .*users.* ORDER BY age desc, name").MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("Build Order condition, but got %v", result.Statement.SQL.String())
 	}


### PR DESCRIPTION
- [x]  Do only one thing
- [x]  Non breaking API changes
- [x]  Tested

### What did this pull request do?

This restores the behavior from gorm v1, where calling `DB.Order` with an empty string, nil, or any unexpected type is a no-op.

### User Case Description

I work with a REST API framework that parses a custom query syntax for making complicated queries via REST. In gorm v1, we could simply call `db.Order(parsedQuery.Order)`. With gorm.io/gorm, we *must* check `parsedQuery.Order` for empty strings or else gorm.io/gorm generates invalid SQL.

Closes #4429