### PR TITLE
fix: reset null value in slice

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -587,6 +587,8 @@ func (field *Field) setupValuerAndSetter() {
 			case **bool:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetBool(**data)
+				} else {
+					field.ReflectValueOf(ctx, value).SetBool(false)
 				}
 			case bool:
 				field.ReflectValueOf(ctx, value).SetBool(data)
@@ -606,6 +608,8 @@ func (field *Field) setupValuerAndSetter() {
 			case **int64:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetInt(**data)
+				} else {
+					field.ReflectValueOf(ctx, value).SetInt(0)
 				}
 			case int64:
 				field.ReflectValueOf(ctx, value).SetInt(data)
@@ -670,6 +674,8 @@ func (field *Field) setupValuerAndSetter() {
 			case **uint64:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetUint(**data)
+				} else {
+					field.ReflectValueOf(ctx, value).SetUint(0)
 				}
 			case uint64:
 				field.ReflectValueOf(ctx, value).SetUint(data)
@@ -722,6 +728,8 @@ func (field *Field) setupValuerAndSetter() {
 			case **float64:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetFloat(**data)
+				} else {
+					field.ReflectValueOf(ctx, value).SetFloat(0)
 				}
 			case float64:
 				field.ReflectValueOf(ctx, value).SetFloat(data)
@@ -766,6 +774,8 @@ func (field *Field) setupValuerAndSetter() {
 			case **string:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetString(**data)
+				} else {
+					field.ReflectValueOf(ctx, value).SetString("")
 				}
 			case string:
 				field.ReflectValueOf(ctx, value).SetString(data)

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -1258,3 +1258,54 @@ func TestQueryScannerWithSingleColumn(t *testing.T) {
 
 	AssertEqual(t, result2.data, 20)
 }
+
+func TestQueryResetNullValue(t *testing.T) {
+	type QueryResetNullValue struct {
+		ID      int
+		Name    string     `gorm:"default:NULL"`
+		Flag    bool       `gorm:"default:NULL"`
+		Number1 int64      `gorm:"default:NULL"`
+		Number2 uint64     `gorm:"default:NULL"`
+		Number3 float64    `gorm:"default:NULL"`
+		Now     *time.Time `gorm:"defalut:NULL"`
+	}
+
+	DB.Migrator().DropTable(&QueryResetNullValue{})
+	DB.AutoMigrate(&QueryResetNullValue{})
+
+	now := time.Now()
+	q1 := QueryResetNullValue{
+		Name:    "name",
+		Flag:    true,
+		Number1: 100,
+		Number2: 200,
+		Number3: 300.1,
+		Now:     &now,
+	}
+
+	q2 := QueryResetNullValue{}
+
+	var err error
+	err = DB.Create(&q1).Error
+	if err != nil {
+		t.Errorf("failed to create:%v", err)
+	}
+
+	err = DB.Create(&q2).Error
+	if err != nil {
+		t.Errorf("failed to create:%v", err)
+	}
+
+	var qs []QueryResetNullValue
+	err = DB.Find(&qs).Error
+	if err != nil {
+		t.Errorf("failed to find:%v", err)
+	}
+
+	if len(qs) != 2 {
+		t.Fatalf("find count not equal:%d", len(qs))
+	}
+
+	AssertEqual(t, q1, qs[0])
+	AssertEqual(t, q2, qs[1])
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
closes #5415 
closes #5414

Slice elem will reuse after #5388, so the null value should be updated, and we should change judge `relValue.IsNil()` in join.

Seems like a breaking change now, I'm not sure if revert is required as user-defined Serializers may also be affected

### User Case Description

<!-- Your use case -->
