### PR TITLE
fix: omit not work when use join 

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -100,7 +100,7 @@ func BuildQuerySQL(db *gorm.DB) {
 		}
 
 		if len(db.Statement.Joins) != 0 || len(joins) != 0 {
-			if len(db.Statement.Selects) == 0 && db.Statement.Schema != nil {
+			if len(db.Statement.Selects) == 0 && len(db.Statement.Omits) == 0 && db.Statement.Schema != nil {
 				clauseSelect.Columns = make([]clause.Column, len(db.Statement.Schema.DBNames))
 				for idx, dbName := range db.Statement.Schema.DBNames {
 					clauseSelect.Columns[idx] = clause.Column{Table: db.Statement.Table, Name: dbName}

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWithSingleConnection(t *testing.T) {
-	var expectedName = "test"
+	expectedName := "test"
 	var actualName string
 
 	setSQL, getSQL := getSetSQL(DB.Dialector.Name())
@@ -27,7 +27,6 @@ func TestWithSingleConnection(t *testing.T) {
 		}
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf(fmt.Sprintf("WithSingleConnection should work, but got err %v", err))
 	}

--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -158,6 +158,22 @@ func TestJoinsWithSelect(t *testing.T) {
 	}
 }
 
+func TestJoinWithOmit(t *testing.T) {
+	user := *GetUser("joins_with_omit", Config{Pets: 2})
+	DB.Save(&user)
+
+	results := make([]*User, 0)
+
+	if err := DB.Table("users").Omit("name").Where("users.name = ?", "joins_with_omit").Joins("left join pets on pets.user_id = users.id").Find(&results).Error; err != nil {
+		return
+	}
+
+	if len(results) != 2 || results[0].Name != "" || results[1].Name != "" {
+		t.Errorf("Should find all two pets with Join omit and should not find user's name, got %+v", results)
+		return
+	}
+}
+
 func TestJoinCount(t *testing.T) {
 	companyA := Company{Name: "A"}
 	companyB := Company{Name: "B"}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

omit not work when use join

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
```
func TestJoinWithOmit(t *testing.T) {
	user := *GetUser("joins_with_omit", Config{Pets: 2})
	DB.Save(&user)

	results := make([]*User, 0)

	if err := DB.Table("users").Omit("name").Where("users.name = ?", "joins_with_omit").Joins("left join pets on pets.user_id = users.id").Find(&results).Error; err != nil {
		return
	}

	if len(results) != 2 || results[0].Name != "" || results[1].Name != "" {
		t.Errorf("Should find all two pets with Join omit and should not find user's name, got %+v", results)
		return
	}
}

```
<!-- Your use case -->
