### PR TITLE
feat(order): support call Order once to order by multi column

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -219,6 +219,12 @@ func (db *DB) Order(value interface{}) (tx *DB) {
 		tx.Statement.AddClause(clause.OrderBy{
 			Columns: []clause.OrderByColumn{v},
 		})
+
+	case clause.OrderByColumns:
+		tx.Statement.AddClause(clause.OrderBy{
+			Columns: v,
+		})
+
 	case string:
 		if v != "" {
 			tx.Statement.AddClause(clause.OrderBy{

--- a/clause/order_by.go
+++ b/clause/order_by.go
@@ -6,6 +6,8 @@ type OrderByColumn struct {
 	Reorder bool
 }
 
+type OrderByColumns = []OrderByColumn
+
 type OrderBy struct {
 	Columns    []OrderByColumn
 	Expression Expression


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

```
var a []interface
db.Table("aaa").
		Order(clause.OrderByColumns{
			{Column: clause.Column{Name: "e"}, Desc: true},
			{Column: clause.Column{Name: "f"}, Desc: false},
		}).
		Find(&a)
```
sql: ```SELECT * FROM "aaa" ORDER BY "e" DESC,"f"```

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
When I want to order by multi columns,I can call Order like this:
```
db.Table("aaa").
		Order(clause.OrderByColumn{Column: clause.Column{Name: "id"}, Desc: true}).
		Order(clause.OrderByColumn{Column: clause.Column{Name: "other column"}, Desc: false}).
		Find(&a)

// SELECT * FROM "aaa" ORDER BY "id" DESC,"other column"
```
This pr only implement a more convenient way which pass a `[]clause.OrderByColumn` to `Order` instead of calling `Order` multi time

<!-- Your use case -->
```
db.Table("aaa").
		Order(
			clause.OrderByColumns{
				{Column: clause.Column{Name: "id"}, Desc: true},
				{Column: clause.Column{Name: "other column"}, Desc: false},
			},
		).
		Find(&a1)
```
