### PR TITLE
feat: alias map string interface

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -16,6 +16,15 @@ import (
 // for Config.cacheStore store PreparedStmtDB key
 const preparedStmtDBKey = "preparedStmt"
 
+// M is a convenient alias for a map[string]interface{} map, useful for
+// dealing with GORM in a native way.  For instance:
+//
+//     gorm.M{"a": 1, "b": true}
+//
+// There's no special handling for this type in addition to what's done anyway
+// for an equivalent map type.
+type M = map[string]interface{}
+
 // Config GORM config
 type Config struct {
 	// GORM perform single create, update, delete operations in transactions by default to ensure database data integrity

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -136,6 +136,25 @@ func TestCreateFromMap(t *testing.T) {
 	if err := DB.Where("name = ?", "create_from_map_3").First(&result3).Error; err != nil || result3.Age != 20 {
 		t.Fatalf("failed to query data after create from slice of map, got error %v", err)
 	}
+
+	datas2 := []gorm.M{
+		{"Name": "create_from_M_1", "Age": 21},
+		{"name": "create_from_M_2", "Age": 22},
+	}
+
+	if err := DB.Model(&User{}).Create(&datas2).Error; err != nil {
+		t.Fatalf("failed to create data from slice of map, got error: %v", err)
+	}
+
+	var result4 User
+	if err := DB.Where("name = ?", "create_from_M_1").First(&result4).Error; err != nil || result4.Age != 21 {
+		t.Fatalf("failed to query data after create from slice of map, got error %v", err)
+	}
+
+	var result5 User
+	if err := DB.Where("name = ?", "create_from_M_2").First(&result5).Error; err != nil || result5.Age != 22 {
+		t.Fatalf("failed to query data after create from slice of map, got error %v", err)
+	}
 }
 
 func TestCreateWithAssociations(t *testing.T) {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

close #5203
`gorm.M` is convenient alias for `map[string]interface{}` like `bson.M/gin.H/..`
Because the following writing is difficult to observe
```go
map[string]interface{}{} 
*map[string]interface{}{} 
[]map[string]interface{}{}
*[]map[string]interface{}{}
```

### User Case Description

```go
db.Model(&User{}).Create([]map[string]interface{}{
  {"Name": "jinzhu_1", "Age": 18},
  {"Name": "jinzhu_2", "Age": 20},
})

db.Model(&User{}).Create([]gorm.M{
  {"Name": "jinzhu_1", "Age": 18},
  {"Name": "jinzhu_2", "Age": 20},
})
```
