### PR TITLE
fix: generate sql incorrect when use soft_delete and only one OR

### DIFF
--- a/clause/where.go
+++ b/clause/where.go
@@ -94,8 +94,12 @@ func And(exprs ...Expression) Expression {
 		return nil
 	}
 
-	if _, ok := exprs[0].(OrConditions); !ok && len(exprs) == 1 {
-		return exprs[0]
+	if len(exprs) == 1 {
+
+		if _, ok := exprs[0].(OrConditions); !ok {
+			return exprs[0]
+		}
+
 	}
 
 	return AndConditions{Exprs: exprs}

--- a/clause/where.go
+++ b/clause/where.go
@@ -92,9 +92,12 @@ func (where Where) MergeClause(clause *Clause) {
 func And(exprs ...Expression) Expression {
 	if len(exprs) == 0 {
 		return nil
-	} else if len(exprs) == 1 {
+	}
+
+	if _, ok := exprs[0].(OrConditions); !ok && len(exprs) == 1 {
 		return exprs[0]
 	}
+
 	return AndConditions{Exprs: exprs}
 }
 

--- a/clause/where.go
+++ b/clause/where.go
@@ -95,11 +95,9 @@ func And(exprs ...Expression) Expression {
 	}
 
 	if len(exprs) == 1 {
-
 		if _, ok := exprs[0].(OrConditions); !ok {
 			return exprs[0]
 		}
-
 	}
 
 	return AndConditions{Exprs: exprs}

--- a/soft_delete.go
+++ b/soft_delete.go
@@ -65,7 +65,7 @@ func (sd SoftDeleteQueryClause) MergeClause(*clause.Clause) {
 func (sd SoftDeleteQueryClause) ModifyStatement(stmt *Statement) {
 	if _, ok := stmt.Clauses["soft_delete_enabled"]; !ok && !stmt.Statement.Unscoped {
 		if c, ok := stmt.Clauses["WHERE"]; ok {
-			if where, ok := c.Expression.(clause.Where); ok && len(where.Exprs) > 1 {
+			if where, ok := c.Expression.(clause.Where); ok && len(where.Exprs) >= 1 {
 				for _, expr := range where.Exprs {
 					if orCond, ok := expr.(clause.OrConditions); ok && len(orCond.Exprs) == 1 {
 						where.Exprs = []clause.Expression{clause.And(where.Exprs...)}

--- a/tests/soft_delete_test.go
+++ b/tests/soft_delete_test.go
@@ -83,3 +83,13 @@ func TestDeletedAtUnMarshal(t *testing.T) {
 		t.Errorf("Failed, result.DeletedAt: %v is not same as expected.DeletedAt: %v", result.DeletedAt, expected.DeletedAt)
 	}
 }
+
+func TestDeletedAtOneOr(t *testing.T) {
+	actualSQL := DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
+		return tx.Or("id = ?", 1).Find(&User{})
+	})
+
+	if !regexp.MustCompile(` WHERE id = 1 AND .users.\..deleted_at. IS NULL`).MatchString(actualSQL) {
+		t.Fatalf("invalid sql generated, got %v", actualSQL)
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?
PR for https://github.com/go-gorm/gorm/issues/4914
- fix generate sql incorrect when use `soft_delete` and only one `or`
- 修复使用 `soft_delete` 并且仅有一个 `or` 时生成错误SQL.
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

Code:
```
func TestGORMorCondition(t *testing.T) {
	user := User{Name: "jinzhu"}
	DB.Create(&user)

	ret := make([]*User, 0)
	id := []uint32{1}
	db := DB
	for _, id := range id {
		db = db.Or("id = ?", id)
	}
	db.Find(&ret)
}
```
SQL:
```
[0.125ms] [rows:1] SELECT * FROM `users` WHERE id = 1 OR `users`.`deleted_at` IS NULL
```

<!-- Your use case -->
