### PR TITLE
fix missing error-check in AutoMigrate

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -99,7 +99,10 @@ func (m Migrator) AutoMigrate(values ...interface{}) error {
 			}
 		} else {
 			if err := m.RunWithValue(value, func(stmt *gorm.Statement) (errr error) {
-				columnTypes, _ := m.DB.Migrator().ColumnTypes(value)
+				columnTypes, err := m.DB.Migrator().ColumnTypes(value)
+				if err != nil {
+					return err
+				}
 
 				for _, dbName := range stmt.Schema.DBNames {
 					field := stmt.Schema.FieldsByDBName[dbName]


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Error check was missing in AutoMigrate.
Due to this miss, errors of underlying drivers might not be delivered, resulting in misleading error texts.
Example of such behavior is showed in https://github.com/go-gorm/gorm/issues/5282, which is ```duplicate column name: id``` but real error was in SQLite driver, namely ```invalid ddl``` 

### User Case Description

<!-- Your use case -->
