### PR TITLE
AutoMigrate() should always migrate checks, even there is no relationship constraints.

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -135,12 +135,12 @@ func (m Migrator) AutoMigrate(values ...interface{}) error {
 							}
 						}
 					}
+				}
 
-					for _, chk := range stmt.Schema.ParseCheckConstraints() {
-						if !tx.Migrator().HasConstraint(value, chk.Name) {
-							if err := tx.Migrator().CreateConstraint(value, chk.Name); err != nil {
-								return err
-							}
+				for _, chk := range stmt.Schema.ParseCheckConstraints() {
+					if !tx.Migrator().HasConstraint(value, chk.Name) {
+						if err := tx.Migrator().CreateConstraint(value, chk.Name); err != nil {
+							return err
 						}
 					}
 				}

--- a/tests/postgres_test.go
+++ b/tests/postgres_test.go
@@ -63,13 +63,13 @@ func TestPostgres(t *testing.T) {
 }
 
 type Post struct {
-	ID         uuid.UUID `gorm:"primary_key;type:uuid;default:uuid_generate_v4();autoincrement"`
+	ID         uuid.UUID `gorm:"primary_key;type:uuid;default:uuid_generate_v4();"`
 	Title      string
 	Categories []*Category `gorm:"Many2Many:post_categories"`
 }
 
 type Category struct {
-	ID    uuid.UUID `gorm:"primary_key;type:uuid;default:uuid_generate_v4();autoincrement"`
+	ID    uuid.UUID `gorm:"primary_key;type:uuid;default:uuid_generate_v4();"`
 	Title string
 	Posts []*Post `gorm:"Many2Many:post_categories"`
 }


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fix bug: `AutoMigrate()` doesn't update check constraints if there is no relationship constraints.

### User Case Description

`AutoMigrate()` updates check constraints, no matter there are relationship constraints or not.
