### PR TITLE
Add new schema initials from the Go lint package

### DIFF
--- a/schema/naming.go
+++ b/schema/naming.go
@@ -101,7 +101,7 @@ func (ns NamingStrategy) formatName(prefix, table, name string) string {
 
 var (
 	// https://github.com/golang/lint/blob/master/lint.go#L770
-	commonInitialisms         = []string{"API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "LHS", "QPS", "RAM", "RHS", "RPC", "SLA", "SMTP", "SSH", "TLS", "TTL", "UID", "UI", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XSRF", "XSS"}
+	commonInitialisms         = []string{"ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "LHS", "QPS", "RAM", "RHS", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS"}
 	commonInitialismsReplacer *strings.Replacer
 )
 

--- a/schema/naming_test.go
+++ b/schema/naming_test.go
@@ -25,6 +25,7 @@ func TestToDBName(t *testing.T) {
 		"SHA256Hash":                "sha256_hash",
 		"SHA256HASH":                "sha256_hash",
 		"ThisIsActuallyATestSoWeMayBeAbleToUseThisCodeInGormPackageAlsoIdCanBeUsedAtTheEndAsID": "this_is_actually_a_test_so_we_may_be_able_to_use_this_code_in_gorm_package_also_id_can_be_used_at_the_end_as_id",
+		"UDP_TCP_SQL": "udp_tcp_sql",
 	}
 
 	ns := NamingStrategy{}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

There are new common initials added to the Go lint package, which are not included in the schema common initials. To be consistent, they are added to the schema package.

### User Case Description

This PR ensures table names that include initials are consistent with the initial accepted by the Go lint package.
