### PR TITLE
fix: Omit 'Reference' and 'Reference.*' should be same

### DIFF
--- a/callbacks/associations.go
+++ b/callbacks/associations.go
@@ -348,6 +348,10 @@ func saveAssociations(db *gorm.DB, rel *schema.Relationship, values interface{},
 		refName        = rel.Name + "."
 	)
 
+	if _, ok := selectColumns[rel.Name+".*"]; ok {
+		return nil
+	}
+
 	for name, ok := range selectColumns {
 		columnName := ""
 		if strings.HasPrefix(name, refName) {

--- a/statement.go
+++ b/statement.go
@@ -674,6 +674,7 @@ func (stmt *Statement) SelectAndOmitColumns(requireCreate, requireUpdate bool) (
 
 	// omit columns
 	for _, omit := range stmt.Omits {
+		omit = strings.TrimSuffix(omit, ".*")
 		if stmt.Schema == nil {
 			results[omit] = false
 		} else if omit == "*" {

--- a/statement.go
+++ b/statement.go
@@ -674,7 +674,6 @@ func (stmt *Statement) SelectAndOmitColumns(requireCreate, requireUpdate bool) (
 
 	// omit columns
 	for _, omit := range stmt.Omits {
-		omit = strings.TrimSuffix(omit, ".*")
 		if stmt.Schema == nil {
 			results[omit] = false
 		} else if omit == "*" {

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -446,7 +446,7 @@ func TestSelectWithCreate(t *testing.T) {
 
 func TestOmitWithCreate(t *testing.T) {
 	user := *GetUser("omit_create", Config{Account: true, Pets: 3, Toys: 3, Company: true, Manager: true, Team: 3, Languages: 3, Friends: 4})
-	DB.Omit("Account", "Toys", "Manager", "Birthday").Create(&user)
+	DB.Omit("Account.*", "Toys", "Manager", "Birthday").Create(&user)
 
 	var result User
 	DB.Preload("Account").Preload("Pets").Preload("Toys").Preload("Company").Preload("Manager").Preload("Team").Preload("Languages").Preload("Friends").First(&result, user.ID)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

```go
	DB.Omit("Account,Manager").Create(&user)	 // work
	DB.Omit("Account.*,Manager.*").Create(&user) // not work 
```
Seems `Omit("Reference")` work but `Omit("Reference.*")` doesn't, they should be the same.

close #5058
