### PR TITLE
fix: preload panic when model and dest different

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -218,6 +218,13 @@ func Preload(db *gorm.DB) {
 		}
 		sort.Strings(preloadNames)
 
+		// different schema
+		if db.Statement.ReflectValue.CanAddr() && db.Statement.Dest != db.Statement.Model {
+			if err := db.Statement.Parse(db.Statement.Dest); err != nil {
+				db.AddError(err)
+			}
+		}
+
 		for _, name := range preloadNames {
 			if rel := db.Statement.Schema.Relationships.Relations[name]; rel != nil {
 				preload(db, rel, append(db.Statement.Preloads[name], db.Statement.Preloads[clause.Associations]...), preloadMap[name])

--- a/tests/preload_test.go
+++ b/tests/preload_test.go
@@ -251,3 +251,20 @@ func TestPreloadGoroutine(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestPreloadWithDiffModel(t *testing.T) {
+	user := *GetUser("preload_with_diff_model", Config{Account: true})
+
+	if err := DB.Create(&user).Error; err != nil {
+		t.Fatalf("errors happened when create: %v", err)
+	}
+
+	CheckUser(t, user, user)
+
+	var result struct {
+		Something string
+		User
+	}
+	DB.Model(&User{}).Select("users.*, 'yo' as something").Preload("Account").Find(&result, user.ID)
+	CheckUser(t, user, result.User)
+}

--- a/tests/preload_test.go
+++ b/tests/preload_test.go
@@ -13,6 +13,25 @@ import (
 	. "gorm.io/gorm/utils/tests"
 )
 
+// https://github.com/go-gorm/gorm/issues/4886
+func TestPreloadWithDiffModel(t *testing.T) {
+	user := *GetUser("preload_with_diff_model", Config{Account: true})
+
+	if err := DB.Create(&user).Error; err != nil {
+		t.Fatalf("errors happened when create: %v", err)
+	}
+
+	var result struct {
+		Something string
+		User
+	}
+
+	DB.Model(User{}).Preload("Account", clause.Eq{Column: "number", Value: user.Account.Number}).Select(
+		"users.*, 'yo' as something").First(&result, "name = ?", user.Name)
+
+	CheckUser(t, user, result.User)
+}
+
 func TestPreloadWithAssociations(t *testing.T) {
 	user := *GetUser("preload_with_associations", Config{
 		Account:   true,
@@ -250,27 +269,4 @@ func TestPreloadGoroutine(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-}
-
-func TestPreloadWithDiffModel(t *testing.T) {
-	DB.Migrator().DropTable(&User{}, &Account{})
-	if err := DB.AutoMigrate(&User{}, &Account{}); err != nil {
-		t.Error(err)
-	}
-
-	user := *GetUser("preload_with_diff_model", Config{Account: true})
-
-	if err := DB.Create(&user).Error; err != nil {
-		t.Fatalf("errors happened when create: %v", err)
-	}
-
-	var result struct {
-		Something string
-		User
-	}
-
-	DB.Model(User{}).Preload("Account", clause.Eq{Column: "number", Value: user.Account.Number}).Select(
-		"users.*, 'yo' as something").First(&result, "name = ?", user.Name)
-
-	CheckUser(t, user, result.User)
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
`Preload` will panic when `Mode` and `Dest` is different schema.
```
 DB.Model(User{}).Preload("Account").Select("users.*, 'yo' as something").First(&result, user.ID).
```
close #4886
