### PR TITLE
Adjust ToStringKey use unpack params, fix  pass []any as any in variadic function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.txt
 _book
 .idea
 vendor
+.vscode

--- a/callbacks/associations.go
+++ b/callbacks/associations.go
@@ -206,7 +206,7 @@ func SaveAfterAssociations(create bool) func(db *gorm.DB) {
 								}
 							}
 
-							cacheKey := utils.ToStringKey(relPrimaryValues)
+							cacheKey := utils.ToStringKey(relPrimaryValues...)
 							if len(relPrimaryValues) != len(rel.FieldSchema.PrimaryFields) || !identityMap[cacheKey] {
 								identityMap[cacheKey] = true
 								if isPtr {
@@ -292,7 +292,7 @@ func SaveAfterAssociations(create bool) func(db *gorm.DB) {
 								}
 							}
 
-							cacheKey := utils.ToStringKey(relPrimaryValues)
+							cacheKey := utils.ToStringKey(relPrimaryValues...)
 							if len(relPrimaryValues) != len(rel.FieldSchema.PrimaryFields) || !identityMap[cacheKey] {
 								identityMap[cacheKey] = true
 								distinctElems = reflect.Append(distinctElems, elem)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -12,3 +12,20 @@ func TestIsValidDBNameChar(t *testing.T) {
 		}
 	}
 }
+
+func TestToStringKey(t *testing.T) {
+	cases := []struct {
+		values []interface{}
+		key    string
+	}{
+		{[]interface{}{"a"}, "a"},
+		{[]interface{}{1, 2, 3}, "1_2_3"},
+		{[]interface{}{[]interface{}{1, 2, 3}}, "[1 2 3]"},
+		{[]interface{}{[]interface{}{"1", "2", "3"}}, "[1 2 3]"},
+	}
+	for _, c := range cases {
+		if key := ToStringKey(c.values...); key != c.key {
+			t.Errorf("%v: expected %v, got %v", c.values, c.key, key)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

i am writing a [linter](https://github.com/alingse/asasalint) to lint my silly bug in work.
and run github Actions for some  top go packages, gorm failed [here](https://github.com/alingse/asasalint/runs/7263106786?check_suite_focus=true)

```
Error: /home/runner/work/asasalint/asasalint/gorm/callbacks/associations.go:209:38: pass []any as any to func ToStringKey func(values ...interface{}) string
Error: /home/runner/work/asasalint/asasalint/gorm/callbacks/associations.go:29[5](https://github.com/alingse/asasalint/runs/7263106786?check_suite_focus=true#step:7:6):38: pass []any as any to func ToStringKey func(values ...interface{}) string
Error: /home/runner/work/asasalint/asasalint/gorm/migrator/migrator.go:201:29: pass []any as any to func append func([]interface{}, ...interface{}) []interface{}
```
these three is not bug (`migrator/migrator.go:201` is by desgin)

ToStringKey's current usage worked, but change to use unpacked params might be better.

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
