### PR TITLE
Refactor: redundant type from composite literal

### DIFF
--- a/statement_test.go
+++ b/statement_test.go
@@ -37,18 +37,18 @@ func TestWhereCloneCorruption(t *testing.T) {
 
 func TestNameMatcher(t *testing.T) {
 	for k, v := range map[string][]string{
-		"table.name":         []string{"table", "name"},
-		"`table`.`name`":     []string{"table", "name"},
-		"'table'.'name'":     []string{"table", "name"},
-		"'table'.name":       []string{"table", "name"},
-		"table1.name_23":     []string{"table1", "name_23"},
-		"`table_1`.`name23`": []string{"table_1", "name23"},
-		"'table23'.'name_1'": []string{"table23", "name_1"},
-		"'table23'.name1":    []string{"table23", "name1"},
-		"'name1'":            []string{"", "name1"},
-		"`name_1`":           []string{"", "name_1"},
-		"`Name_1`":           []string{"", "Name_1"},
-		"`Table`.`nAme`":     []string{"Table", "nAme"},
+		"table.name":         {"table", "name"},
+		"`table`.`name`":     {"table", "name"},
+		"'table'.'name'":     {"table", "name"},
+		"'table'.name":       {"table", "name"},
+		"table1.name_23":     {"table1", "name_23"},
+		"`table_1`.`name23`": {"table_1", "name23"},
+		"'table23'.'name_1'": {"table23", "name_1"},
+		"'table23'.name1":    {"table23", "name1"},
+		"'name1'":            {"", "name1"},
+		"`name_1`":           {"", "name_1"},
+		"`Name_1`":           {"", "Name_1"},
+		"`Table`.`nAme`":     {"Table", "nAme"},
 	} {
 		if matches := nameMatcher.FindStringSubmatch(k); len(matches) < 3 || matches[1] != v[0] || matches[2] != v[1] {
 			t.Errorf("failed to match value: %v, got %v, expect: %v", k, matches, v)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

redundant type from array, slice, or map composite literal.
### User Case Description

N/A