### PR TITLE
let gorm can scan protobuf struct without add an ignore tag ("-")

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -155,7 +155,7 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 	}
 
 	for i := 0; i < modelType.NumField(); i++ {
-		if fieldStruct := modelType.Field(i); ast.IsExported(fieldStruct.Name) {
+		if fieldStruct := modelType.Field(i); ast.IsExported(fieldStruct.Name) && fieldStruct.Tag.Get("json") != "-" {
 			if field := schema.ParseField(fieldStruct); field.EmbeddedSchema != nil {
 				schema.Fields = append(schema.Fields, field.EmbeddedSchema.Fields...)
 			} else {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -297,3 +297,21 @@ func TestEmbeddedStructForCustomizedNamingStrategy(t *testing.T) {
 		})
 	}
 }
+
+func TestParseProtobufStruct(t *testing.T) {
+	type Response struct {
+		Code                 *uint32                `protobuf:"varint,1,opt,name=code" json:"code,omitempty"`
+		XXX_NoUnkeyedLiteral struct{}               `json:"-"`
+		XXX_unrecognized     []byte                 `json:"-"`
+		XXX_sizecache        int32                  `json:"-"`
+	}
+
+	responseSchema, err := schema.Parse(&Response{}, &sync.Map{}, CustomizedNamingStrategy{schema.NamingStrategy{}})
+	if err != nil {
+		t.Fatalf("failed to parse protobuf struct, got error %v", err)
+	}
+
+	if len(responseSchema.Fields) != 1 || responseSchema.Fields[0].Name != "Code" {
+		t.Errorf("schema %v do include private field in protobuf struct", responseSchema)
+	}
+}


### PR DESCRIPTION
let gorm can scan protobuf struct without add an ignore tag ("-")

link: https://github.com/go-gorm/gorm/issues/4877

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [V] Do only one thing
- [V] Non breaking API changes
- [V] Tested

### What did this pull request do?

implement the  [#4877](https://github.com/go-gorm/gorm/issues/4877)

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

when gorm process the struct which is generated by the protobuf.

<!-- Your use case -->
