### PR TITLE
feat: QuoteTo accept clause.Expr

### DIFF
--- a/clause/expression_test.go
+++ b/clause/expression_test.go
@@ -156,6 +156,18 @@ func TestExpression(t *testing.T) {
 		},
 		ExpectedVars: []interface{}{"a", "b"},
 		Result:       "`column-name` NOT IN (?,?)",
+	}, {
+		Expressions: []clause.Expression{
+			clause.Eq{Column: clause.Expr{SQL: "SUM(?)", Vars: []interface{}{clause.Column{Name: "id"}}}, Value: 100},
+		},
+		ExpectedVars: []interface{}{100},
+		Result:       "SUM(`id`) = ?",
+	}, {
+		Expressions: []clause.Expression{
+			clause.Gte{Column: clause.Expr{SQL: "SUM(?)", Vars: []interface{}{clause.Column{Table: "users", Name: "id"}}}, Value: 100},
+		},
+		ExpectedVars: []interface{}{100},
+		Result:       "SUM(`users`.`id`) >= ?",
 	}}
 
 	for idx, result := range results {

--- a/statement.go
+++ b/statement.go
@@ -129,6 +129,8 @@ func (stmt *Statement) QuoteTo(writer clause.Writer, field interface{}) {
 			stmt.QuoteTo(writer, d)
 		}
 		writer.WriteByte(')')
+	case clause.Expr:
+		v.Build(stmt)
 	case string:
 		stmt.DB.Dialector.QuoteTo(writer, v)
 	case []string:

--- a/statement_test.go
+++ b/statement_test.go
@@ -3,12 +3,9 @@ package gorm
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	"gorm.io/gorm/clause"
-	"gorm.io/gorm/logger"
-	"gorm.io/gorm/schema"
 )
 
 func TestWhereCloneCorruption(t *testing.T) {
@@ -35,44 +32,5 @@ func TestWhereCloneCorruption(t *testing.T) {
 				t.Errorf("Where conditions should be different")
 			}
 		})
-	}
-}
-
-var _ Dialector = new(dummyDialector)
-
-type dummyDialector struct{}
-
-func (dummyDialector) Name() string         { return "dummy" }
-func (dummyDialector) Initialize(*DB) error { return nil }
-func (dummyDialector) DefaultValueOf(field *schema.Field) clause.Expression {
-	return clause.Expr{SQL: "DEFAULT"}
-}
-func (dummyDialector) Migrator(*DB) Migrator { return nil }
-func (dummyDialector) BindVarTo(writer clause.Writer, stmt *Statement, v interface{}) {
-	writer.WriteByte('?')
-}
-func (dummyDialector) QuoteTo(writer clause.Writer, str string) { writer.WriteString("`" + str + "`") }
-func (dummyDialector) Explain(sql string, vars ...interface{}) string {
-	return logger.ExplainSQL(sql, nil, `"`, vars...)
-}
-func (dummyDialector) DataTypeOf(*schema.Field) string { return "" }
-
-var db, _ = Open(dummyDialector{})
-
-func TestStatement_WriteQuoted(t *testing.T) {
-	s := Statement{DB: db}
-
-	testdata := map[string]clause.Expression{
-		"SUM(`users`.`id`)": clause.Expr{SQL: "SUM(?)", Vars: []interface{}{clause.Column{Table: "users", Name: "id"}}},
-	}
-
-	for result, expr := range testdata {
-		s.WriteQuoted(expr)
-		if s.SQL.String() != result {
-			t.Errorf("WriteQuoted test fail, expected: %s, got %s", result, s.SQL.String())
-		}
-
-		s.SQL = strings.Builder{}
-		s.Vars = []interface{}{}
 	}
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -3,9 +3,12 @@ package gorm
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"gorm.io/gorm/clause"
+	"gorm.io/gorm/logger"
+	"gorm.io/gorm/schema"
 )
 
 func TestWhereCloneCorruption(t *testing.T) {
@@ -32,5 +35,44 @@ func TestWhereCloneCorruption(t *testing.T) {
 				t.Errorf("Where conditions should be different")
 			}
 		})
+	}
+}
+
+var _ Dialector = new(dummyDialector)
+
+type dummyDialector struct{}
+
+func (dummyDialector) Name() string         { return "dummy" }
+func (dummyDialector) Initialize(*DB) error { return nil }
+func (dummyDialector) DefaultValueOf(field *schema.Field) clause.Expression {
+	return clause.Expr{SQL: "DEFAULT"}
+}
+func (dummyDialector) Migrator(*DB) Migrator { return nil }
+func (dummyDialector) BindVarTo(writer clause.Writer, stmt *Statement, v interface{}) {
+	writer.WriteByte('?')
+}
+func (dummyDialector) QuoteTo(writer clause.Writer, str string) { writer.WriteString("`" + str + "`") }
+func (dummyDialector) Explain(sql string, vars ...interface{}) string {
+	return logger.ExplainSQL(sql, nil, `"`, vars...)
+}
+func (dummyDialector) DataTypeOf(*schema.Field) string { return "" }
+
+var db, _ = Open(dummyDialector{})
+
+func TestStatement_WriteQuoted(t *testing.T) {
+	s := Statement{DB: db}
+
+	testdata := map[string]clause.Expression{
+		"SUM(`users`.`id`)": clause.Expr{SQL: "SUM(?)", Vars: []interface{}{clause.Column{Table: "users", Name: "id"}}},
+	}
+
+	for result, expr := range testdata {
+		s.WriteQuoted(expr)
+		if s.SQL.String() != result {
+			t.Errorf("WriteQuoted test fail, expected: %s, got %s", result, s.SQL.String())
+		}
+
+		s.SQL = strings.Builder{}
+		s.Vars = []interface{}{}
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

`Statement.QuoteTo` accept `clause.Expr` as parameter
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
```go
s.WriteQuoted(clause.Expr{SQL: "SUM(?)", Vars: []interface{}{clause.Column{Table: "users", Name: "id"}}})
```
