### PR TITLE
fixed FirstOrCreate not handled error when table is not exists

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -354,6 +354,8 @@ func (db *DB) FirstOrCreate(dest interface{}, conds ...interface{}) (tx *DB) {
 		} else {
 			tx.Error = result.Error
 		}
+	} else {
+		tx.Error = result.Error
 	}
 	return tx
 }

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -351,8 +351,6 @@ func (db *DB) FirstOrCreate(dest interface{}, conds ...interface{}) (tx *DB) {
 			}
 
 			return tx.Model(dest).Updates(assigns)
-		} else {
-			tx.Error = result.Error
 		}
 	} else {
 		tx.Error = result.Error

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -476,6 +476,13 @@ func TestOmitWithCreate(t *testing.T) {
 	CheckUser(t, result2, user2)
 }
 
+func TestFirstOrCreateNotExistsTable(t *testing.T) {
+	company := Company{Name: "first_or_create_if_not_exists_table"}
+	if err := DB.Table("not_exists").FirstOrCreate(&company).Error; err == nil {
+		t.Errorf("not exists table, but err is nil")
+	}
+}
+
 func TestFirstOrCreateWithPrimaryKey(t *testing.T) {
 	company := Company{ID: 100, Name: "company100_with_primarykey"}
 	DB.FirstOrCreate(&company)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

In FirstOrCreate, `result.Error` of `queryTx.Find` is not nil, but not assign to tx.Error.
I fixed `result.Error` assign to `tx.Error`.

https://github.com/ophum/gorm/blob/8edc4825256aa0dcc0f74bd3e92b7fc59ba09241/finisher_api.go#L319

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

when using a table that does not exist.

<!-- Your use case -->
