### PR TITLE
feat: support gob serialize

### DIFF
--- a/tests/serializer_test.go
+++ b/tests/serializer_test.go
@@ -19,11 +19,20 @@ type SerializerStruct struct {
 	Name            []byte                 `gorm:"json"`
 	Roles           Roles                  `gorm:"serializer:json"`
 	Contracts       map[string]interface{} `gorm:"serializer:json"`
+	JobInfo         Job                    `gorm:"type:bytes;serializer:gob"`
 	CreatedTime     int64                  `gorm:"serializer:unixtime;type:time"` // store time in db, use int as field type
 	EncryptedString EncryptedString
 }
 
 type Roles []string
+
+type Job struct {
+	Title    string
+	Number   int
+	Location string
+	IsIntern bool
+}
+
 type EncryptedString string
 
 func (es *EncryptedString) Scan(ctx context.Context, field *schema.Field, dst reflect.Value, dbValue interface{}) (err error) {
@@ -56,6 +65,12 @@ func TestSerializer(t *testing.T) {
 		Contracts:       map[string]interface{}{"name": "jinzhu", "age": 10},
 		EncryptedString: EncryptedString("pass"),
 		CreatedTime:     createdAt.Unix(),
+		JobInfo: Job{
+			Title:    "programmer",
+			Number:   9920,
+			Location: "Kenmawr",
+			IsIntern: false,
+		},
 	}
 
 	if err := DB.Create(&data).Error; err != nil {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Implement a GobSerializer in schema/serializer to support Gob encoding in the latest released serializer tag feature. 

### User Case Description

<!-- Your use case -->

In the past, if we want to set the value of a struct into a certain field, we would marshal the struct to a string/bytes(normally with json/msgpack/gob). With the support for serializer, it becomes a relatively easy job. 

But now it only supports json and unixtime. Golang provide native support for gob, which has a better performance over json. Hopefully, this will help developers reduce the trouble on writing gob encoding and decoding.
