### PR TITLE
Inherit clone flag (NewDB) on transaction creation

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -585,7 +585,7 @@ func (db *DB) Transaction(fc func(tx *DB) error, opts ...*sql.TxOptions) (err er
 func (db *DB) Begin(opts ...*sql.TxOptions) *DB {
 	var (
 		// clone statement
-		tx  = db.getInstance().Session(&Session{Context: db.Statement.Context, newDB: db.clone == 1})
+		tx  = db.getInstance().Session(&Session{Context: db.Statement.Context, NewDB: db.clone == 1})
 		opt *sql.TxOptions
 		err error
 	)

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -585,7 +585,7 @@ func (db *DB) Transaction(fc func(tx *DB) error, opts ...*sql.TxOptions) (err er
 func (db *DB) Begin(opts ...*sql.TxOptions) *DB {
 	var (
 		// clone statement
-		tx  = db.getInstance().Session(&Session{Context: db.Statement.Context})
+		tx  = db.getInstance().Session(&Session{Context: db.Statement.Context, newDB: db.clone == 1})
 		opt *sql.TxOptions
 		err error
 	)


### PR DESCRIPTION
- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

I find it very reassuring to know that after a finisher API, I get a clean db object for my next queries.
If you look at the example in https://gorm.io/docs you'd see many queries running one after the other.. but in reality they wouldn’t work in transaction.
That’s because in default mode, NewDB is false and will make all the clauses stay even after a finisher API.

My solution is just to have the value of the clone flag in the “parent” db object, be injected to its children transactions.


### User Case Description

I have many usages of transactions around my code and many of them consist of multiple queries that aren't sharing the same clauses (e.g different `WHERE`).
So instead of having to use `db.begin().Session(gorm.Session{NewDB: true})` on each transaction, because :
A. it is verbose
B. It hurts maintainability, since new devs are expecting of all transaction to work as their parent DB object.
