### PR TITLE
#5635 Add Config.DryRunMigration to prevent actually changing the schema when doing AutoMigrate()

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -31,6 +31,8 @@ type Config struct {
 	NowFunc func() time.Time
 	// DryRun generate sql without execute
 	DryRun bool
+	// DryRunMigration runs AutoMigrate() without changing schema
+	DryRunMigration bool
 	// PrepareStmt executes the given query in cached statement
 	PrepareStmt bool
 	// DisableAutomaticPing
@@ -457,10 +459,12 @@ func (db *DB) Use(plugin Plugin) error {
 // ToSQL for generate SQL string.
 //
 // db.ToSQL(func(tx *gorm.DB) *gorm.DB {
-// 		return tx.Model(&User{}).Where(&User{Name: "foo", Age: 20})
-// 			.Limit(10).Offset(5)
-//			.Order("name ASC")
-//			.First(&User{})
+//
+//	return tx.Model(&User{}).Where(&User{Name: "foo", Age: 20})
+//		.Limit(10).Offset(5)
+//		.Order("name ASC")
+//		.First(&User{})
+//
 // })
 func (db *DB) ToSQL(queryFn func(tx *DB) *DB) string {
 	tx := queryFn(db.Session(&Session{DryRun: true, SkipDefaultTransaction: true}))


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add a flag `Config.DryRunMigration` to let AutoMigrate() return an error before changing the schema.

### User Case Description

See #5635.
