### PR TITLE
Fix extra 'AND' when len(values) == 0 ON IN.NegationBuild()

### DIFF
--- a/clause/expression.go
+++ b/clause/expression.go
@@ -210,11 +210,12 @@ func (in IN) Build(builder Builder) {
 }
 
 func (in IN) NegationBuild(builder Builder) {
+	builder.WriteQuoted(in.Column)
 	switch len(in.Values) {
 	case 0:
+		builder.WriteString(" IS NOT NULL")
 	case 1:
 		if _, ok := in.Values[0].([]interface{}); !ok {
-			builder.WriteQuoted(in.Column)
 			builder.WriteString(" <> ")
 			builder.AddVar(builder, in.Values[0])
 			break
@@ -222,7 +223,6 @@ func (in IN) NegationBuild(builder Builder) {
 
 		fallthrough
 	default:
-		builder.WriteQuoted(in.Column)
 		builder.WriteString(" NOT IN (")
 		builder.AddVar(builder, in.Values...)
 		builder.WriteByte(')')

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -436,6 +436,11 @@ func TestNot(t *testing.T) {
 		t.Fatalf("Build NOT condition, but got %v", result.Statement.SQL.String())
 	}
 
+	result = dryDB.Not(map[string]interface{}{"name": []string{}}).Find(&User{})
+	if !regexp.MustCompile("SELECT \\* FROM .*users.* WHERE .*name.* IS NOT NULL").MatchString(result.Statement.SQL.String()) {
+		t.Fatalf("Build NOT condition, but got %v", result.Statement.SQL.String())
+	}
+	
 	result = dryDB.Not(map[string]interface{}{"name": []string{"jinzhu", "jinzhu 2"}}).Find(&User{})
 	if !regexp.MustCompile("SELECT \\* FROM .*users.* WHERE .*name.* NOT IN \\(.+,.+\\)").MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("Build NOT condition, but got %v", result.Statement.SQL.String())


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
Three reasons for this PR:   
1. When `DB.Not(map[string]interface{}{"name": []string{}}).Where("age = ?", 10)`, Generate sql `SELECT * FROM ``users`` WHERE   AND ``age`` = 10;` , it is a bad sql.
2. In some database, like postgresql, when exec ` ``name`` NOT IN ('jinzhu')`, the result dose not contain the row where `name` == NULL, so when `is not` in an empty array,  to some extent, it can be considered that `name` IS NOT NULL. 
3. NegationBuild() should be the inverse of Build(), but when len(values)==0, the Build() return the row where `name`==NULL, so NegationBuild() should not return the row where `name`==NULL. 

### User Case Description

<!-- Your use case -->
```go
DB.Not(map[string]interface{}{"name": []string{}}).Where("age = ?", 10).Find(&User{})`   
```

Thanks!