### PR TITLE
fix (clause/expression): Allow sql stmt terminator

### DIFF
--- a/clause/expression.go
+++ b/clause/expression.go
@@ -121,7 +121,7 @@ func (expr NamedExpr) Build(builder Builder) {
 		if v == '@' && !inName {
 			inName = true
 			name = []byte{}
-		} else if v == ' ' || v == ',' || v == ')' || v == '"' || v == '\'' || v == '`' || v == '\n' {
+		} else if v == ' ' || v == ',' || v == ')' || v == '"' || v == '\'' || v == '`' || v == '\n' || v == ';' {
 			if inName {
 				if nv, ok := namedMap[string(name)]; ok {
 					builder.AddVar(builder, nv)

--- a/clause/expression_test.go
+++ b/clause/expression_test.go
@@ -89,6 +89,11 @@ func TestNamedExpr(t *testing.T) {
 		SQL:    "create table ? (? ?, ? ?)",
 		Vars:   []interface{}{},
 		Result: "create table ? (? ?, ? ?)",
+	}, {
+		SQL:          "name1 = @name AND name2 = @name;",
+		Vars:         []interface{}{sql.Named("name", "jinzhu")},
+		Result:       "name1 = ? AND name2 = ?;",
+		ExpectedVars: []interface{}{"jinzhu", "jinzhu"},
 	}}
 
 	for idx, result := range results {


### PR DESCRIPTION

Example: select * from table_name where name == @name;

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Allow the sql stmt terminator ";" at the end of a named parameter.

### User Case Description

Example: 
`select * from table_name where name == @name;`

Allow the stmt terminator `;` at the end of the stmt without a space between it and the named parameter.