### PR TITLE
Add with clause support

### DIFF
--- a/callbacks/callbacks.go
+++ b/callbacks/callbacks.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	createClauses = []string{"INSERT", "VALUES", "ON CONFLICT"}
-	queryClauses  = []string{"SELECT", "FROM", "WHERE", "GROUP BY", "ORDER BY", "LIMIT", "FOR"}
+	queryClauses  = []string{"WITH", "SELECT", "FROM", "WHERE", "GROUP BY", "ORDER BY", "LIMIT", "FOR"}
 	updateClauses = []string{"UPDATE", "SET", "WHERE"}
 	deleteClauses = []string{"DELETE", "FROM", "WHERE"}
 )

--- a/chainable_api.go
+++ b/chainable_api.go
@@ -124,13 +124,23 @@ func (db *DB) with(name string, recursive bool, args ...interface{}) (tx *DB) {
 			}
 		}
 	case []string:
-		for _, col := range arg {
-			if strings.Contains(col, ",") {
-				tx.AddError(fmt.Errorf("unsupported mixed string type"))
-				return
+		switch len(args) {
+		case 1:
+			tx.AddError(fmt.Errorf("unsupported with subquery type %T", arg))
+			return
+		case 2:
+			// arg[0] is columns ans arg[1] is subquery
+			for _, col := range arg {
+				if strings.Contains(col, ",") {
+					tx.AddError(fmt.Errorf("unsupported mixed string type"))
+					return
+				}
 			}
+			columns = arg
+		default:
+			tx.AddError(fmt.Errorf("unsupported multiple columns %v", args[1:len(args)-1]))
+			return
 		}
-		columns = arg
 	default:
 		// specify optional columns field with a wrong type
 		if len(args) > 1 {

--- a/clause/clause_test.go
+++ b/clause/clause_test.go
@@ -17,15 +17,15 @@ var db, _ = gorm.Open(tests.DummyDialector{}, nil)
 func checkBuildClauses(t *testing.T, clauses []clause.Interface, result string, vars []interface{}) {
 	var (
 		buildNames    []string
-		buildNamesMap = map[string]bool{}
+		buildNamesSet = map[string]struct{}{}
 		user, _       = schema.Parse(&tests.User{}, &sync.Map{}, db.NamingStrategy)
 		stmt          = gorm.Statement{DB: db, Table: user.Table, Schema: user, Clauses: map[string]clause.Clause{}}
 	)
 
 	for _, c := range clauses {
-		if _, ok := buildNamesMap[c.Name()]; !ok {
+		if _, ok := buildNamesSet[c.Name()]; !ok {
 			buildNames = append(buildNames, c.Name())
-			buildNamesMap[c.Name()] = true
+			buildNamesSet[c.Name()] = struct{}{}
 		}
 
 		stmt.AddClause(c)

--- a/clause/with.go
+++ b/clause/with.go
@@ -1,3 +1,88 @@
 package clause
 
-type With struct{}
+import "strings"
+
+// With Common Table Expressions
+type With struct {
+	Recursive  bool
+	Exprs      []Expression
+	Expression Expression
+}
+
+// Name with clause name
+func (with With) Name() string {
+	return "WITH"
+}
+
+// Build build with clause
+func (with With) Build(builder Builder) {
+	if with.Expression != nil {
+		with.Expression.Build(builder)
+		return
+	}
+	if len(with.Exprs) == 0 {
+		return
+	}
+
+	if with.Recursive {
+		builder.WriteString("RECURSIVE ")
+	}
+	for idx, expr := range with.Exprs {
+		if idx != 0 {
+			builder.WriteByte(',')
+		}
+		expr.Build(builder)
+	}
+}
+
+// MergeClause merge with clauses
+func (with With) MergeClause(clause *Clause) {
+	if w, ok := clause.Expression.(With); ok {
+		if !with.Recursive {
+			with.Recursive = w.Recursive
+		}
+		if w.Expression != nil {
+			with.Expression = w.Expression
+			with.Exprs = nil
+		} else if with.Expression == nil {
+			exprs := make([]Expression, len(w.Exprs)+len(with.Exprs))
+			copy(exprs, w.Exprs)
+			copy(exprs[len(w.Exprs):], with.Exprs)
+			with.Exprs = exprs
+		}
+	}
+	clause.Expression = with
+}
+
+// WithExpression with expression
+type WithExpression struct {
+	Name    string
+	Columns []string
+	Expr    Expression
+}
+
+func (with WithExpression) Build(builder Builder) {
+	if with.Name == "" || with.Expr == nil {
+		return
+	}
+
+	builder.WriteQuoted(with.Name)
+
+	if len(with.Columns) > 0 {
+		builder.WriteByte(' ')
+		builder.WriteByte('(')
+		for idx, column := range with.Columns {
+			if idx != 0 {
+				builder.WriteByte(',')
+			}
+			column = strings.TrimSpace(column)
+			builder.WriteQuoted(column)
+		}
+		builder.WriteByte(')')
+	}
+
+	builder.WriteString(" AS ")
+	builder.WriteByte('(')
+	with.Expr.Build(builder)
+	builder.WriteByte(')')
+}

--- a/clause/with_test.go
+++ b/clause/with_test.go
@@ -1,0 +1,104 @@
+package clause_test
+
+import (
+	"fmt"
+	"testing"
+
+	"gorm.io/gorm/clause"
+)
+
+func TestWith(t *testing.T) {
+	results := []struct {
+		Clauses []clause.Interface
+		Result  string
+		Vars    []interface{}
+	}{
+		{
+			[]clause.Interface{clause.With{Exprs: []clause.Expression{
+				clause.WithExpression{Name: "cte1", Columns: []string{"foo", "bar"}, Expr: clause.Expr{SQL: "SELECT 1, 2"}},
+				clause.WithExpression{Name: "cte2", Expr: clause.Expr{SQL: "SELECT 1"}},
+			}}},
+			"WITH `cte1` (`foo`,`bar`) AS (SELECT 1, 2),`cte2` AS (SELECT 1)",
+			nil,
+		},
+		{
+			[]clause.Interface{
+				clause.With{
+					Recursive: true,
+					Exprs:     []clause.Expression{clause.WithExpression{Name: "cte1", Expr: clause.Expr{SQL: "SELECT 1"}}},
+				},
+				clause.With{
+					Recursive: false,
+					Exprs:     []clause.Expression{clause.WithExpression{Name: "cte2", Expr: clause.Expr{SQL: "SELECT 2"}}},
+				},
+			},
+			"WITH RECURSIVE `cte1` AS (SELECT 1),`cte2` AS (SELECT 2)",
+			nil,
+		},
+		{
+			[]clause.Interface{
+				clause.With{
+					Expression: clause.Expr{SQL: "`cte1` AS (SELECT 1)"},
+				},
+				clause.With{
+					Exprs: []clause.Expression{clause.WithExpression{Name: "cte2", Expr: clause.Expr{SQL: "SELECT 2"}}},
+				},
+			},
+			"WITH `cte1` AS (SELECT 1)",
+			nil,
+		},
+		{
+			[]clause.Interface{
+				clause.With{
+					Exprs: []clause.Expression{clause.WithExpression{Name: "cte1", Expr: clause.Expr{SQL: "SELECT 1"}}},
+				},
+				clause.With{
+					Expression: clause.Expr{SQL: "`cte2` AS (SELECT 2)"},
+				},
+			},
+			"WITH `cte2` AS (SELECT 2)",
+			nil,
+		},
+		{
+			[]clause.Interface{clause.With{
+				Exprs: []clause.Expression{
+					clause.WithExpression{Name: "cte1", Columns: []string{"foo", "bar"}, Expr: clause.Expr{SQL: "SELECT 1, 2"}},
+				},
+				Expression: clause.Expr{SQL: "cte2 AS (SELECT 1)"},
+			}},
+			"WITH cte2 AS (SELECT 1)",
+			nil,
+		},
+		{
+			[]clause.Interface{clause.With{
+				Recursive:  false,
+				Exprs:      nil,
+				Expression: nil,
+			}},
+			"WITH",
+			nil,
+		},
+		{
+			[]clause.Interface{clause.With{Exprs: []clause.Expression{clause.WithExpression{
+				Name: "",
+				Expr: clause.Expr{SQL: "SELECT 1"},
+			}}}},
+			"WITH",
+			nil,
+		},
+		{
+			[]clause.Interface{clause.With{Exprs: []clause.Expression{clause.WithExpression{
+				Name: "cte1",
+				Expr: nil,
+			}}}},
+			"WITH",
+			nil,
+		},
+	}
+
+	for idx, result := range results {
+		t.Run(fmt.Sprintf("case #%v", idx), func(t *testing.T) {
+			checkBuildClauses(t, result.Clauses, result.Result, result.Vars)
+		})
+	}
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add WITH and WITH RECURSIVE support.
Modify clause.With and add WithExpression.
All code added in package clause are tested.
All edge case on DB.With are tested manually, see details below.

在 gorm 包内添加了 With 和 Recursive 两个 api 用于支持 with 查询。
在 clause 包内补充了 With clause 并且添加了 WithExpression expression。
clause 包代码已维护测试代码。
gorm 包代码的所有边界情况都经过手工测试，详见下方说明。

### User Case Description

``` go
// good cases
// db = db.With("cte", "SELECT id, `name` FROM users")
// db = db.With("cte", gorm.Expr("SELECT id, `name` FROM users"))
// db = db.With("cte", db.Select("id", "name").Table("users"))
// db = db.With("cte", "id", "name", "SELECT id, `name` FROM users")
// db = db.With("cte", "id, name", "SELECT id, `name` FROM users")
// db = db.With("cte", []string{"id", "name"}, "SELECT id, `name` FROM users")

// error cases
// db = db.With("cte")
// db = db.With("cte", "a", "b,c", "select 1,2,3")
// db = db.With("cte", "a", 2, "select 1,2")
// db = db.With("cte", []string{"a", "b,c"}, "select 1,2,3")
// db = db.With("cte", 1, "select 1")
// db = db.With("cte", []string{"a"})
// db = db.With("cte", []string{"a"}, "b", "SELECT 1, 2")

db = db.With("cte", "id", "name", "SELECT id, `name` FROM users")
db = db.Table("cte")
db = db.Find(&users)
// WITH `cte` (`id`,`name`) AS (SELECT id, `name` FROM users) SELECT * FROM `cte`
```
