### PR TITLE
fix: serializer use default valueOf in assignInterfacesToValue

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -240,6 +240,10 @@ func (tx *DB) assignInterfacesToValue(values ...interface{}) {
 						if f.Readable {
 							if v, isZero := f.ValueOf(tx.Statement.Context, reflectValue); !isZero {
 								if field := tx.Statement.Schema.LookUpField(f.Name); field != nil {
+									// serializer should use default implementation of ValueOf when assign to value
+									if field.Serializer != nil {
+										v, _ = field.DefaultValueOf(tx.Statement.Context, reflectValue)
+									}
 									tx.AddError(field.Set(tx.Statement.Context, tx.Statement.ReflectValue, v))
 								}
 							}

--- a/tests/serializer_test.go
+++ b/tests/serializer_test.go
@@ -83,4 +83,52 @@ func TestSerializer(t *testing.T) {
 	}
 
 	AssertEqual(t, result, data)
+
+}
+
+func TestSerializer_AssignFirstOrCreate(t *testing.T) {
+	DB.Migrator().DropTable(&SerializerStruct{})
+	if err := DB.Migrator().AutoMigrate(&SerializerStruct{}); err != nil {
+		t.Fatalf("no error should happen when migrate scanner, valuer struct, got error %v", err)
+	}
+
+	createdAt := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	data := SerializerStruct{
+		Name:            []byte("ag9920"),
+		Roles:           []string{"r1", "r2"},
+		Contracts:       map[string]interface{}{"name": "jing1", "age": 11},
+		EncryptedString: EncryptedString("pass"),
+		CreatedTime:     createdAt.Unix(),
+		JobInfo: Job{
+			Title:    "programmer",
+			Number:   9920,
+			Location: "Shadyside",
+			IsIntern: false,
+		},
+	}
+
+	// first time insert record
+	out := SerializerStruct{}
+	if err := DB.Assign(data).FirstOrCreate(&out).Error; err != nil {
+		t.Fatalf("failed to FirstOrCreate Assigned data, got error %v", err)
+	}
+	var result SerializerStruct
+	if err := DB.First(&result, out.ID).Error; err != nil {
+		t.Fatalf("failed to query data, got error %v", err)
+	}
+	AssertEqual(t, result, out)
+
+	//update record
+	data.Roles = append(data.Roles, "r3")
+	data.JobInfo.Location = "Gates Hillman Complex"
+	if err := DB.Assign(data).FirstOrCreate(&out).Error; err != nil {
+		t.Fatalf("failed to FirstOrCreate Assigned data, got error %v", err)
+	}
+	if err := DB.First(&result, out.ID).Error; err != nil {
+		t.Fatalf("failed to query data, got error %v", err)
+	}
+
+	AssertEqual(t, result.Roles, data.Roles)
+	AssertEqual(t, result.JobInfo.Location, data.JobInfo.Location)
 }


### PR DESCRIPTION

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fix the serializer feature in the scenario of Assign().FirstOrCreate() and provide the corresponding test case.


### User Case Description

My team uses Assign().FirstCreate() to implement CreateOrUpdateXXXX function. But when I try to run the following code (the intention was to simply insert the new record into the user_config table). I got an error message " failed to set value {"CommonItemList":[1,2,3,4]} to field UserConfig ". 

Then I dig into the FirstOrCreate() function, and compare the implementation with Create function. GORM would do a `field.ValueOf` to get the field and then call `field.Set` to actually set the data (in assignInterfacesToValue function). After assigning, GORM would call Create() to insert the data.

Since serializer's ValueOf returned a `schema.serializer` object, not the real FieldType (in this case, *main.UserConfig), it's not possible to assign the value to the field. 

`schema.serializer` serves like a wrapper for the field that requires serialization, it implements driver.Valuer interface.

But the corresponding ValueOf method will be called in `ConvertToCreateValues` function, which transforms `*main.UserConfig` to `schema.serializer`. So the early transformation in  assignInterfacesToValue in not needed, we just need the default ValueOf implementation.


```
package main

import (
	"context"
	"fmt"

	"gorm.io/driver/sqlite"
	"gorm.io/gorm"
)

type BizUserConfig struct {
	ID         int64       `gorm:"column:id;primary_key" json:"id"`
	UserConfig *UserConfig `gorm:"column:user_config;type:string;serializer:json" json:"user_config"`
}

type UserConfig struct {
	CommonItemList []int64
}

func (w *BizUserConfig) TableName() string {
	return "biz_user_config"
}

func CreateOrUpdateUserConfig(ctx context.Context, cfg *BizUserConfig) error {
	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
	if err != nil {
		return err
	}
	err = db.AutoMigrate(&BizUserConfig{})
	if err != nil {
		return err
	}
	out := BizUserConfig{}
	tx := db.
		Model(&BizUserConfig{}).
		Assign(cfg).
		FirstOrCreate(&out)

	if tx.Error != nil {
		return fmt.Errorf("gorm.FirstOrCreate err=%s", tx.Error)
	}
	return nil
}

func main() {
	ctx := context.Background()
	cfg := &BizUserConfig{
		UserConfig: &UserConfig{
			CommonItemList: []int64{1, 2, 3, 4},
		},
	}
	err := CreateOrUpdateUserConfig(ctx, cfg)
	if err != nil {
		fmt.Println("err", err)
	}
}
```

