### PR TITLE
Update Delete Godoc to describe soft delete behaviour

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -388,7 +388,9 @@ func (db *DB) UpdateColumns(values interface{}) (tx *DB) {
 	return tx.callbacks.Update().Execute(tx)
 }
 
-// Delete delete value match given conditions, if the value has primary key, then will including the primary key as condition
+// Delete deletes value matching given conditions. If value contains primary key it is included in the conditions.
+// If value includes a deleted_at field, then Delete performs a soft delete instead by setting deleted_at with the current
+// time if null.
 func (db *DB) Delete(value interface{}, conds ...interface{}) (tx *DB) {
 	tx = db.getInstance()
 	if len(conds) > 0 {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

gorm's Delete() method performs either a soft or hard delete, depending on whether the passed data model includes a `deletedAt` field.  This is detailed [here in the docs](https://gorm.io/docs/delete.html#Soft-Delete) and this PR adds this to the Godoc comment.

I've also cleaned up the grammar to make the language of the comment consistent.

### User Case Description

As a new user to gorm I found myself referencing the external docs at gorm.io to learn the behaviour of this method.  Adding key details to inline documentation improves the user experience.

If there is an appetite for contribution to documentation I would like to submit more PRs like this across the codebase.
