### PR TITLE
fix: return id which have type string after created

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -239,6 +239,14 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 				field.HasDefaultValue = true
 				field.AutoIncrement = true
 			}
+		case String:
+			if _, ok := field.TagSettings["PRIMARYKEY"]; !ok {
+				if !field.HasDefaultValue || field.DefaultValueInterface != nil {
+					schema.FieldsWithDefaultDBValue = append(schema.FieldsWithDefaultDBValue, field)
+				}
+
+				field.HasDefaultValue = true
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Returning the ID which has uuid.UUID or String type after created

### User Case Description

<!-- Your use case -->
I have a sql script like the below and run on Postgres DB:
```sql
CREATE TABLE "users" (
    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
    "email" TEXT NOT NULL,
    "password" TEXT,
    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
    "updated_at" TIMESTAMP(3) NOT NULL,
    "deleted_at" TIMESTAMP(3),
    CONSTRAINT "users_pkey" primary KEY ("id")
);
```
In the golang code, I created a struct like this:
```go
type User struct {
	ID        uuid.UUID      `json:"id"`
	Email     string         `json:"email"`
	Password  string         `json:"password"`
	CreatedAt time.Time      `json:"created_at"`
	UpdatedAt time.Time      `json:"updated_at"`
	DeletedAt gorm.DeletedAt `json:"deleted_at"`
}
```

I use this method to create user:
```go
user := &User{
         Email:    newUser.Email,
         Password: newUser.Password,
}
result := db.Select("Email", "Password").Create(user)
fmt.Println(user)
```
The ID was not return after created, so that the user.ID has zero value (not expected).
 
