### PR TITLE
index: add composite id

### DIFF
--- a/schema/index.go
+++ b/schema/index.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -31,7 +32,12 @@ func (schema *Schema) ParseIndexes() map[string]Index {
 
 	for _, field := range schema.Fields {
 		if field.TagSettings["INDEX"] != "" || field.TagSettings["UNIQUEINDEX"] != "" {
-			for _, index := range parseFieldIndexes(field) {
+			fieldIndexes, err := parseFieldIndexes(field)
+			if err != nil {
+				schema.err = err
+				break
+			}
+			for _, index := range fieldIndexes {
 				idx := indexes[index.Name]
 				idx.Name = index.Name
 				if idx.Class == "" {
@@ -82,7 +88,7 @@ func (schema *Schema) LookIndex(name string) *Index {
 	return nil
 }
 
-func parseFieldIndexes(field *Field) (indexes []Index) {
+func parseFieldIndexes(field *Field) (indexes []Index, err error) {
 	for _, value := range strings.Split(field.Tag.Get("gorm"), ";") {
 		if value != "" {
 			v := strings.Split(value, ":")
@@ -106,7 +112,20 @@ func parseFieldIndexes(field *Field) (indexes []Index) {
 				}
 
 				if name == "" {
-					name = field.Schema.namer.IndexName(field.Schema.Table, field.Name)
+					subName := field.Name
+					const key = "COMPOSITE"
+					if composite, found := settings[key]; found {
+						if len(composite) == 0 || composite == key {
+							err = fmt.Errorf(
+								"The composite tag of %s.%s cannot be empty",
+								field.Schema.Name,
+								field.Name)
+							return
+						}
+						subName = composite
+					}
+					name = field.Schema.namer.IndexName(
+						field.Schema.Table, subName)
 				}
 
 				if (k == "UNIQUEINDEX") || settings["UNIQUE"] != "" {
@@ -138,5 +157,6 @@ func parseFieldIndexes(field *Field) (indexes []Index) {
 		}
 	}
 
+	err = nil
 	return
 }

--- a/schema/index_test.go
+++ b/schema/index_test.go
@@ -19,6 +19,36 @@ type UserIndex struct {
 	OID          int64  `gorm:"index:idx_id;index:idx_oid,unique"`
 	MemberNumber string `gorm:"index:idx_id,priority:1"`
 	Name7        string `gorm:"index:type"`
+
+	// Composite Index: In the same level of struct.
+	Data0A string `gorm:"index:,composite:comp_id0"`
+	Data0B string `gorm:"index:,composite:comp_id0"`
+
+	// Composite Index: In the different levels of struct.
+	Data1A string `gorm:"index:,composite:comp_id1"`
+	CompIdxLevel1C
+
+	// Composite Index: Unique and priority
+	Data2A string `gorm:"index:,unique,composite:comp_id2,priority:2"`
+	CompIdxLevel2C
+}
+
+type CompIdxLevel1C struct {
+	CompIdxLevel1B
+	Data1C string `gorm:"index:,composite:comp_id1"`
+}
+
+type CompIdxLevel1B struct {
+	Data1B string `gorm:"index:,composite:comp_id1"`
+}
+
+type CompIdxLevel2C struct {
+	CompIdxLevel2B
+	Data2C string `gorm:"index:,unique,composite:comp_id2,priority:1"`
+}
+
+type CompIdxLevel2B struct {
+	Data2B string `gorm:"index:,unique,composite:comp_id2,priority:3"`
 }
 
 func TestParseIndex(t *testing.T) {
@@ -83,6 +113,36 @@ func TestParseIndex(t *testing.T) {
 			Name:   "type",
 			Type:   "",
 			Fields: []schema.IndexOption{{Field: &schema.Field{Name: "Name7"}}},
+		},
+		"idx_user_indices_comp_id0": {
+			Name: "idx_user_indices_comp_id0",
+			Type: "",
+			Fields: []schema.IndexOption{{
+				Field: &schema.Field{Name: "Data0A"},
+			}, {
+				Field: &schema.Field{Name: "Data0B"},
+			}},
+		},
+		"idx_user_indices_comp_id1": {
+			Name: "idx_user_indices_comp_id1",
+			Fields: []schema.IndexOption{{
+				Field: &schema.Field{Name: "Data1A"},
+			}, {
+				Field: &schema.Field{Name: "Data1B"},
+			}, {
+				Field: &schema.Field{Name: "Data1C"},
+			}},
+		},
+		"idx_user_indices_comp_id2": {
+			Name:  "idx_user_indices_comp_id2",
+			Class: "UNIQUE",
+			Fields: []schema.IndexOption{{
+				Field: &schema.Field{Name: "Data2C"},
+			}, {
+				Field: &schema.Field{Name: "Data2A"},
+			}, {
+				Field: &schema.Field{Name: "Data2B"},
+			}},
 		},
 	}
 

--- a/schema/index_test.go
+++ b/schema/index_test.go
@@ -20,15 +20,15 @@ type UserIndex struct {
 	MemberNumber string `gorm:"index:idx_id,priority:1"`
 	Name7        string `gorm:"index:type"`
 
-	// Composite Index: In the same level of struct.
+	// Composite Index: Flattened structure.
 	Data0A string `gorm:"index:,composite:comp_id0"`
 	Data0B string `gorm:"index:,composite:comp_id0"`
 
-	// Composite Index: In the different levels of struct.
+	// Composite Index: Nested structure.
 	Data1A string `gorm:"index:,composite:comp_id1"`
 	CompIdxLevel1C
 
-	// Composite Index: Unique and priority
+	// Composite Index: Unique and priority.
 	Data2A string `gorm:"index:,unique,composite:comp_id2,priority:2"`
 	CompIdxLevel2C
 }


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
In the issue #3973, if a struct with any composite indexes, these indexes will be invalid when the struct is embedded more than once. Because a composite index **must** specify its name, embedding more than once results in the duplicated name in db. Also if the name of index is specified manually, `NamingStrategy` will not be applied. Take the example of #3973:
```go
type Bar0 struct {
  Foo
}
type Bar1 struct {
  Foo
}
```
Both `Bar0` and `Bar1` will try to create an index of the same name `my_idx`. In this pull request, it provides a new field of index tag which is named to `composite`. It means the id of composite index. All fields which have the same composite id of the struct are put together to the same index, just like the original rule. But the improvement is it lets the most derived/embedding struct generates the name of index by `NamingStrategy`. For example:
```go
type Foo struct {
  IndexA int `gorm:"index:,unique,composite:myname"`
  IndexB int `gorm:"index:,unique,composite:myname"`
}
```
If the table `Foo` is created, the name of composite index will be `idx_foo_myname`.
```go
type Bar0 struct {
  Foo
}
type Bar1 struct {
  Foo
}
```
Respectively, the name of composite index are `idx_bar0_myname` and `idx_bar1_myname`.

`composite` only works if not specify the name of index, so it keeps the original API from being broken.