### PR TITLE
add restore api

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -635,3 +635,19 @@ func (db *DB) Exec(sql string, values ...interface{}) (tx *DB) {
 
 	return tx.callbacks.Raw().Execute(tx)
 }
+
+func (db *DB) Restore(values interface{}) (tx *DB) {
+	tx = db.getInstance()
+	tx.Statement.Unscoped = true
+	tx.Statement.Parse(values)
+
+	dest := make(map[string]interface{})
+	for _, c := range tx.Statement.Schema.DeleteClauses {
+		fieldName := c.(SoftDeleteDeleteClause).Field.DBName
+		dest[fieldName] = nil
+	}
+
+	tx.Statement.Dest = dest
+
+	return tx.callbacks.Update().Execute(tx)
+}

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -641,13 +641,13 @@ func (db *DB) Restore(values interface{}) (tx *DB) {
 	tx.Statement.Unscoped = true
 	tx.Statement.Parse(values)
 
-	dest := make(map[string]interface{})
-	for _, c := range tx.Statement.Schema.DeleteClauses {
-		fieldName := c.(SoftDeleteDeleteClause).Field.DBName
-		dest[fieldName] = nil
-	}
+	tx.Statement.Dest = make(map[string]interface{})
 
-	tx.Statement.Dest = dest
+	for _, c := range tx.Statement.Schema.DeleteClauses {
+		if optimizer, ok := c.(UnDeleteDester); ok {
+			optimizer.SetUnDeleteDest(tx.Statement)
+		}
+	}
 
 	return tx.callbacks.Update().Execute(tx)
 }

--- a/soft_delete.go
+++ b/soft_delete.go
@@ -162,3 +162,13 @@ func (sd SoftDeleteDeleteClause) ModifyStatement(stmt *Statement) {
 		stmt.Build("UPDATE", "SET", "WHERE")
 	}
 }
+
+func (sd SoftDeleteDeleteClause) SetUnDeleteDest(stmt *Statement) {
+	if stmt.Unscoped {
+		if sd.Field.DefaultValue != "" {
+			stmt.SetColumn(sd.Field.DBName, clause.Expr{SQL: sd.Field.DefaultValue}, true)
+		} else {
+			stmt.SetColumn(sd.Field.DBName, nil, true)
+		}
+	}
+}

--- a/statement.go
+++ b/statement.go
@@ -57,6 +57,11 @@ type StatementModifier interface {
 	ModifyStatement(*Statement)
 }
 
+// UnDeleteDester set undelete dest interface
+type UnDeleteDester interface {
+	SetUnDeleteDest(*Statement)
+}
+
 // WriteString write string
 func (stmt *Statement) WriteString(str string) (int, error) {
 	return stmt.SQL.WriteString(str)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Can recover data that has been soft deleted
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
    // recover soft delete
   db.Where("name = ?", "nelson").Restore(&email)

  I'm sorry 
 It's unclear at first that there's another delete library.  [ https://github.com/go-gorm/soft_delete]( https://github.com/go-gorm/soft_delete)
This pull request contains all current soft deletes and has passed the corresponding test.

associated request : https://github.com/go-gorm/soft_delete/pull/6

Suggest：I personally think that `gorm.io/sofr_delete` and `gorm.io/plugin/soft_delete` have the same logic and can be merged and should not be separated


<!-- Your use case -->
