### PR TITLE
Fix scanIntoStruct

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -74,7 +74,7 @@ func (db *DB) scanIntoStruct(rows Rows, reflectValue reflect.Value, values []int
 				relValue := joinFields[idx][0].ReflectValueOf(db.Statement.Context, reflectValue)
 				if relValue.Kind() == reflect.Ptr && relValue.IsNil() {
 					if value := reflect.ValueOf(values[idx]).Elem(); value.Kind() == reflect.Ptr && value.IsNil() {
-						return
+						continue
 					}
 
 					relValue.Set(reflect.New(relValue.Type().Elem()))

--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestJoins(t *testing.T) {
-	user := *GetUser("joins-1", Config{Company: true, Manager: true, Account: true})
+	user := *GetUser("joins-1", Config{Company: true, Manager: true, Account: true, NamedPet: false})
 
 	DB.Create(&user)
 
 	var user2 User
-	if err := DB.Joins("Company").Joins("Manager").Joins("Account").First(&user2, "users.name = ?", user.Name).Error; err != nil {
+	if err := DB.Joins("NamedPet").Joins("Company").Joins("Manager").Joins("Account").First(&user2, "users.name = ?", user.Name).Error; err != nil {
 		t.Fatalf("Failed to load with joins, got error: %v", err)
 	}
 


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

If there are more joins in the query, the scanIntoStruct function stops loading the data as soon as a null association is encountered. The test reproduces the case in question

### User Case Description
