### PR TITLE
feat: add `Connection` to execute multiple commands in a single conn

### DIFF
--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -1,0 +1,48 @@
+package tests_test
+
+import (
+	"fmt"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"testing"
+)
+
+func TestWithSingleConnection(t *testing.T) {
+
+	var expectedName = "test"
+	var actualName string
+
+	setSQL, getSQL := getSetSQL(DB.Dialector.Name())
+	if len(setSQL) == 0 || len(getSQL) == 0 {
+		return
+	}
+
+	err := DB.Connection(func(tx *gorm.DB) error {
+		if err := tx.Exec(setSQL, expectedName).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Raw(getSQL).Scan(&actualName).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf(fmt.Sprintf("WithSingleConnection should work, but got err %v", err))
+	}
+
+	if actualName != expectedName {
+		t.Errorf("WithSingleConnection() method should get correct value, expect: %v, got %v", expectedName, actualName)
+	}
+
+}
+
+func getSetSQL(driverName string) (string, string) {
+	switch driverName {
+	case mysql.Dialector{}.Name():
+		return "SET @testName := ?", "SELECT @testName"
+	default:
+		return "", ""
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [×] Do only one thing
- [×] Non breaking API changes
- [×] Tested

### What did this pull request do?

- en : feat: add `Connection` to execute multiple commands in a single conn
- zh : 支持一个 conn 内可以执行多个命令
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
```
func TestWithSingleConnection(t *testing.T) {

	var expectedName = "test"
	var actualName string

	setSQL, getSQL := getSetSQL(DB.Dialector.Name())
	if len(setSQL) == 0 || len(getSQL) == 0 {
		return
	}

	err := DB.Connection(func(tx *gorm.DB) error {
		if err := tx.Exec(setSQL, expectedName).Error; err != nil {
			return err
		}

		if err := tx.Raw(getSQL).Scan(&actualName).Error; err != nil {
			return err
		}
		return nil
	})

	if err != nil {
		t.Errorf(fmt.Sprintf("Connection should work, but got err %v", err))
	}

	if actualName != expectedName {
		t.Errorf("Connection() method should get correct value, expect: %v, got %v", expectedName, actualName)
	}

}

```
<!-- Your use case -->
