### PR TITLE
Fixed #5355 - Named variables don't work when followed by Windows CRLF line endings

### DIFF
--- a/clause/expression.go
+++ b/clause/expression.go
@@ -127,7 +127,7 @@ func (expr NamedExpr) Build(builder Builder) {
 		if v == '@' && !inName {
 			inName = true
 			name = []byte{}
-		} else if v == ' ' || v == ',' || v == ')' || v == '"' || v == '\'' || v == '`' || v == '\n' || v == ';' {
+		} else if v == ' ' || v == ',' || v == ')' || v == '"' || v == '\'' || v == '`' || v == '\r' || v == '\n' || v == ';' {
 			if inName {
 				if nv, ok := namedMap[string(name)]; ok {
 					builder.AddVar(builder, nv)

--- a/clause/expression_test.go
+++ b/clause/expression_test.go
@@ -95,6 +95,16 @@ func TestNamedExpr(t *testing.T) {
 		Result:       "name1 = ? AND name2 = ?;",
 		ExpectedVars: []interface{}{"jinzhu", "jinzhu"},
 	}, {
+		SQL:          "name1 = @name1\r\n AND name2 = @name2",
+		Vars:         []interface{}{map[string]interface{}{"name1": "jinzhu", "name2": "jinzhu"}},
+		Result:       "name1 = ?\r\n AND name2 = ?",
+		ExpectedVars: []interface{}{"jinzhu", "jinzhu"},
+	}, {
+		SQL:          "name1 = @name1\r\n AND name2 = @name2",
+		Vars:         []interface{}{map[string]interface{}{"name1": "jinzhu", "name2": "jinzhu"}},
+		Result:       "name1 = ?\r\n AND name2 = ?",
+		ExpectedVars: []interface{}{"jinzhu", "jinzhu"},
+	}, {
 		SQL:    "?",
 		Vars:   []interface{}{clause.Column{Table: "table", Name: "col"}},
 		Result: "`table`.`col`",

--- a/clause/expression_test.go
+++ b/clause/expression_test.go
@@ -100,9 +100,9 @@ func TestNamedExpr(t *testing.T) {
 		Result:       "name1 = ?\r\n AND name2 = ?",
 		ExpectedVars: []interface{}{"jinzhu", "jinzhu"},
 	}, {
-		SQL:          "name1 = @name1\r\n AND name2 = @name2",
+		SQL:          "name1 = @name1\r AND name2 = @name2",
 		Vars:         []interface{}{map[string]interface{}{"name1": "jinzhu", "name2": "jinzhu"}},
-		Result:       "name1 = ?\r\n AND name2 = ?",
+		Result:       "name1 = ?\r AND name2 = ?",
 		ExpectedVars: []interface{}{"jinzhu", "jinzhu"},
 	}, {
 		SQL:    "?",


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fixes https://github.com/go-gorm/gorm/issues/5355

### User Case Description
If a named variable is followed by Windows CRLF style line endings, the variable name will include the \r portion of the line ending which causes the variable lookup in the namedMap to fail. In my PR, I've updated the expression builder to look for \r in addition to \n.