### PR TITLE
fix: when `id`(PrioritizedPrimaryField) datatype is bigint, AUTO_INCREMENT is missed

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -229,7 +229,7 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 	}
 
 	if field := schema.PrioritizedPrimaryField; field != nil {
-		switch field.GORMDataType {
+		switch field.DataType {
 		case Int, Uint:
 			if _, ok := field.TagSettings["AUTOINCREMENT"]; !ok {
 				if !field.HasDefaultValue || field.DefaultValueInterface != nil {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

change PrioritizedPrimaryField datatype check from `GORMDataType` to `DataType`,
that's mean datatype is `int` or `uint` AUTO_INCREMENT will be added.

```go
package main

import (
	"log"

	"gorm.io/driver/mysql"
	"gorm.io/gorm"
)

// Node 节点数据
type Node struct {
	//good case
	//ID int64 `gorm:"primaryKey;column:id;type:int;AUTO_INCREMENT"`

	//bad case
	ID int64  `gorm:"column:id;type:bigint;primaryKey;AUTO_INCREMENT"`
	IP string `gorm:"column:ip;type:varchar(32);default:null"`
}

func main() {
	dsn := "root:12345678@tcp(127.0.0.1:3306)/k8s?charset=utf8mb4&parseTime=True&loc=Local"
	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
	if err != nil {
		log.Println(err)
		return
	}

	if err := db.Debug().AutoMigrate(Node{}); err != nil {
		log.Println(err)
		return
	}

	node := Node{IP: "1.2.3.4"}
	result := db.Create(&node)
	log.Println(node.ID, result.Error, result.RowsAffected)
}
```
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/9859316/184568762-1f385ffd-3ca8-4304-a03b-392b96caaac8.png">

### User Case Description

<!-- Your use case -->
> bad case: 1
```go
ID              int64  `gorm:"column:id;type:bigint;primaryKey;AUTO_INCREMENT"` 
```
> bad case: 2
```go
ID              int64  `gorm:"column:id;type:bigint(20);primaryKey;AUTO_INCREMENT"` 
```

> bad case: 3
```go
ID              int64  `gorm:"column:id;type:int(24);primaryKey;AUTO_INCREMENT"` 
```

> good case
```go
ID              int64  `gorm:"column:id;type:int;primaryKey;AUTO_INCREMENT"`  
```
