### PR TITLE
fix: FindInBatches with offset limit

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -187,7 +187,7 @@ func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, bat
 		if limit, ok := c.Expression.(clause.Limit); ok {
 			totalSize = limit.Limit
 
-			if batchSize > totalSize {
+			if totalSize > 0 && batchSize > totalSize {
 				batchSize = totalSize
 			}
 

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -212,12 +212,11 @@ func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, bat
 		}
 
 		if totalSize > 0 {
-			if totalSize/batchSize == batch {
-				batchSize = totalSize % batchSize
-			}
-
 			if totalSize <= int(rowsAffected) {
 				break
+			}
+			if totalSize/batchSize == batch {
+				batchSize = totalSize % batchSize
 			}
 		}
 

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -330,14 +330,24 @@ func TestFindInBatchesWithOffsetLimit(t *testing.T) {
 		AssertEqual(t, results[i], targetUsers[i])
 	}
 
+	var sub1 []User
 	// limit < batchSize
-	if result := DB.Limit(5).Where("name = ?", users[0].Name).FindInBatches(&sub, 10, func(tx *gorm.DB, batch int) error {
+	if result := DB.Limit(5).Where("name = ?", users[0].Name).FindInBatches(&sub1, 10, func(tx *gorm.DB, batch int) error {
 		return nil
 	}); result.Error != nil || result.RowsAffected != 5 {
 		t.Errorf("Failed to batch find, got error %v, rows affected: %v", result.Error, result.RowsAffected)
 	}
 
-	if result := DB.Limit(4).Where("name = ?", users[0].Name).FindInBatches(&sub, 2, func(tx *gorm.DB, batch int) error {
+	var sub2 []User
+	// only offset
+	if result := DB.Offset(3).Where("name = ?", users[0].Name).FindInBatches(&sub2, 2, func(tx *gorm.DB, batch int) error {
+		return nil
+	}); result.Error != nil || result.RowsAffected != 7 {
+		t.Errorf("Failed to batch find, got error %v, rows affected: %v", result.Error, result.RowsAffected)
+	}
+
+	var sub3 []User
+	if result := DB.Limit(4).Where("name = ?", users[0].Name).FindInBatches(&sub3, 2, func(tx *gorm.DB, batch int) error {
 		return nil
 	}); result.Error != nil || result.RowsAffected != 4 {
 		t.Errorf("Failed to batch find, got error %v, rows affected: %v", result.Error, result.RowsAffected)

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -336,6 +336,12 @@ func TestFindInBatchesWithOffsetLimit(t *testing.T) {
 	}); result.Error != nil || result.RowsAffected != 5 {
 		t.Errorf("Failed to batch find, got error %v, rows affected: %v", result.Error, result.RowsAffected)
 	}
+
+	if result := DB.Limit(4).Where("name = ?", users[0].Name).FindInBatches(&sub, 2, func(tx *gorm.DB, batch int) error {
+		return nil
+	}); result.Error != nil || result.RowsAffected != 4 {
+		t.Errorf("Failed to batch find, got error %v, rows affected: %v", result.Error, result.RowsAffected)
+	}
 }
 
 func TestFindInBatchesWithError(t *testing.T) {

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -292,6 +292,52 @@ func TestFindInBatches(t *testing.T) {
 	}
 }
 
+func TestFindInBatchesWithOffsetLimit(t *testing.T) {
+	users := []User{
+		*GetUser("find_in_batches_with_offset_limit", Config{}),
+		*GetUser("find_in_batches_with_offset_limit", Config{}),
+		*GetUser("find_in_batches_with_offset_limit", Config{}),
+		*GetUser("find_in_batches_with_offset_limit", Config{}),
+		*GetUser("find_in_batches_with_offset_limit", Config{}),
+		*GetUser("find_in_batches_with_offset_limit", Config{}),
+		*GetUser("find_in_batches_with_offset_limit", Config{}),
+		*GetUser("find_in_batches_with_offset_limit", Config{}),
+		*GetUser("find_in_batches_with_offset_limit", Config{}),
+		*GetUser("find_in_batches_with_offset_limit", Config{}),
+	}
+
+	DB.Create(&users)
+
+	var (
+		sub, results []User
+		lastBatch    int
+	)
+
+	// offset limit
+	if result := DB.Offset(3).Limit(5).Where("name = ?", users[0].Name).FindInBatches(&sub, 2, func(tx *gorm.DB, batch int) error {
+		results = append(results, sub...)
+		lastBatch = batch
+		return nil
+	}); result.Error != nil || result.RowsAffected != 5 {
+		t.Errorf("Failed to batch find, got error %v, rows affected: %v", result.Error, result.RowsAffected)
+	}
+	if lastBatch != 3 {
+		t.Fatalf("incorrect last batch, expected: %v, got: %v", 3, lastBatch)
+	}
+
+	targetUsers := users[3:8]
+	for i := 0; i < len(targetUsers); i++ {
+		AssertEqual(t, results[i], targetUsers[i])
+	}
+
+	// limit < batchSize
+	if result := DB.Limit(5).Where("name = ?", users[0].Name).FindInBatches(&sub, 10, func(tx *gorm.DB, batch int) error {
+		return nil
+	}); result.Error != nil || result.RowsAffected != 5 {
+		t.Errorf("Failed to batch find, got error %v, rows affected: %v", result.Error, result.RowsAffected)
+	}
+}
+
 func TestFindInBatchesWithError(t *testing.T) {
 	if name := DB.Dialector.Name(); name == "sqlserver" {
 		t.Skip("skip sqlserver due to it will raise data race for invalid sql")


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
I think when the user uses `Offset` in `FindInBatches` the meaning is to skip the previous N records, and user uses `LIMIT` in `FindInBatches` the meaning is find total of N records.

close #5252

### User Case Description

<!-- Your use case -->
