### PR TITLE
add test: shouldn't execute ALTER COLUMN ... TYPE smallint

### DIFF
--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -1,6 +1,7 @@
 package tests_test
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"gorm.io/driver/postgres"
+
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
 	. "gorm.io/gorm/utils/tests"
@@ -72,6 +74,45 @@ func TestMigrate(t *testing.T) {
 			t.Fatalf("Failed to find index for many2many for %v %v", indexes[0], indexes[1])
 		}
 	}
+
+}
+
+func TestAutoMigrateInt8PG(t *testing.T) {
+	if DB.Dialector.Name() != "postgres" {
+		return
+	}
+
+	type Smallint int8
+
+	type MigrateInt struct {
+		Int8 Smallint
+	}
+
+	tracer := Tracer{
+		Logger: DB.Config.Logger,
+		Test: func(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error) {
+			sql, _ := fc()
+			if strings.HasPrefix(sql, "ALTER TABLE \"migrate_ints\" ALTER COLUMN \"int8\" TYPE smallint") {
+				t.Fatalf("shouldn't execute ALTER COLUMN TYPE if such type is already existed in DB schema: sql: %s", sql)
+			}
+		},
+	}
+
+	DB.Migrator().DropTable(&MigrateInt{})
+
+	// The first AutoMigrate to make table with field with correct type
+	if err := DB.AutoMigrate(&MigrateInt{}); err != nil {
+		t.Fatalf("Failed to auto migrate: error: %v", err)
+	}
+
+	// make new session to set custom logger tracer
+	session := DB.Session(&gorm.Session{Logger: tracer})
+
+	// The second AutoMigrate to catch an error
+	if err := session.AutoMigrate(&MigrateInt{}); err != nil {
+		t.Fatalf("Failed to auto migrate: error: %v", err)
+	}
+
 }
 
 func TestAutoMigrateSelfReferential(t *testing.T) {

--- a/tests/tracer_test.go
+++ b/tests/tracer_test.go
@@ -1,0 +1,34 @@
+package tests_test
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm/logger"
+)
+
+type Tracer struct {
+	Logger logger.Interface
+	Test   func(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error)
+}
+
+func (S Tracer) LogMode(level logger.LogLevel) logger.Interface {
+	return S.Logger.LogMode(level)
+}
+
+func (S Tracer) Info(ctx context.Context, s string, i ...interface{}) {
+	S.Logger.Info(ctx, s, i...)
+}
+
+func (S Tracer) Warn(ctx context.Context, s string, i ...interface{}) {
+	S.Logger.Warn(ctx, s, i...)
+}
+
+func (S Tracer) Error(ctx context.Context, s string, i ...interface{}) {
+	S.Logger.Error(ctx, s, i...)
+}
+
+func (S Tracer) Trace(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error) {
+	S.Logger.Trace(ctx, begin, fc, err)
+	S.Test(ctx, begin, fc, err)
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add new test which should be failed for now because gorm still executes `ALTER TABLE "migrate_ints" ALTER COLUMN "int8" TYPE smallint USING "int8"::smallint` during `AutoMigrate` every time when such field already has such type (smallint).
It was tested on the newest version of gorm/postgres.

### User Case Description

It is not good idea to execute such DDL on the huge databases. Let's fix it. I also will try to find a root cause, but I am not sure that I can do it quickly...
