### PR TITLE
style: fix coding typo

### DIFF
--- a/migrator/column_type.go
+++ b/migrator/column_type.go
@@ -44,7 +44,7 @@ func (ct ColumnType) DatabaseTypeName() string {
 	return ct.SQLColumnType.DatabaseTypeName()
 }
 
-// ColumnType returns the database type of the column. lke `varchar(16)`
+// ColumnType returns the database type of the column. like `varchar(16)`
 func (ct ColumnType) ColumnType() (columnType string, ok bool) {
 	return ct.ColumnTypeValue.String, ct.ColumnTypeValue.Valid
 }

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -43,10 +43,8 @@ func TestExceptionsWithInvalidSql(t *testing.T) {
 func TestSetAndGet(t *testing.T) {
 	if value, ok := DB.Set("hello", "world").Get("hello"); !ok {
 		t.Errorf("Should be able to get setting after set")
-	} else {
-		if value.(string) != "world" {
-			t.Errorf("Setted value should not be changed")
-		}
+	} else if value.(string) != "world" {
+		t.Errorf("Set value should not be changed")
 	}
 
 	if _, ok := DB.Get("non_existing"); ok {

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -258,7 +258,7 @@ func TestMigrateTable(t *testing.T) {
 	DB.Migrator().DropTable("new_table_structs")
 
 	if DB.Migrator().HasTable(&NewTableStruct{}) {
-		t.Fatal("should not found droped table")
+		t.Fatal("should not found dropped table")
 	}
 }
 

--- a/tests/sql_builder_test.go
+++ b/tests/sql_builder_test.go
@@ -360,7 +360,7 @@ func TestToSQL(t *testing.T) {
 	})
 	assertEqualSQL(t, `SELECT * FROM "users" WHERE id = 100 AND "users"."deleted_at" IS NULL ORDER BY age desc LIMIT 10`, sql)
 
-	// after model chagned
+	// after model changed
 	if DB.Statement.DryRun || DB.DryRun {
 		t.Fatal("Failed expect DB.DryRun and DB.Statement.ToSQL to be false")
 	}
@@ -426,13 +426,13 @@ func TestToSQL(t *testing.T) {
 	})
 	assertEqualSQL(t, `UPDATE "users" SET "name"='Foo',"age"=100 WHERE id = 100 AND "users"."deleted_at" IS NULL`, sql)
 
-	// after model chagned
+	// after model changed
 	if DB.Statement.DryRun || DB.DryRun {
 		t.Fatal("Failed expect DB.DryRun and DB.Statement.ToSQL to be false")
 	}
 }
 
-// assertEqualSQL for assert that the sql is equal, this method will ignore quote, and dialect speicals.
+// assertEqualSQL for assert that the sql is equal, this method will ignore quote, and dialect specials.
 func assertEqualSQL(t *testing.T, expected string, actually string) {
 	t.Helper()
 
@@ -440,7 +440,7 @@ func assertEqualSQL(t *testing.T, expected string, actually string) {
 	expected = replaceQuoteInSQL(expected)
 	actually = replaceQuoteInSQL(actually)
 
-	// ignore updated_at value, becase it's generated in Gorm inernal, can't to mock value on update.
+	// ignore updated_at value, because it's generated in Gorm internal, can't to mock value on update.
 	updatedAtRe := regexp.MustCompile(`(?i)"updated_at"=".+?"`)
 	actually = updatedAtRe.ReplaceAllString(actually, `"updated_at"=?`)
 	expected = updatedAtRe.ReplaceAllString(expected, `"updated_at"=?`)
@@ -462,7 +462,7 @@ func replaceQuoteInSQL(sql string) string {
 	// convert single quote into double quote
 	sql = strings.ReplaceAll(sql, `'`, `"`)
 
-	// convert dialect speical quote into double quote
+	// convert dialect special quote into double quote
 	switch DB.Dialector.Name() {
 	case "postgres":
 		sql = strings.ReplaceAll(sql, `"`, `"`)

--- a/tests/upsert_test.go
+++ b/tests/upsert_test.go
@@ -319,7 +319,7 @@ func TestUpdateWithMissWhere(t *testing.T) {
 	tx := DB.Session(&gorm.Session{DryRun: true}).Save(&user)
 
 	if err := tx.Error; err != nil {
-		t.Fatalf("failed to update user,missing where condtion,err=%+v", err)
+		t.Fatalf("failed to update user,missing where condition,err=%+v", err)
 	}
 
 	if !regexp.MustCompile("WHERE .id. = [^ ]+$").MatchString(tx.Statement.SQL.String()) {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
No logic update.
Fix all typos in current repo with the help of [typos](https://github.com/crate-ci/typos).

Two exception:
- Column names such as `actived` in logger/sql_test.go remain the same as before to ensure compatibility.
- Variables defined in functions remain the same, such as `datas` in callbacks/preload.go. 
