### PR TITLE
Fix error info not match description problem.

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -104,7 +104,7 @@ func (p *processor) Execute(db *DB) *DB {
 	if stmt.Model != nil {
 		if err := stmt.Parse(stmt.Model); err != nil && (!errors.Is(err, schema.ErrUnsupportedDataType) || (stmt.Table == "" && stmt.TableExpr == nil && stmt.SQL.Len() == 0)) {
 			if errors.Is(err, schema.ErrUnsupportedDataType) && stmt.Table == "" && stmt.TableExpr == nil {
-				db.AddError(fmt.Errorf("%w: Table not set, please set it like: db.Model(&user) or db.Table(\"users\")", err))
+				db.AddError(fmt.Errorf("%w: Table not set, please set it like: db.Model(&user)", err))
 			} else {
 				db.AddError(err)
 			}


### PR DESCRIPTION
db.Table() to locate table is misleading. remove it.