### PR TITLE
fix: replace empty table name result in panic

### DIFF
--- a/schema/naming.go
+++ b/schema/naming.go
@@ -120,7 +120,14 @@ func (ns NamingStrategy) toDBName(name string) string {
 	}
 
 	if ns.NameReplacer != nil {
-		name = ns.NameReplacer.Replace(name)
+
+		tmpName := ns.NameReplacer.Replace(name)
+
+		if tmpName == "" {
+			return name
+		}
+
+		name = tmpName
 	}
 
 	if ns.NoLowerCase {

--- a/schema/naming.go
+++ b/schema/naming.go
@@ -120,7 +120,6 @@ func (ns NamingStrategy) toDBName(name string) string {
 	}
 
 	if ns.NameReplacer != nil {
-
 		tmpName := ns.NameReplacer.Replace(name)
 
 		if tmpName == "" {

--- a/schema/naming_test.go
+++ b/schema/naming_test.go
@@ -197,3 +197,14 @@ func TestFormatNameWithStringLongerThan64Characters(t *testing.T) {
 		t.Errorf("invalid formatted name generated, got %v", formattedName)
 	}
 }
+
+func TestReplaceEmptyTableName(t *testing.T) {
+	ns := NamingStrategy{
+		SingularTable: true,
+		NameReplacer:  strings.NewReplacer("Model", ""),
+	}
+	tableName := ns.TableName("Model")
+	if tableName != "Model" {
+		t.Errorf("invalid table name generated, got %v", tableName)
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

-  en: fix replace empty table name result in panic.  if replaced name equal to `""` , should return name.
-  zh: 修复替换 table name 为空时会导致 panic.    如果替换后的 name 等于 `""` 就将 name 返回.

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description


<!-- Your use case -->

```
func TestReplaceEmptyTableName(t *testing.T) {
	ns := NamingStrategy{
		SingularTable: true,
		NameReplacer:  strings.NewReplacer("Model", ""),
	}
	tableName := ns.TableName("Model")
	if tableName != "Model" {
		t.Errorf("invalid table name generated, got %v", tableName)
	}
}
```
