### PR TITLE
Fix: Where clauses with named arguments may cause generation of unintended queries

### DIFF
--- a/clause/where.go
+++ b/clause/where.go
@@ -60,6 +60,9 @@ func buildExprs(exprs []Expression, builder Builder, joinCond string) {
 			case Expr:
 				sql := strings.ToLower(v.SQL)
 				wrapInParentheses = strings.Contains(sql, "and") || strings.Contains(sql, "or")
+			case NamedExpr:
+				sql := strings.ToLower(v.SQL)
+				wrapInParentheses = strings.Contains(sql, "and") || strings.Contains(sql, "or")
 			}
 		}
 

--- a/tests/named_argument_test.go
+++ b/tests/named_argument_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"database/sql"
+	"errors"
 	"testing"
 
 	"gorm.io/gorm"
@@ -66,4 +67,16 @@ func TestNamedArg(t *testing.T) {
 	}
 
 	AssertEqual(t, result6, namedUser)
+
+	var result7 NamedUser
+	if err := DB.Where("name1 = @name OR name2 = @name", sql.Named("name", "jinzhu-new")).Where("name3 = 'jinzhu-new3'").First(&result7).Error; err == nil || !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("should return record not found error, but got %v", err)
+	}
+
+	DB.Delete(&namedUser)
+
+	var result8 NamedUser
+	if err := DB.Where("name1 = @name OR name2 = @name", map[string]interface{}{"name": "jinzhu-new"}).First(&result8).Error; err == nil || !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("should return record not found error, but got %v", err)
+	}
 }


### PR DESCRIPTION
* [x]  Do only one thing
* [x]  Non breaking API changes
* [x]  Tested


### What did this pull request do?

During the building of Where clauses, the NamedExpr type is omitted while determining whether the expression should be wrapped in parentheses. Therefore, although it is required, Where clauses containing both named arguments and OR conditions are not wrapped, and this causes the generation of different queries than desired. This pull request tries to fix this issue.
### User Case Description

eg:

For the gorm statement below,

```go
db.Model(&User{}).Where("role = @role1 OR role = @role2",
map[string]interface{}{"role1": "admin", "role2": "super_admin"}).Find(&results)
```

the following query is generated.

~~~~sql
SELECT * FROM users WHERE role = 'admin' or role = 'super_admin' AND users.deleted_at IS NULL
~~~~

Due to the precedence of `AND` over `OR`, the query will be interpreted like
~~~~sql
`WHERE role = 'admin' or (role = 'super_admin' AND users.deleted_at IS NULL)` 
~~~~

instead of

~~~~sql
`WHERE (role = 'admin' or role = 'super_admin') AND users.deleted_at IS NULL` 
~~~~

which is actually intended, and it leads to getting softly deleted admin users without being aware, which may also be dangerous.

