### PR TITLE
Fix self-referential belongs to constraint

### DIFF
--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -519,7 +519,7 @@ func (rel *Relationship) ParseConstraint() *Constraint {
 
 	if rel.Type == BelongsTo {
 		for _, r := range rel.FieldSchema.Relationships.Relations {
-			if r.FieldSchema == rel.Schema && len(rel.References) == len(r.References) {
+			if r != rel && r.FieldSchema == rel.Schema && len(rel.References) == len(r.References) {
 				matched := true
 				for idx, ref := range r.References {
 					if !(rel.References[idx].PrimaryKey == ref.PrimaryKey && rel.References[idx].ForeignKey == ref.ForeignKey &&

--- a/schema/relationship_test.go
+++ b/schema/relationship_test.go
@@ -93,6 +93,21 @@ func TestBelongsToWithOnlyReferences2(t *testing.T) {
 	})
 }
 
+func TestSelfReferentialBelongsTo(t *testing.T) {
+	type User struct {
+		ID        int32 `gorm:"primaryKey"`
+		Name      string
+		CreatorID *int32
+		Creator   *User
+	}
+
+	checkStructRelation(t, &User{}, Relation{
+		Name: "Creator", Type: schema.BelongsTo, Schema: "User", FieldSchema: "User",
+		References: []Reference{{"ID", "User", "CreatorID", "User", "", false}},
+	})
+
+}
+
 func TestSelfReferentialBelongsToOverrideReferences(t *testing.T) {
 	type User struct {
 		ID        int32 `gorm:"primaryKey"`

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -54,6 +54,27 @@ func TestMigrate(t *testing.T) {
 	}
 }
 
+func TestAutoMigrateSelfReferential(t *testing.T) {
+	type MigratePerson struct {
+		ID        uint
+		Name      string
+		ManagerID *uint
+		Manager   *MigratePerson
+	}
+
+	if err := DB.Debug().Migrator().DropTable(&MigratePerson{}); err != nil {
+		t.Fatalf("Failed to drop table, got error %v", err)
+	}
+
+	if err := DB.AutoMigrate(&MigratePerson{}); err != nil {
+		t.Fatalf("Failed to auto migrate, but got error %v", err)
+	}
+
+	if !DB.Migrator().HasConstraint("migrate_people", "fk_migrate_people_manager") {
+		t.Fatalf("Failed to find has one constraint between people and managers")
+	}
+}
+
 func TestSmartMigrateColumn(t *testing.T) {
 	fullSupported := map[string]bool{"mysql": true, "postgres": true}[DB.Dialector.Name()]
 

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -62,9 +62,7 @@ func TestAutoMigrateSelfReferential(t *testing.T) {
 		Manager   *MigratePerson
 	}
 
-	if err := DB.Debug().Migrator().DropTable(&MigratePerson{}); err != nil {
-		t.Fatalf("Failed to drop table, got error %v", err)
-	}
+	DB.Migrator().DropTable(&MigratePerson{})
 
 	if err := DB.AutoMigrate(&MigratePerson{}); err != nil {
 		t.Fatalf("Failed to auto migrate, but got error %v", err)


### PR DESCRIPTION
### What did this pull request do?

- Added a condition in the parse constraint in order to differentiate between a duplicate constraint (caused by a belongs-to and a has-many relationship between two models) and a self-referential belongs-to.
- There are probably many ways to make this check (perhaps checking the type of the relation instead of the whole object), so I would appreciate any feedback!

### User Case Description

Addresses the concerns from #4372 (now able to create self-referential belongs-to constraints)
