### PR TITLE
Ability to use generic functions

### DIFF
--- a/clause/function.go
+++ b/clause/function.go
@@ -1,0 +1,42 @@
+package clause
+
+import (
+	"fmt"
+	"log"
+)
+
+type Database string
+
+var (
+	Postgres Database = "postgres"
+	Sqlite   Database = "sqlite"
+)
+
+type Function interface {
+	GetSql() string
+}
+
+type FuncDateWithoutTime struct {
+	Database Database
+	Field    string
+	Alias    string
+	SQL      string
+}
+
+func (fnc FuncDateWithoutTime) GetSql() string {
+	alias := fnc.Alias
+	if fnc.Alias == "" {
+		alias = fnc.Field
+	}
+	switch fnc.Database {
+	case Postgres:
+		fnc.SQL = fmt.Sprintf(" to_char(%s, %s) as %s", fnc.Field, "'YYYY-MM-DD'", alias)
+	case Sqlite:
+		fnc.SQL = fmt.Sprintf(" strftime(%s, %s) as %s", "'%Y-%m-%d' ", fnc.Field, alias)
+	default:
+		log.Print("database not implemented yet for this function")
+		return ""
+	}
+
+	return fnc.SQL
+}

--- a/clause/function.go
+++ b/clause/function.go
@@ -8,8 +8,10 @@ import (
 type Database string
 
 var (
-	Postgres Database = "postgres"
-	Sqlite   Database = "sqlite"
+	Postgres  Database = "postgres"
+	Sqlite    Database = "sqlite"
+	Mysql     Database = "mysql"
+	SqlServer Database = "sqlserver"
 )
 
 type Function interface {
@@ -33,6 +35,10 @@ func (fnc FuncDateWithoutTime) GetSql() string {
 		fnc.SQL = fmt.Sprintf(" to_char(%s, %s) as %s", fnc.Field, "'YYYY-MM-DD'", alias)
 	case Sqlite:
 		fnc.SQL = fmt.Sprintf(" strftime(%s, %s) as %s", "'%Y-%m-%d' ", fnc.Field, alias)
+	case Mysql:
+		fnc.SQL = fmt.Sprintf(" DATE_FORMAT(%s, %s) as %s", fnc.Field, "'%Y-%m-%d' ", alias)
+	case SqlServer:
+		fnc.SQL = fmt.Sprintf(" FORMAT(%s, %s) as %s", fnc.Field, "'yyyy-MM-dd' ", alias)
 	default:
 		log.Print("database not implemented yet for this function")
 		return ""

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -1360,7 +1360,7 @@ func TestQueryResetNullValue(t *testing.T) {
 	AssertEqual(t, q2, qs[1])
 }
 
-func TestFuncDateWihtoutTimeSQLITE(t *testing.T) {
+func TestFuncDateWihtoutTime(t *testing.T) {
 	users := []User{
 		*GetUser("find", Config{}),
 		*GetUser("find", Config{}),
@@ -1376,8 +1376,10 @@ func TestFuncDateWihtoutTimeSQLITE(t *testing.T) {
 			Birthday string
 			Name     string
 		}
-		var fn clause.FuncDateWithoutTime = clause.FuncDateWithoutTime{Database: "sqlite", Field: "birthday"}
+
+		var fn clause.FuncDateWithoutTime = clause.FuncDateWithoutTime{Database: clause.Database(DB.Dialector.Name()), Field: "birthday"}
 		var sql string = fn.GetSql()
+
 		if err := DB.Model(&User{}).Select([]string{sql, "name"}).Where("name = ?", "find").First(&first).Error; err != nil {
 			t.Errorf("errors happened when query first: %v", err)
 		} else {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

It creates the ability for the user to use a generic function in order to retrieve date fields without time.

### User Case Description

<!-- Your use case -->

We have a report application that runs complexes queries, this application has the ability to connect into different databases.
When trying to use some functions, for the time being, we have to write a proprietary function to handle date formats.
This feature would solve this specific problem, but it can grow, as more specific functions became necessary.
