### PR TITLE
fix: callbcak sort when using multiple plugin

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -246,7 +246,13 @@ func sortCallbacks(cs []*callback) (fns []func(*DB), err error) {
 		sortCallback  func(*callback) error
 	)
 	sort.Slice(cs, func(i, j int) bool {
-		return cs[j].before == "*" || cs[j].after == "*"
+		if cs[j].before == "*" && cs[i].before != "*" {
+			return true
+		}
+		if cs[j].after == "*" && cs[i].after != "*" {
+			return true
+		}
+		return false
 	})
 
 	for _, c := range cs {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
When using multiple plugins, they may register different callbacks with `Before("*")` or `After("*")`, the order will be out of order.

### User Case Description
current order
```go
createCallback.Before("*").Register("plugin_1_fn1", c1)
createCallback.After("*").Register("plugin_1_fn2", c2) //[c1 c2]
createCallback.Before("*").Register("plugin_2_fn1", c3)//[c1 c3 c2]
createCallback.After("*").Register("plugin_2_fn2", c4)//[c3 c1 c4 c2]
```
