### PR TITLE
fix: query scanner in single column

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -272,7 +272,17 @@ func Scan(rows *sql.Rows, db *DB, mode ScanMode) {
 			}
 		case reflect.Struct, reflect.Ptr:
 			if initialized || rows.Next() {
-				db.scanIntoStruct(sch, rows, reflectValue, values, columns, fields, joinFields)
+				if update {
+					db.scanIntoStruct(sch, rows, reflectValue, values, columns, fields, joinFields)
+				} else {
+					elem := reflect.New(reflectValueType)
+					db.scanIntoStruct(sch, rows, elem, values, columns, fields, joinFields)
+					if isPtr {
+						db.Statement.ReflectValue.Set(elem)
+					} else {
+						db.Statement.ReflectValue.Set(elem.Elem())
+					}
+				}
 			}
 		default:
 			db.AddError(rows.Scan(dest))


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

The following error is throwed `destination not a pointer` when query single column into scanner .
<!--
provide a general description of the code changes in your pull request
-->
close #5091

