### PR TITLE
Fix OnConstraint builder

### DIFF
--- a/clause/on_conflict.go
+++ b/clause/on_conflict.go
@@ -16,27 +16,27 @@ func (OnConflict) Name() string {
 
 // Build build onConflict clause
 func (onConflict OnConflict) Build(builder Builder) {
-	if len(onConflict.Columns) > 0 {
-		builder.WriteByte('(')
-		for idx, column := range onConflict.Columns {
-			if idx > 0 {
-				builder.WriteByte(',')
-			}
-			builder.WriteQuoted(column)
-		}
-		builder.WriteString(`) `)
-	}
-
-	if len(onConflict.TargetWhere.Exprs) > 0 {
-		builder.WriteString(" WHERE ")
-		onConflict.TargetWhere.Build(builder)
-		builder.WriteByte(' ')
-	}
-
 	if onConflict.OnConstraint != "" {
 		builder.WriteString("ON CONSTRAINT ")
 		builder.WriteString(onConflict.OnConstraint)
 		builder.WriteByte(' ')
+	} else {
+		if len(onConflict.Columns) > 0 {
+			builder.WriteByte('(')
+			for idx, column := range onConflict.Columns {
+				if idx > 0 {
+					builder.WriteByte(',')
+				}
+				builder.WriteQuoted(column)
+			}
+			builder.WriteString(`) `)
+		}
+
+		if len(onConflict.TargetWhere.Exprs) > 0 {
+			builder.WriteString(" WHERE ")
+			onConflict.TargetWhere.Build(builder)
+			builder.WriteByte(' ')
+		}
 	}
 
 	if onConflict.DoNothing {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Fix https://github.com/go-gorm/gorm/issues/5713
<!--
provide a general description of the code changes in your pull request
-->
If `OnConstraint ` is specified in `clause.OnConflict`, just ignore the columns and `where target` configs. Follow the [document](https://www.postgresql.org/docs/15/sql-insert.html), something like `ON CONFLICT xx ON CONSTRAINT yy` is invalid. 
