### PR TITLE
feat: migrator support type aliases

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -68,6 +68,7 @@ type Migrator interface {
 	// Database
 	CurrentDatabase() string
 	FullDataTypeOf(*schema.Field) clause.Expr
+	GetTypeAliases(databaseTypeName string) []string
 
 	// Tables
 	CreateTable(dst ...interface{}) error

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -408,9 +408,21 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 
 	alterColumn := false
 
-	// check type
-	if !field.PrimaryKey && !strings.HasPrefix(fullDataType, realDataType) {
-		alterColumn = true
+	if !field.PrimaryKey {
+		// check type
+		var isSameType bool
+		aliases := m.DB.Migrator().GetTypeAliases(realDataType)
+		aliases = append(aliases, realDataType)
+		for _, alias := range aliases {
+			if strings.HasPrefix(fullDataType, alias) {
+				isSameType = true
+				break
+			}
+		}
+
+		if !isSameType {
+			alterColumn = true
+		}
 	}
 
 	// check size
@@ -862,4 +874,9 @@ func (m Migrator) CurrentTable(stmt *gorm.Statement) interface{} {
 // GetIndexes return Indexes []gorm.Index and execErr error
 func (m Migrator) GetIndexes(dst interface{}) ([]gorm.Index, error) {
 	return nil, errors.New("not support")
+}
+
+// GetTypeAliases return database type aliases
+func (m Migrator) GetTypeAliases(databaseTypeName string) []string {
+	return nil
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

There are many aliases for database types, in order to avoid the same type of column alter.
For example
```log
-- pgsql
smallint <-> int2
integer <-> int4 
bigint <-> int8
decimal <->  numeric

-- mysql
bool <-> tinyint
```

related to 
https://github.com/go-gorm/gorm/issues/5625
https://github.com/go-gorm/postgres/pull/111
https://github.com/go-gorm/gorm/pull/5499
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
