### PR TITLE
fix:remove the tableName judgment in pluck

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -483,8 +483,6 @@ func (db *DB) Pluck(column string, dest interface{}) (tx *DB) {
 				column = f.DBName
 			}
 		}
-	} else if tx.Statement.Table == "" {
-		tx.AddError(ErrModelValueRequired)
 	}
 
 	if len(tx.Statement.Selects) != 1 {

--- a/tests/distinct_test.go
+++ b/tests/distinct_test.go
@@ -31,6 +31,12 @@ func TestDistinct(t *testing.T) {
 
 	AssertEqual(t, names1, []string{"distinct", "distinct-2", "distinct-3"})
 
+	var names2 []string
+	DB.Scopes(func(db *gorm.DB) *gorm.DB {
+		return db.Table("users")
+	}).Where("name like ?", "distinct%").Order("name").Pluck("name", &names2)
+	AssertEqual(t, names2, []string{"distinct", "distinct", "distinct", "distinct-2", "distinct-3"})
+
 	var results []User
 	if err := DB.Distinct("name", "age").Where("name like ?", "distinct%").Order("name, age desc").Find(&results).Error; err != nil {
 		t.Errorf("failed to query users, got error: %v", err)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
it causes problem when use **Scope** to set TableName and  use **Pluck**.

### User Case Description

a demo is provided below.
<!-- Your use case -->
```
func Find() error {
	db := GetDBConnection()
	var ids []int
	db.Scopes(func(db *gorm.DB) *gorm.DB {
		return db.Table("users")
	}).Debug().Pluck("id", &ids)
	return nil
}
// result: model value required
```