### PR TITLE
fix when index name is "type", parseFieldIndexes will set index TYPE is "TYPE"

### DIFF
--- a/schema/index.go
+++ b/schema/index.go
@@ -89,11 +89,12 @@ func parseFieldIndexes(field *Field) (indexes []Index) {
 			k := strings.TrimSpace(strings.ToUpper(v[0]))
 			if k == "INDEX" || k == "UNIQUEINDEX" {
 				var (
-					name      string
-					tag       = strings.Join(v[1:], ":")
-					idx       = strings.Index(tag, ",")
-					settings  = ParseTagSetting(tag, ",")
-					length, _ = strconv.Atoi(settings["LENGTH"])
+					name       string
+					tag        = strings.Join(v[1:], ":")
+					idx        = strings.Index(tag, ",")
+					tagSetting = strings.Join(strings.Split(tag, ",")[1:], ",")
+					settings   = ParseTagSetting(tagSetting, ",")
+					length, _  = strconv.Atoi(settings["LENGTH"])
 				)
 
 				if idx == -1 {

--- a/schema/index_test.go
+++ b/schema/index_test.go
@@ -81,6 +81,7 @@ func TestParseIndex(t *testing.T) {
 		},
 		"type": {
 			Name:   "type",
+			Type:   "",
 			Fields: []schema.IndexOption{{Field: &schema.Field{Name: "Name7"}}},
 		},
 	}

--- a/schema/index_test.go
+++ b/schema/index_test.go
@@ -18,6 +18,7 @@ type UserIndex struct {
 	Age          int64  `gorm:"index:profile,expression:ABS(age),option:WITH PARSER parser_name"`
 	OID          int64  `gorm:"index:idx_id;index:idx_oid,unique"`
 	MemberNumber string `gorm:"index:idx_id,priority:1"`
+	Name7        string `gorm:"index:type"`
 }
 
 func TestParseIndex(t *testing.T) {
@@ -77,6 +78,10 @@ func TestParseIndex(t *testing.T) {
 			Name:   "idx_oid",
 			Class:  "UNIQUE",
 			Fields: []schema.IndexOption{{Field: &schema.Field{Name: "OID"}}},
+		},
+		"type": {
+			Name:   "type",
+			Fields: []schema.IndexOption{{Field: &schema.Field{Name: "Name7"}}},
 		},
 	}
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
```
Name7        string `gorm:"index:type"``
```
call `AutoMigrate`,when index name is type, `parseFieldIndexes` will parse index TYPE is "TYPE", because `ParseTagSetting`'s params is `type`, it will return `map[TYPE]TYPE`,,so we should exclude index name in call `ParseTagSetting`'s params

error generate sql 
```
`CREATE INDEX `type` ON `xxxx`(`xxx`,`type`) USING TYPE`
```
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
```
Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'TYPE' at line 1", "elapsed": 0.000959069, "rows": 0, "sql": "CREATE INDEX `type` ON `xxxxxxxxx`(`xxxxx`,`type`) USING TYPE
```

https://github.com/go-gorm/playground/pull/446
<!-- Your use case -->

