### PR TITLE
fixed belongs_to & has_one reversed if field same (proper fix)

### DIFF
--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jinzhu/inflection"
 	"gorm.io/gorm/clause"
+	"gorm.io/gorm/utils"
 )
 
 // RelationshipType relationship type
@@ -404,11 +405,14 @@ func (schema *Schema) guessRelation(relation *Relationship, field *Field, cgl gu
 
 	if len(relation.foreignKeys) > 0 {
 		for _, foreignKey := range relation.foreignKeys {
-			if f := foreignSchema.LookUpField(foreignKey); f != nil {
-				foreignFields = append(foreignFields, f)
-			} else {
+			ff := foreignSchema.LookUpField(foreignKey)
+			pf := primarySchema.LookUpField(foreignKey)
+			isKeySame := utils.ExistsIn(foreignKey, &relation.primaryKeys)
+			if ff == nil || (pf != nil && ff != nil && schema == primarySchema && primarySchema != foreignSchema && !isKeySame) {
 				reguessOrErr()
 				return
+			} else {
+				foreignFields = append(foreignFields, ff)
 			}
 		}
 	} else {

--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -408,7 +408,7 @@ func (schema *Schema) guessRelation(relation *Relationship, field *Field, cgl gu
 			ff := foreignSchema.LookUpField(foreignKey)
 			pf := primarySchema.LookUpField(foreignKey)
 			isKeySame := utils.ExistsIn(foreignKey, &relation.primaryKeys)
-			if ff == nil || (pf != nil && ff != nil && schema == primarySchema && primarySchema != foreignSchema && !isKeySame) {
+			if ff == nil || (pf != nil && ff != nil && schema == primarySchema && primarySchema != foreignSchema && !isKeySame && field.IndirectFieldType.Kind() == reflect.Struct) {
 				reguessOrErr()
 				return
 			} else {

--- a/schema/relationship_test.go
+++ b/schema/relationship_test.go
@@ -482,3 +482,22 @@ func TestSameForeignKey(t *testing.T) {
 		},
 	)
 }
+
+func TestBelongsToWithSameForeignKey(t *testing.T) {
+	type Profile struct {
+		gorm.Model
+		Name         string
+		ProfileRefer int
+	}
+
+	type User struct {
+		gorm.Model
+		Profile      Profile `gorm:"ForeignKey:ProfileRefer"`
+		ProfileRefer int
+	}
+
+	checkStructRelation(t, &User{}, Relation{
+		Name: "Profile", Type: schema.BelongsTo, Schema: "User", FieldSchema: "Profile",
+		References: []Reference{{"ID", "Profile", "ProfileRefer", "User", "", false}},
+	})
+}

--- a/schema/relationship_test.go
+++ b/schema/relationship_test.go
@@ -501,3 +501,22 @@ func TestBelongsToWithSameForeignKey(t *testing.T) {
 		References: []Reference{{"ID", "Profile", "ProfileRefer", "User", "", false}},
 	})
 }
+
+func TestHasManySameForeignKey(t *testing.T) {
+	type Profile struct {
+		gorm.Model
+		Name      string
+		UserRefer uint
+	}
+
+	type User struct {
+		gorm.Model
+		UserRefer uint
+		Profile   []Profile `gorm:"ForeignKey:UserRefer"`
+	}
+
+	checkStructRelation(t, &User{}, Relation{
+		Name: "Profile", Type: schema.HasMany, Schema: "User", FieldSchema: "Profile",
+		References: []Reference{{"ID", "User", "UserRefer", "Profile", "", true}},
+	})
+}

--- a/schema/relationship_test.go
+++ b/schema/relationship_test.go
@@ -144,6 +144,25 @@ func TestHasOneOverrideReferences(t *testing.T) {
 	})
 }
 
+func TestHasOneOverrideReferences2(t *testing.T) {
+
+	type Profile struct {
+		gorm.Model
+		Name string
+	}
+
+	type User struct {
+		gorm.Model
+		ProfileID uint     `gorm:"column:profile_id"`
+		Profile   *Profile `gorm:"foreignKey:ID;references:ProfileID"`
+	}
+
+	checkStructRelation(t, &User{}, Relation{
+		Name: "Profile", Type: schema.HasOne, Schema: "User", FieldSchema: "Profile",
+		References: []Reference{{"ProfileID", "User", "ID", "Profile", "", true}},
+	})
+}
+
 func TestHasOneWithOnlyReferences(t *testing.T) {
 	type Profile struct {
 		gorm.Model
@@ -483,22 +502,47 @@ func TestSameForeignKey(t *testing.T) {
 	)
 }
 
-func TestBelongsToWithSameForeignKey(t *testing.T) {
+func TestBelongsToSameForeignKey(t *testing.T) {
+
+	type User struct {
+		gorm.Model
+		Name string
+		UUID string
+	}
+
+	type UserAux struct {
+		gorm.Model
+		Aux  string
+		UUID string
+		User User `gorm:"ForeignKey:UUID;references:UUID;belongsTo"`
+	}
+
+	checkStructRelation(t, &UserAux{},
+		Relation{
+			Name: "User", Type: schema.BelongsTo, Schema: "UserAux", FieldSchema: "User",
+			References: []Reference{
+				{"UUID", "User", "UUID", "UserAux", "", false},
+			},
+		},
+	)
+}
+
+func TestHasOneWithSameForeignKey(t *testing.T) {
 	type Profile struct {
 		gorm.Model
 		Name         string
-		ProfileRefer int
+		ProfileRefer int // not used in relationship
 	}
 
 	type User struct {
 		gorm.Model
-		Profile      Profile `gorm:"ForeignKey:ProfileRefer"`
+		Profile      Profile `gorm:"ForeignKey:ID;references:ProfileRefer"`
 		ProfileRefer int
 	}
 
 	checkStructRelation(t, &User{}, Relation{
-		Name: "Profile", Type: schema.BelongsTo, Schema: "User", FieldSchema: "Profile",
-		References: []Reference{{"ID", "Profile", "ProfileRefer", "User", "", false}},
+		Name: "Profile", Type: schema.HasOne, Schema: "User", FieldSchema: "Profile",
+		References: []Reference{{"ProfileRefer", "User", "ID", "Profile", "", true}},
 	})
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -111,3 +111,15 @@ func ToString(value interface{}) string {
 	}
 	return ""
 }
+
+func ExistsIn(a string, list *[]string) bool {
+	if list == nil {
+		return false
+	}
+	for _, b := range *list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -114,15 +114,3 @@ func ToString(value interface{}) string {
 	}
 	return ""
 }
-
-func ExistsIn(a string, list *[]string) bool {
-	if list == nil {
-		return false
-	}
-	for _, b := range *list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
### This PR fixes the following issues:
 - #4316
 - #4622 

### Reverts the following merge requests:
- #4343 

### Proposes solutions for both: 
- #4316 is solved by adding a tag that forces it to go through belongsTo  
 ```User User `gorm:"ForeignKey:UUID;references:UUID;belongsTo"``` 
  whereas hasTo case is  
```User User `gorm:"ForeignKey:UUID;references:UUID"``` (This is when SameForeignKey)
- #4622 is solved by reverting code from #4343 