### PR TITLE
fix: block and arguments is not equal

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -194,6 +194,7 @@ func (stmt *Statement) AddVar(writer clause.Writer, vars ...interface{}) {
 				writer.WriteByte(')')
 			} else {
 				writer.WriteString("(NULL)")
+				stmt.Vars = append(stmt.Vars, v)
 			}
 		case *DB:
 			subdb := v.Session(&Session{Logger: logger.Discard, DryRun: true}).getInstance()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30972393/195897967-df9c11d8-9b6e-4984-bee6-5ce330ffd2ad.png)
![image](https://user-images.githubusercontent.com/30972393/195898022-6a591d62-8d76-4385-9451-9a0a2b7fd5c5.png)

clickhouse: when table field is Array(string)