### PR TITLE
Adding support to Pointers in Preloads

### DIFF
--- a/schema/utils.go
+++ b/schema/utils.go
@@ -104,7 +104,12 @@ func GetIdentityFieldValuesMap(reflectValue reflect.Value, fields []*Field) (map
 		loaded        = map[interface{}]bool{}
 		notZero, zero bool
 	)
-
+	if reflectValue.Kind() == reflect.Interface {
+		reflectValue = reflectValue.Elem()
+		if reflectValue.Kind() == reflect.Ptr {
+			reflectValue = reflectValue.Elem()
+		}
+	}
 	switch reflectValue.Kind() {
 	case reflect.Struct:
 		results = [][]interface{}{make([]interface{}, len(fields))}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This will add Preload-Support to relations, which are stored as pointers.

### User Case Description

I have to use pointers, caused by other database-engines that store structs in structs. This will fix BelongsTo and HasOne relations as pointers by resolving the structs beneath the pointers.