### PR TITLE
fix: many2many auto migrate

### DIFF
--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -235,7 +235,8 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 			Name:    joinFieldName,
 			PkgPath: ownField.StructField.PkgPath,
 			Type:    ownField.StructField.Type,
-			Tag:     removeSettingFromTag(ownField.StructField.Tag, "column", "autoincrement", "index", "unique", "uniqueindex"),
+			Tag: removeSettingFromTag(appendSettingFromTag(ownField.StructField.Tag, "primaryKey"),
+				"column", "autoincrement", "index", "unique", "uniqueindex"),
 		})
 	}
 
@@ -258,7 +259,8 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 			Name:    joinFieldName,
 			PkgPath: relField.StructField.PkgPath,
 			Type:    relField.StructField.Type,
-			Tag:     removeSettingFromTag(relField.StructField.Tag, "column", "autoincrement", "index", "unique", "uniqueindex"),
+			Tag: removeSettingFromTag(appendSettingFromTag(relField.StructField.Tag, "primaryKey"),
+				"column", "autoincrement", "index", "unique", "uniqueindex"),
 		})
 	}
 

--- a/schema/utils.go
+++ b/schema/utils.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -57,6 +58,14 @@ func removeSettingFromTag(tag reflect.StructTag, names ...string) reflect.Struct
 		tag = reflect.StructTag(regexp.MustCompile(`(?i)(gorm:.*?)(`+name+`(:.*?)?)(;|("))`).ReplaceAllString(string(tag), "${1}${5}"))
 	}
 	return tag
+}
+
+func appendSettingFromTag(tag reflect.StructTag, value string) reflect.StructTag {
+	t := tag.Get("gorm")
+	if strings.Contains(t, value) {
+		return tag
+	}
+	return reflect.StructTag(fmt.Sprintf(`gorm:"%s;%s"`, value, t))
 }
 
 // GetRelationsValues get relations's values from a reflect value

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -657,3 +657,37 @@ func TestMigrateWithSpecialName(t *testing.T) {
 	AssertEqual(t, true, DB.Migrator().HasTable("coupon_product_1"))
 	AssertEqual(t, true, DB.Migrator().HasTable("coupon_product_2"))
 }
+
+// https://github.com/go-gorm/gorm/issues/5320
+func TestPrimarykeyID(t *testing.T) {
+	if DB.Dialector.Name() != "postgres" {
+		return
+	}
+
+	type MissPKLanguage struct {
+		ID   string `gorm:"type:uuid;default:uuid_generate_v4()"`
+		Name string
+	}
+
+	type MissPKUser struct {
+		ID              string           `gorm:"type:uuid;default:uuid_generate_v4()"`
+		MissPKLanguages []MissPKLanguage `gorm:"many2many:miss_pk_user_languages;"`
+	}
+
+	var err error
+	err = DB.Migrator().DropTable(&MissPKUser{}, &MissPKLanguage{})
+	if err != nil {
+		t.Fatalf("DropTable err:%v", err)
+	}
+
+	err = DB.AutoMigrate(&MissPKUser{}, &MissPKLanguage{})
+	if err != nil {
+		t.Fatalf("AutoMigrate err:%v", err)
+	}
+
+	// patch
+	err = DB.AutoMigrate(&MissPKUser{}, &MissPKLanguage{})
+	if err != nil {
+		t.Fatalf("AutoMigrate err:%v", err)
+	}
+}

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -680,6 +680,8 @@ func TestPrimarykeyID(t *testing.T) {
 		t.Fatalf("DropTable err:%v", err)
 	}
 
+	DB.Exec(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`)
+
 	err = DB.AutoMigrate(&MissPKUser{}, &MissPKLanguage{})
 	if err != nil {
 		t.Fatalf("AutoMigrate err:%v", err)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
In many2many situation, `ownField` and `relField` cannot be resolved to primary keys, but are composite primary keys in the database.

This issues cause by field size and field database size not equal when they cannot be resolved to primary keys.

I don't know how to test in other driver and does only postgres have this problem, if so, maybe we can change [here](https://github.com/go-gorm/postgres/blob/master/migrator.go#L204) to `columnType.PrimaryKey()` 

close #5320

### User Case Description

<!-- Your use case -->
