### PR TITLE
use TableName() if struct implement `Tabler` interface

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -394,10 +394,14 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 						selected := selectedColumns[field.DBName] || selectedColumns[field.Name]
 						if selected || (!restricted && field.Readable) {
 							if v, isZero := field.ValueOf(stmt.Context, reflectValue); !isZero || selected {
+								tableName := clause.CurrentTable
+								if e, ok := arg.(schema.Tabler); ok {
+									tableName = e.TableName()
+								}
 								if field.DBName != "" {
-									conds = append(conds, clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: field.DBName}, Value: v})
+									conds = append(conds, clause.Eq{Column: clause.Column{Table: tableName, Name: field.DBName}, Value: v})
 								} else if field.DataType != "" {
-									conds = append(conds, clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: field.Name}, Value: v})
+									conds = append(conds, clause.Eq{Column: clause.Column{Table: tableName, Name: field.Name}, Value: v})
 								}
 							}
 						}


### PR DESCRIPTION
### What did this pull request do?

For `where` with struct as first argument, if the structure implement `Tabler` interface, we could use the table name.

### User Case Description

```go

type StorageDepartmentUserRole struct {
	DepartmentId *string `gorm:"column:department_id"`
	UserId       *uint64 `gorm:"column:user_id"`
}

func (w StorageDepartmentUserRole) TableName() string {
	return "department_user_role"
}

type StorageUser struct {
	Id       *uint64 `gorm:"column:id"`
	Username *string `gorm:"column:username"`
}

func (u StorageUser) TableName() string {
	return "user"
}

type GetWorkspaceUserRoleRequest struct {
	WorkspaceUserRoleOption *StorageDepartmentUserRole
	UserOption              *StorageUser
}

func ToPtrString(s string) *string {
	return &s
}

func ToPtrUint64(v uint64) *uint64 {
	return &v
}

func main() {
	db, err := gorm.Open(sqlite.Open("test.db"), &gorm.Config{})
	if err != nil {
		panic("failed to connect database")
	}

	var f StorageDepartmentUserRole

	s := db.ToSQL(func(tx *gorm.DB) *gorm.DB {
		return db.
			Model(&StorageWorkspaceUserRole{}).
			Joins("INNER JOIN mpbackend_user ON mpbackend_user.id = mpbackend_workspace_user_role.user_id").
			Where(&StorageDepartmentUserRole{
				DepartmentId: ToPtrString("Septem-Department"),
			}).
			Where(&StorageUser{
				Id: ToPtrUint64(5),
			}).
			Take(&f)
	})

	fmt.Println(s)
}
```

Output: 
```sql
SELECT `department_user_role`.`department_id`,`department_user_role`.`user_id` 
FROM `department_user_role` INNER JOIN mpbackend_user ON mpbackend_user.id = mpbackend_workspace_user_role.user_id 
WHERE `department_user_role`.`department_id` = "Septem-Department" AND `user`.`id` = 5 LIMIT 1```

