### PR TITLE
Ability to use pure-Go SQLITE driver

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,7 +10,7 @@ require (
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b // indirect
 	gorm.io/driver/mysql v1.2.1
 	gorm.io/driver/postgres v1.2.3
-	gorm.io/driver/sqlite v1.2.6
+	github.com/glebarez/sqlite v1.3.2
 	gorm.io/driver/sqlserver v1.2.1
 	gorm.io/gorm v1.22.4
 )

--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -9,7 +9,7 @@ import (
 
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
-	"gorm.io/driver/sqlite"
+	"github.com/glebarez/sqlite"
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"


### PR DESCRIPTION
This PR is solely for triggering CI checks against non-standard, pure-Go SQLite driver for GORM.
The corresponding issue is: https://github.com/go-gorm/gorm/issues/4922