### PR TITLE
Replace `ioutil.Discard` with `io.Discard`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gorm.io/gorm
 
-go 1.14
+go 1.16
 
 require (
 	github.com/jinzhu/inflection v1.0.0

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -68,8 +68,8 @@ type Interface interface {
 }
 
 var (
-	// Discard Discard logger will print any log to ioutil.Discard
-	Discard = New(log.New(ioutil.Discard, "", log.LstdFlags), Config{})
+	// Discard Discard logger will print any log to io.Discard
+	Discard = New(log.New(io.Discard, "", log.LstdFlags), Config{})
 	// Default Default logger
 	Default = New(log.New(os.Stdout, "\r\n", log.LstdFlags), Config{
 		SlowThreshold:             200 * time.Millisecond,

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module gorm.io/gorm/tests
 
-go 1.14
+go 1.16
 
 require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

`"io/ioutil"` has been deprecated since Go 1.16.
https://tip.golang.org/doc/go1.16#ioutil

### User Case Description

<!-- Your use case -->

N/A