### PR TITLE
style: fix linter check problem for NamingStrategy and onConflictOption

### DIFF
--- a/callbacks/associations.go
+++ b/callbacks/associations.go
@@ -323,7 +323,7 @@ func SaveAfterAssociations(create bool) func(db *gorm.DB) {
 	}
 }
 
-func onConflictOption(stmt *gorm.Statement, s *schema.Schema, selectColumns map[string]bool, restricted bool, defaultUpdatingColumns []string) (onConflict clause.OnConflict) {
+func onConflictOption(stmt *gorm.Statement, s *schema.Schema, defaultUpdatingColumns []string) (onConflict clause.OnConflict) {
 	if len(defaultUpdatingColumns) > 0 || stmt.DB.FullSaveAssociations {
 		onConflict.Columns = make([]clause.Column, 0, len(s.PrimaryFieldDBNames))
 		for _, dbName := range s.PrimaryFieldDBNames {
@@ -349,7 +349,7 @@ func saveAssociations(db *gorm.DB, rel *schema.Relationship, rValues reflect.Val
 
 	var (
 		selects, omits []string
-		onConflict     = onConflictOption(db.Statement, rel.FieldSchema, selectColumns, restricted, defaultUpdatingColumns)
+		onConflict     = onConflictOption(db.Statement, rel.FieldSchema, defaultUpdatingColumns)
 		refName        = rel.Name + "."
 		values         = rValues.Interface()
 	)

--- a/schema/naming.go
+++ b/schema/naming.go
@@ -85,9 +85,9 @@ func (ns NamingStrategy) IndexName(table, column string) string {
 }
 
 func (ns NamingStrategy) formatName(prefix, table, name string) string {
-	formattedName := strings.Replace(strings.Join([]string{
+	formattedName := strings.ReplaceAll(strings.Join([]string{
 		prefix, table, name,
-	}, "_"), ".", "_", -1)
+	}, "_"), ".", "_")
 
 	if utf8.RuneCountInString(formattedName) > 64 {
 		h := sha1.New()


### PR DESCRIPTION

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

No feature changes, just pure coding style fix in the following two places:
1. callbacks/associations.go
`onConflictOption` function doesn't need the `selectColumns` param for its own logic, this is unused. Removing the param helps reduce memory cost.

2. schema/naming.go
`formatName` method would do a strings.Replace to get `formattedName`, the num for replacement is -1, which means ReplaceAll. So I change the strings.Replace method call to strings.ReplaceAll to make it more straightforward and understandable. 
