### PR TITLE
support unique index and soft delete

### DIFF
--- a/clause/on_conflict.go
+++ b/clause/on_conflict.go
@@ -26,7 +26,7 @@ func (onConflict OnConflict) Build(builder Builder) {
 		}
 		builder.WriteString(`) `)
 	}
-	
+
 	if len(onConflict.TargetWhere.Exprs) > 0 {
 		builder.WriteString(" WHERE ")
 		onConflict.TargetWhere.Build(builder)

--- a/model.go
+++ b/model.go
@@ -14,9 +14,27 @@ type Model struct {
 	DeletedAt DeletedAt `gorm:"index"`
 }
 
+// UnDelete clear model's deleted info, you need save this model manually
+func (m *Model) UnDelete() {
+	m.DeletedAt.Valid = false
+}
+
+// ModelSupportUnique model that support soft delete and unique index
+//
+// For example
+//
+// when you annouce an unique index for column A,
+// gorm will automate create a composite index for A & deleted_flag.
+//
+// create: deleted_flag default to 0
+// delete: set deleted_flag's value to primary id to avoid unique conflict
 type ModelSupportUnique struct {
-	ID          uint `gorm:"primarykey"`
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	Model
 	DeletedFlag DeletedFlag `gorm:"type:BIGINT UNSIGNED NOT NULL DEFAULT 0" json:"deleted_flag"`
+}
+
+// UnDelete clear model's deleted info, you need save this model manually
+func (m *ModelSupportUnique) UnDelete() {
+	m.Model.UnDelete()
+	m.DeletedFlag = 0
 }

--- a/model.go
+++ b/model.go
@@ -13,3 +13,10 @@ type Model struct {
 	UpdatedAt time.Time
 	DeletedAt DeletedAt `gorm:"index"`
 }
+
+type ModelSupportUnique struct {
+	ID          uint `gorm:"primarykey"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	DeletedFlag DeletedFlag `gorm:"type:BIGINT UNSIGNED NOT NULL DEFAULT 0" json:"deleted_flag"`
+}

--- a/schema/index.go
+++ b/schema/index.go
@@ -51,6 +51,26 @@ func (schema *Schema) ParseIndexes() map[string]Index {
 				}
 
 				idx.Fields = append(idx.Fields, index.Fields...)
+
+				// create combined index for unique
+				if index.Class == "UNIQUE" {
+					if df := schema.LookUpField("deleted_flag"); df != nil {
+						var exists bool
+						for _, f := range idx.Fields {
+							if f.Field.Name == df.Name {
+								exists = true
+								break
+							}
+						}
+
+						if !exists {
+							idx.Fields = append(idx.Fields, IndexOption{
+								Field: df,
+							})
+						}
+					}
+				}
+
 				sort.Slice(idx.Fields, func(i, j int) bool {
 					return idx.Fields[i].priority < idx.Fields[j].priority
 				})

--- a/schema/index.go
+++ b/schema/index.go
@@ -65,7 +65,8 @@ func (schema *Schema) ParseIndexes() map[string]Index {
 
 						if !exists {
 							idx.Fields = append(idx.Fields, IndexOption{
-								Field: df,
+								Field:    df,
+								priority: 100,
 							})
 						}
 					}

--- a/soft_delete_unique.go
+++ b/soft_delete_unique.go
@@ -65,10 +65,11 @@ func (sd SoftDeleteUniqueDeleteClause) Build(clause.Builder) {
 func (sd SoftDeleteUniqueDeleteClause) MergeClause(*clause.Clause) {
 }
 
+var regReplaceUpdate = regexp.MustCompile(`UPDATE (.+?) WHERE `)
+
 func (sd SoftDeleteUniqueDeleteClause) ModifyStatement(stmt *Statement) {
-	re := regexp.MustCompile(`UPDATE (.*) WHERE `)
 	if sql := stmt.SQL.String(); sql != "" {
-		setClause := re.FindStringSubmatch(sql)[1]
+		setClause := regReplaceUpdate.FindStringSubmatch(sql)[1]
 		if setClause == "" {
 			return
 		}

--- a/soft_delete_unique.go
+++ b/soft_delete_unique.go
@@ -1,0 +1,80 @@
+package gorm
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
+)
+
+type DeletedFlag uint
+
+// // Scan implements the Scanner interface.
+// func (n *DeletedFlag) Scan(value interface{}) error {
+// 	return (*sql.NullTime)(n).Scan(value)
+// }
+
+// // Value implements the driver Valuer interface.
+// func (n DeletedFlag) Value() (driver.Value, error) {
+// 	if !n.Valid {
+// 		return nil, nil
+// 	}
+// 	return n.Time, nil
+// }
+
+// func (n DeletedFlag) MarshalJSON() ([]byte, error) {
+// 	if n.Valid {
+// 		return json.Marshal(n.Time)
+// 	}
+// 	return json.Marshal(nil)
+// }
+
+// func (n *DeletedFlag) UnmarshalJSON(b []byte) error {
+// 	if string(b) == "null" {
+// 		n.Valid = false
+// 		return nil
+// 	}
+// 	err := json.Unmarshal(b, &n.Time)
+// 	if err == nil {
+// 		n.Valid = true
+// 	}
+// 	return err
+// }
+
+func (DeletedFlag) QueryClauses(f *schema.Field) []clause.Interface {
+	return []clause.Interface{SoftDeleteQueryClause{Field: f}}
+}
+
+func (DeletedFlag) DeleteClauses(f *schema.Field) []clause.Interface {
+	return []clause.Interface{SoftDeleteUniqueDeleteClause{Field: f}}
+}
+
+type SoftDeleteUniqueDeleteClause struct {
+	Field *schema.Field
+}
+
+func (sd SoftDeleteUniqueDeleteClause) Name() string {
+	return ""
+}
+
+func (sd SoftDeleteUniqueDeleteClause) Build(clause.Builder) {
+}
+
+func (sd SoftDeleteUniqueDeleteClause) MergeClause(*clause.Clause) {
+}
+
+func (sd SoftDeleteUniqueDeleteClause) ModifyStatement(stmt *Statement) {
+	re := regexp.MustCompile(`UPDATE (.*) WHERE `)
+	if sql := stmt.SQL.String(); sql != "" {
+		setClause := re.FindStringSubmatch(sql)[1]
+		if setClause == "" {
+			return
+		}
+
+		newSetClause := fmt.Sprintf("%s, %s = `%s`.`id`", setClause, sd.Field.DBName, stmt.Table)
+		stmt.SQL.Reset()
+		stmt.SQL.WriteString(strings.Replace(sql, setClause, newSetClause, 1))
+	}
+}

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -440,7 +440,7 @@ func TestNot(t *testing.T) {
 	if !regexp.MustCompile("SELECT \\* FROM .*users.* WHERE .*name.* IS NOT NULL").MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("Build NOT condition, but got %v", result.Statement.SQL.String())
 	}
-	
+
 	result = dryDB.Not(map[string]interface{}{"name": []string{"jinzhu", "jinzhu 2"}}).Find(&User{})
 	if !regexp.MustCompile("SELECT \\* FROM .*users.* WHERE .*name.* NOT IN \\(.+,.+\\)").MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("Build NOT condition, but got %v", result.Statement.SQL.String())


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add support to unique index & soft delete.


### User Case Description

#### Current

When use unique index with soft-delete. deleted row still occupied unique index. 

For example:


| id | deleted_at | unique_col |
| :---: | :---: | :---: |
| 1 | 2021-09-03T00:00:00Z | 1 |


If you want insert an row with `unique_cil=1`, will be rejected. even if there is no undeleted row with value 1.


### With this patch

with this patch, when you add an new column named `deleted_flag`, 
deleted row will not occupied unique index.

* migrating: every unique index will be convert to composite index with `deleted_flag`
* creating: `deleted_flag` is default to 0
* deleting: `deleted_flat` will set to primary id

For example:


| id | deleted_at | deleted_flag | unique_col |
| :---: | :---: | :--: |:---: |
| 1 | 2021-09-03T00:00:00Z | 1 | 1 |


When you insert an new row with `unique_col = 1`, the insert row will be `(2, nil, 0, 1)`, it won't conflict with the deleted row.
