### PR TITLE
use callbacks.Begin as a hook to handle begin operation

### DIFF
--- a/callbacks/callbacks.go
+++ b/callbacks/callbacks.go
@@ -80,4 +80,7 @@ func RegisterDefaultCallbacks(db *gorm.DB, config *Config) {
 	rawCallback := db.Callback().Raw()
 	rawCallback.Register("gorm:raw", RawExec)
 	rawCallback.Clauses = config.QueryClauses
+
+	transactionCallback := db.Callback().Transaction()
+	transactionCallback.Register("gorm:begin", Begin)
 }


### PR DESCRIPTION
make transaction support hooks

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Use callbacks.Begin as hook to handle real transaction operation, make transaction support before/after hooks.

### User Case Description

- Database sharding: shard database by info in context
- Implement distributed transaction
