### PR TITLE
ToSQL should enable SkipDefaultTransaction by default

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -462,7 +462,7 @@ func (db *DB) Use(plugin Plugin) error {
 //			.First(&User{})
 // })
 func (db *DB) ToSQL(queryFn func(tx *DB) *DB) string {
-	tx := queryFn(db.Session(&Session{DryRun: true}))
+	tx := queryFn(db.Session(&Session{DryRun: true, SkipDefaultTransaction: true}))
 	stmt := tx.Statement
 
 	return db.Dialector.Explain(stmt.SQL.String(), stmt.Vars...)


### PR DESCRIPTION
ToSQL should always enable `SkipDefaultTransaction` regardless of current db.config.
An example of this change may improve performance
```
db, _ := gorm.Open(sqlite.Open("test.db"), &gorm.Config{SkipDefaultTransaction: false})
sql := DB.ToSQL(func(tx *gorm.DB) *gorm.DB {  
   return tx.Clauses(clause.OnConflict{
                                Columns:   []clause.Column{{Name: "id"}},
                                DoUpdates: clause.AssignmentColumns([]string{"name", "age"}),
                     }).Create(&users)
})
```
The Create() call above will actually call `BeginTransaction` and `CommitOrRollbackTransaction` callbacks. But they are costly (involve connection handling) and not necessary in this case.