### PR TITLE
fix: AutoMigrate with special table name

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -759,7 +759,8 @@ func (m Migrator) ReorderModels(values []interface{}, autoAdd bool) (results []i
 			Statement: &gorm.Statement{DB: m.DB, Dest: value},
 		}
 		beDependedOn := map[*schema.Schema]bool{}
-		if err := dep.Parse(value); err != nil {
+		// support for special table name
+		if err := dep.ParseWithSpecialTableName(value, m.DB.Statement.Table); err != nil {
 			m.DB.Logger.Error(context.Background(), "failed to parse value %#v, got error %v", value, err)
 		}
 		if _, ok := parsedSchemas[dep.Statement.Schema]; ok {

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -636,3 +636,14 @@ func TestMigrateSerialColumn(t *testing.T) {
 		AssertEqual(t, v.ID, v.UID)
 	}
 }
+
+// https://github.com/go-gorm/gorm/issues/5300
+func TestMigrateWithSpecialName(t *testing.T) {
+	DB.AutoMigrate(&Coupon{})
+	DB.Table("coupon_product_1").AutoMigrate(&CouponProduct{})
+	DB.Table("coupon_product_2").AutoMigrate(&CouponProduct{})
+
+	AssertEqual(t, true, DB.Migrator().HasTable("coupons"))
+	AssertEqual(t, true, DB.Migrator().HasTable("coupon_product_1"))
+	AssertEqual(t, true, DB.Migrator().HasTable("coupon_product_2"))
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
close #5300

This is because `dep.Schema.Table` and `d.Table`are not equal, `table` name `orders` but `users.dep.table` name `order_1`

https://github.com/go-gorm/gorm/blob/master/migrator/migrator.go#L793

https://github.com/go-gorm/gorm/blob/master/migrator/migrator.go#L809

### User Case Description

<!-- Your use case -->
