### PR TITLE
fix : update miss where's condition when use "<-:create" tag

### DIFF
--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -235,7 +235,7 @@ func ConvertToAssignments(stmt *gorm.Statement) (set clause.Set) {
 		case reflect.Struct:
 			set = make([]clause.Assignment, 0, len(stmt.Schema.FieldsByDBName))
 			for _, dbName := range stmt.Schema.DBNames {
-				if field := updatingSchema.LookUpField(dbName); field != nil && field.Updatable {
+				if field := updatingSchema.LookUpField(dbName); field != nil {
 					if !field.PrimaryKey || !updatingValue.CanAddr() || stmt.Dest != stmt.Model {
 						if v, ok := selectColumns[field.DBName]; (ok && v) || (!ok && (!restricted || (!stmt.SkipHooks && field.AutoUpdateTime > 0))) {
 							value, isZero := field.ValueOf(updatingValue)
@@ -252,7 +252,7 @@ func ConvertToAssignments(stmt *gorm.Statement) (set clause.Set) {
 								isZero = false
 							}
 
-							if ok || !isZero {
+							if (ok || !isZero) && field.Updatable {
 								set = append(set, clause.Assignment{Column: clause.Column{Name: field.DBName}, Value: value})
 								assignValue(field, value)
 							}

--- a/tests/upsert_test.go
+++ b/tests/upsert_test.go
@@ -309,3 +309,22 @@ func TestFindOrCreate(t *testing.T) {
 		t.Errorf("belongs to association should be saved")
 	}
 }
+
+func TestSaveWithFileNotUpdate(t *testing.T) {
+	type User struct {
+		ID   uint   `gorm:"column:id;<-:create"`
+		Name string `gorm:"column:name"`
+	}
+	user := User{ID: 1, Name: "king"}
+	tx := DB.Session(&gorm.Session{DryRun: true}).Save(&user)
+
+	if err := tx.Error; err != nil {
+		t.Fatalf("failed to update user,missing where condtion,err=%+v", err)
+
+	}
+
+	if !regexp.MustCompile("WHERE .id. = [^ ]+$").MatchString(tx.Statement.SQL.String()) {
+		t.Fatalf("invalid updating SQL, got %v", tx.Statement.SQL.String())
+	}
+
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?
fix:update miss where condition for https://github.com/go-gorm/gorm/issues/4734

when use update and model use `<-:create`  tag , maybe result in error.
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->

Demo code:
```
//model.go
type User struct {
	ID   uint   `gorm:"column:id;<-:create"`
	Name string `gorm:"column:name"`
}

//dal.go
user := model.User{ID: 1, Name: "king"}
tx.Debug().Save(&user)
if tx.Error != nil {
	fmt.Printf("Failed, got error: %v \n", tx.Error)
}
```
Run result:
```
[0.135ms] [rows:0] UPDATE `users` SET `name`="king"
Failed, got error: WHERE conditions required 
```

