### PR TITLE
field XXX_NoUnkeyedLiteral: define a valid foreign key for relations or implement the Valuer/Scanner interface

### DIFF
--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jinzhu/inflection"
+
 	"gorm.io/gorm/clause"
 )
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -134,7 +134,7 @@ func Parse(dest interface{}, cacheStore *sync.Map, namer Namer) (*Schema, error)
 		if fieldStruct := modelType.Field(i); ast.IsExported(fieldStruct.Name) {
 			if field := schema.ParseField(fieldStruct); field.EmbeddedSchema != nil {
 				schema.Fields = append(schema.Fields, field.EmbeddedSchema.Fields...)
-			} else {
+			} else if field.Tag.Get("json") != "-" {
 				schema.Fields = append(schema.Fields, field)
 			}
 		}


### PR DESCRIPTION
db.Find(&Srt) raise error:
     field XXX_NoUnkeyedLiteral: define a valid foreign key for relations or implement the Valuer/Scanner interface
HOW：add filter: field.Tag.Get("json") != "-"
WHY：unsupported parsing type: struct{}    set guessLevel to guessEmbeddedHas
     have been commented:schema/relationship.go:381
     as follows：
     reguessOrErr := func() {
     		switch cgl {
     		case guessGuess:
     			schema.guessRelation(relation, field, guessBelongs)
     		case guessBelongs:
     			schema.guessRelation(relation, field, guessEmbeddedBelongs)
     		case guessEmbeddedBelongs:
     			schema.guessRelation(relation, field, guessHas)
     		case guessHas:
     			schema.guessRelation(relation, field, guessEmbeddedHas)
     		// case guessEmbeddedHas:
     		default:
     			schema.err = fmt.Errorf("invalid field found for struct %v's field %s: define a valid foreign key for relations or implement the Valuer/Scanner interface", schema, field.Name)
     		}
     	}

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
