### PR TITLE
test: fix test case and utils

### DIFF
--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -583,7 +583,9 @@ func TestPluck(t *testing.T) {
 	if err := DB.Model(User{}).Where("name like ?", "pluck-user%").Order("name desc").Pluck("name", &names2).Error; err != nil {
 		t.Errorf("got error when pluck name: %v", err)
 	}
-	AssertEqual(t, names, sort.Reverse(sort.StringSlice(names2)))
+
+	sort.Slice(names2, func(i, j int) bool { return names2[i] < names2[j] })
+	AssertEqual(t, names, names2)
 
 	var ids []int
 	if err := DB.Model(User{}).Where("name like ?", "pluck-user%").Pluck("id", &ids).Error; err != nil {

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -83,20 +83,22 @@ func AssertEqual(t *testing.T, got, expect interface{}) {
 		}
 
 		if reflect.ValueOf(got).Kind() == reflect.Struct {
-			if reflect.ValueOf(got).NumField() == reflect.ValueOf(expect).NumField() {
-				exported := false
-				for i := 0; i < reflect.ValueOf(got).NumField(); i++ {
-					if fieldStruct := reflect.ValueOf(got).Type().Field(i); ast.IsExported(fieldStruct.Name) {
-						exported = true
-						field := reflect.ValueOf(got).Field(i)
-						t.Run(fieldStruct.Name, func(t *testing.T) {
-							AssertEqual(t, field.Interface(), reflect.ValueOf(expect).Field(i).Interface())
-						})
+			if reflect.ValueOf(expect).Kind() == reflect.Struct {
+				if reflect.ValueOf(got).NumField() == reflect.ValueOf(expect).NumField() {
+					exported := false
+					for i := 0; i < reflect.ValueOf(got).NumField(); i++ {
+						if fieldStruct := reflect.ValueOf(got).Type().Field(i); ast.IsExported(fieldStruct.Name) {
+							exported = true
+							field := reflect.ValueOf(got).Field(i)
+							t.Run(fieldStruct.Name, func(t *testing.T) {
+								AssertEqual(t, field.Interface(), reflect.ValueOf(expect).Field(i).Interface())
+							})
+						}
 					}
-				}
 
-				if exported {
-					return
+					if exported {
+						return
+					}
 				}
 			}
 		}
@@ -107,6 +109,9 @@ func AssertEqual(t *testing.T, got, expect interface{}) {
 		} else if reflect.ValueOf(expect).Type().ConvertibleTo(reflect.ValueOf(got).Type()) {
 			expect = reflect.ValueOf(got).Convert(reflect.ValueOf(got).Type()).Interface()
 			isEqual()
+		} else {
+			t.Errorf("%v: expect: %+v, got %+v", utils.FileWithLineNum(), expect, got)
+			return
 		}
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
1. `AssertEqual` panic when `got` kind is `struct` but `expect` not.
2. when `got` and `expect` not `ConvertibleTo` at last, test case pass.
3. fix test case due to 2.
```go
...
// names is string slice ["pluck-user1","pluck-user2","pluck-user3"]
// sort.Reverse(sort.StringSlice(names2) result is interface ["pluck-user3","pluck-user2","pluck-user1"]
// but test pass
assertEqual(t, names, sort.Reverse(sort.StringSlice(names2)))
...
```

