### PR TITLE
Offset issue resolved for scanning results back into struct

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -196,7 +196,7 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 				for idx, column := range columns {
 					if field := sch.LookUpField(column); field != nil && field.Readable {
 						if curIndex, ok := selectedColumnsMap[column]; ok {
-							for fieldIndex, selectField := range sch.Fields[curIndex:] {
+							for fieldIndex, selectField := range sch.Fields[curIndex+1:] {
 								if selectField.DBName == column && selectField.Readable {
 									selectedColumnsMap[column] = curIndex + fieldIndex + 1
 									fields[idx] = selectField

--- a/tests/scan_test.go
+++ b/tests/scan_test.go
@@ -184,11 +184,34 @@ func TestScanToEmbedded(t *testing.T) {
 		t.Errorf("Failed to run join query, got error: %v", err)
 	}
 
+	personMatched := false
+	addressMatched := false
+
 	for _, info := range personAddressInfoList {
-		if info.Person != nil {
-			if info.Person.ID == person1.ID && info.Person.Name != person1.Name {
+		if info.Person == nil {
+			t.Fatalf("Failed, expected not nil, got person nil")
+		}
+		if info.Address == nil {
+			t.Fatalf("Failed, expected not nil, got address nil")
+		}
+		if info.Person.ID == person1.ID {
+			personMatched = true
+			if info.Person.Name != person1.Name {
 				t.Errorf("Failed, expected %v, got %v", person1.Name, info.Person.Name)
 			}
 		}
+		if info.Address.ID == address1.ID {
+			addressMatched = true
+			if info.Address.Name != address1.Name {
+				t.Errorf("Failed, expected %v, got %v", address1.Name, info.Address.Name)
+			}
+		}
+	}
+
+	if !personMatched {
+		t.Errorf("Failed, no person matched")
+	}
+	if !addressMatched {
+		t.Errorf("Failed, no address matched")
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR fixes an accidentally introduced bug while merging PR https://github.com/go-gorm/gorm/pull/5143
The modified commit https://github.com/go-gorm/gorm/commit/f3e2da5ba359f0d672249fc52f54ae41c5a66d3a introduced an offset bug which resulted in `nil` for scanning results back into the struct.

It's my bad, I did not write extensive test cases which will catch this bug. Now I've updated test cases to account for all known cases that can happen.

close https://github.com/go-gorm/gorm/issues/5142

This fixes the demo PR for the playground - https://github.com/go-gorm/playground/pull/460
