### PR TITLE
feat: use callback to handle transaction

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -91,7 +91,7 @@ func (p *processor) Begin(tx *DB, opt *sql.TxOptions) *DB {
 	}
 
 	if err != nil {
-		tx.AddError(err)
+		_ = tx.AddError(err)
 	}
 
 	return tx

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -619,27 +619,13 @@ func (db *DB) Begin(opts ...*sql.TxOptions) *DB {
 		// clone statement
 		tx  = db.getInstance().Session(&Session{Context: db.Statement.Context, NewDB: db.clone == 1})
 		opt *sql.TxOptions
-		err error
 	)
 
 	if len(opts) > 0 {
 		opt = opts[0]
 	}
 
-	switch beginner := tx.Statement.ConnPool.(type) {
-	case TxBeginner:
-		tx.Statement.ConnPool, err = beginner.BeginTx(tx.Statement.Context, opt)
-	case ConnPoolBeginner:
-		tx.Statement.ConnPool, err = beginner.BeginTx(tx.Statement.Context, opt)
-	default:
-		err = ErrInvalidTransaction
-	}
-
-	if err != nil {
-		tx.AddError(err)
-	}
-
-	return tx
+	return tx.callbacks.Transaction().Begin(tx, opt)
 }
 
 // Commit commit a transaction


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Make transaction have before and after hooks, so plugin can hack before
or after transaction.

### User Case Description

We hava a gorm plugin to handle database sharding. We save SaaS tenant info into context, then plugin can get the tenant in before hooks and determine which database shard to select. For now, `Transaction` api is not invoked through callbacks, we have to wrap gorm.ConnPool  as gorm.ConnPoolBeginner to select database.
