### PR TITLE
Remove redundant percision check for migrator

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -407,9 +407,7 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 
 	// check precision
 	if precision, _, ok := columnType.DecimalSize(); ok && int64(field.Precision) != precision {
-		if regexp.MustCompile(fmt.Sprintf("[^0-9]%d[^0-9]", field.Precision)).MatchString(m.DataTypeOf(field)) {
-			alterColumn = true
-		}
+		alterColumn = true
 	}
 
 	// check nullable

--- a/schema/utils.go
+++ b/schema/utils.go
@@ -30,7 +30,10 @@ func ParseTagSetting(str string, sep string) map[string]string {
 		}
 
 		values := strings.Split(names[j], ":")
-		k := strings.TrimSpace(strings.ToUpper(values[0]))
+		for i, v := range values {
+			values[i] = strings.TrimSpace(v)
+		}
+		k := strings.ToUpper(values[0])
 
 		if len(values) >= 2 {
 			settings[k] = strings.Join(values[1:], ":")


### PR DESCRIPTION
extra checking can cause "tag:percision" to lose meaning

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [√] Do only one thing
- [√] Non breaking API changes
- [√] Tested

### What did this pull request do?

remove redundant percision check for migrator

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
if I want to change the percision

before
![image](https://user-images.githubusercontent.com/61787040/145159551-ede88704-6017-4b4f-8d03-fee06b71afba.png)

now
![image](https://user-images.githubusercontent.com/61787040/145159493-5bdaf796-8bcc-4788-8fda-52d850e0b84a.png)

