### PR TITLE
add UniqueIndex attribute to Field strucrt(The check error is not caused by my code)

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -440,7 +440,7 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 	}
 
 	// check unique
-	if unique, ok := columnType.Unique(); ok && unique != field.Unique {
+	if unique, ok := columnType.Unique(); ok && !(unique == field.Unique || unique == field.UniqueIndex) {
 		// not primary key
 		if !field.PrimaryKey {
 			alterColumn = true

--- a/schema/field.go
+++ b/schema/field.go
@@ -69,6 +69,7 @@ type Field struct {
 	DefaultValueInterface  interface{}
 	NotNull                bool
 	Unique                 bool
+	UniqueIndex            bool
 	Comment                string
 	Size                   int
 	Precision              int
@@ -114,6 +115,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		HasDefaultValue:        utils.CheckTruth(tagSetting["AUTOINCREMENT"]),
 		NotNull:                utils.CheckTruth(tagSetting["NOT NULL"], tagSetting["NOTNULL"]),
 		Unique:                 utils.CheckTruth(tagSetting["UNIQUE"]),
+		UniqueIndex:            utils.CheckTruth(tagSetting["UNIQUEINDEX"]),
 		Comment:                tagSetting["COMMENT"],
 		AutoIncrementIncrement: 1,
 	}

--- a/schema/field_test.go
+++ b/schema/field_test.go
@@ -332,3 +332,24 @@ func TestTypeAliasField(t *testing.T) {
 		checkSchemaField(t, alias, f, func(f *schema.Field) {})
 	}
 }
+
+type UniqueIndexStruct struct {
+	ID  int64 `gorm:"uniqueIndex:uk@test"`
+	Age int64 `gorm:"unique"`
+}
+
+func TestUniqueIndexTag(t *testing.T) {
+	schema, err := schema.Parse(&UniqueIndexStruct{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("Failed to parse TestUniqueIndexTag with permission, got error %v", err)
+	}
+
+	tests.AssertEqual(t, len(schema.Fields), 2)
+	for _, field := range schema.Fields {
+		if field.Name == "ID" {
+			tests.AssertEqual(t, field.UniqueIndex, true)
+		} else {
+			tests.AssertEqual(t, field.UniqueIndex, false)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

add UniqueIndex attribute to Field strucrt

<!--
provide a general description of the code changes in your pull request
-->

in some case, 
1. defind a struct field and set uniqueIndex tag ony. and call AutoMigrate
2. in some case, you must call AutoMigrage more than once. (eg, restart your app or change struct), the db return  unique = true, but field struct return unique = false.
3. it will be call AlterColumn. in some time(eg: partition table), it will be failure.

in schema/field.go
1.Add UniqueIndex field to Field's struct。
4.Resolve UniqueIndex value from StructField.

in migrator/migrator.go -> MigrateColumn
1.check unique, Check for the uniqueIndex and unique simultaneously


### User Case Description

<!-- Your use case -->

```go
type Order struct{
   ID int                     `gorm:"uniqueIndex:uk@order"`
   BizTime time.Time `gorm:"uniqueIndex:uk@order"`  // it's partition field.
}

// db init
// init PartitionTable 
//..... first
if err := db.AutoMigrate(&Order{}); err != nil{
   painc(err)
}

//... db.AutoMigrate Again. 
if err := db.AutoMigrate(&Order{}); err != nil{
   painc(err)  // it will be painc.  becouse alter Partition Field BizTime
}


```
