### PR TITLE
fix: quote index when creating table

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -223,7 +223,7 @@ func (m Migrator) CreateTable(values ...interface{}) error {
 					}
 
 					createTableSQL += ","
-					values = append(values, clause.Expr{SQL: idx.Name}, tx.Migrator().(BuildIndexOptionsInterface).BuildIndexOptions(idx.Fields, stmt))
+					values = append(values, clause.Column{Name: idx.Name}, tx.Migrator().(BuildIndexOptionsInterface).BuildIndexOptions(idx.Fields, stmt))
 				}
 			}
 

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -262,6 +262,25 @@ func TestMigrateTable(t *testing.T) {
 	}
 }
 
+func TestMigrateWithQuotedIndex(t *testing.T) {
+	if DB.Dialector.Name() != "mysql" {
+		t.Skip()
+	}
+
+	type QuotedIndexStruct struct {
+		gorm.Model
+		Name string `gorm:"size:255;index:AS"` // AS is one of MySQL reserved words
+	}
+
+	if err := DB.Migrator().DropTable(&QuotedIndexStruct{}); err != nil {
+		t.Fatalf("Failed to drop table, got error %v", err)
+	}
+
+	if err := DB.AutoMigrate(&QuotedIndexStruct{}); err != nil {
+		t.Fatalf("Failed to auto migrate, but got error %v", err)
+	}
+}
+
 func TestMigrateIndexes(t *testing.T) {
 	type IndexStruct struct {
 		gorm.Model


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

quote index when creating table, just like CreateIndex

### User Case Description

before
```mysql
CREATE TABLE `quoted_index_structs` (
	`id` BIGINT UNSIGNED AUTO_INCREMENT,
	`name` VARCHAR ( 255 ),
	PRIMARY KEY ( `id` ),
  INDEX AS ( `name` ) 
)
```
after
```mysql
CREATE TABLE `quoted_index_structs` (
	`id` BIGINT UNSIGNED AUTO_INCREMENT,
	`name` VARCHAR ( 255 ),
	PRIMARY KEY ( `id` ),
  INDEX `AS` ( `name` ) 
)
```
