### PR TITLE
fix: tag defalut NULL and default not set should be same

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
+	"gorm.io/gorm/utils"
 )
 
 var (
@@ -448,7 +449,8 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 	}
 
 	// check default value
-	if v, ok := columnType.DefaultValue(); ok && v != field.DefaultValue {
+	if v, ok := columnType.DefaultValue(); ok &&
+		utils.CheckColumnDefaultNull(v) != utils.CheckColumnDefaultNull(field.DefaultValue) {
 		// not primary key
 		if !field.PrimaryKey {
 			alterColumn = true

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -449,11 +449,13 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 	}
 
 	// check default value
-	if v, ok := columnType.DefaultValue(); ok &&
-		utils.CheckColumnDefaultNull(v) != utils.CheckColumnDefaultNull(field.DefaultValue) {
-		// not primary key
-		if !field.PrimaryKey {
-			alterColumn = true
+	if v, ok := columnType.DefaultValue(); ok && v != field.DefaultValue {
+		// not all equal null
+		if !(utils.CheckColumnDefaultNull(v) && utils.CheckColumnDefaultNull(field.DefaultValue)) {
+			// not primary key
+			if !field.PrimaryKey {
+				alterColumn = true
+			}
 		}
 	}
 

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -659,6 +659,10 @@ func TestMigrateWithSpecialName(t *testing.T) {
 }
 
 func TestUniqueColumn(t *testing.T) {
+	if DB.Dialector.Name() != "mysql" {
+		return
+	}
+
 	type UniqueTest struct {
 		ID   string `gorm:"primary_key"`
 		Name string `gorm:"unique"`

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -657,3 +657,56 @@ func TestMigrateWithSpecialName(t *testing.T) {
 	AssertEqual(t, true, DB.Migrator().HasTable("coupon_product_1"))
 	AssertEqual(t, true, DB.Migrator().HasTable("coupon_product_2"))
 }
+
+func TestUniqueColumn(t *testing.T) {
+	type UniqueTest struct {
+		ID   string `gorm:"primary_key"`
+		Name string `gorm:"unique"`
+	}
+
+	var err error
+	err = DB.Migrator().DropTable(&UniqueTest{})
+	if err != nil {
+		t.Errorf("DropTable err:%v", err)
+	}
+
+	err = DB.AutoMigrate(&UniqueTest{})
+	if err != nil {
+		t.Fatalf("AutoMigrate err:%v", err)
+	}
+
+	err = DB.AutoMigrate(&UniqueTest{})
+	if err != nil {
+		t.Fatalf("AutoMigrate err:%v", err)
+	}
+
+	AssertEqual(t, true, DB.Migrator().HasIndex(&UniqueTest{}, "name"))
+	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest{}, "name_1"))
+	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest{}, "name_2"))
+	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest{}, "name_2"))
+
+	type UniqueTest2 struct {
+		ID   string `gorm:"primary_key"`
+		Name string `gorm:"unique;default:NULL"`
+	}
+
+	err = DB.Migrator().DropTable(&UniqueTest2{})
+	if err != nil {
+		t.Errorf("DropTable err:%v", err)
+	}
+
+	err = DB.AutoMigrate(&UniqueTest2{})
+	if err != nil {
+		t.Fatalf("AutoMigrate err:%v", err)
+	}
+
+	err = DB.AutoMigrate(&UniqueTest2{})
+	if err != nil {
+		t.Fatalf("AutoMigrate err:%v", err)
+	}
+
+	AssertEqual(t, true, DB.Migrator().HasIndex(&UniqueTest2{}, "name"))
+	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest2{}, "name_1"))
+	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest2{}, "name_2"))
+	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest2{}, "name_2"))
+}

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -687,7 +687,7 @@ func TestUniqueColumn(t *testing.T) {
 	AssertEqual(t, true, DB.Migrator().HasIndex(&UniqueTest{}, "name"))
 	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest{}, "name_1"))
 	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest{}, "name_2"))
-	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest{}, "name_2"))
+	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest{}, "name_3"))
 
 	type UniqueTest2 struct {
 		ID   string `gorm:"primary_key"`
@@ -712,5 +712,5 @@ func TestUniqueColumn(t *testing.T) {
 	AssertEqual(t, true, DB.Migrator().HasIndex(&UniqueTest2{}, "name"))
 	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest2{}, "name_1"))
 	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest2{}, "name_2"))
-	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest2{}, "name_2"))
+	AssertEqual(t, false, DB.Migrator().HasIndex(&UniqueTest2{}, "name_3"))
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -46,6 +46,13 @@ func CheckTruth(vals ...string) bool {
 	return false
 }
 
+func CheckColumnDefaultNull(val string) bool {
+	if val == "" || !strings.EqualFold(val, "NULL") {
+		return true
+	}
+	return false
+}
+
 func ToStringKey(values ...interface{}) string {
 	results := make([]string, len(values))
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -47,7 +47,7 @@ func CheckTruth(vals ...string) bool {
 }
 
 func CheckColumnDefaultNull(val string) bool {
-	if val == "" || !strings.EqualFold(val, "NULL") {
+	if val == "" || strings.EqualFold(val, "NULL") {
 		return true
 	}
 	return false


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
The following tags settings should be the same
```go
type UniqueTest struct {
		ID   string `gorm:"primary_key"`
		Name string `gorm:"unique"`
}

type UniqueTest2 struct {
		ID   string `gorm:"primary_key"`
		Name string `gorm:"unique;default:NULL"`
}
```
The first case will create duplicate index in `mariadb` just like the second case in other db.

close #5324

### User Case Description

<!-- Your use case -->
