### PR TITLE
feat(Scopes): make Schema and Table accessible from scopes

### DIFF
--- a/tests/schema_in_scopes_test.go
+++ b/tests/schema_in_scopes_test.go
@@ -1,0 +1,51 @@
+package tests_test
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+	. "gorm.io/gorm/utils/tests"
+)
+
+func TestSchemaAccessibleFromScopes(t *testing.T) {
+	users := []User{
+		*GetUser("schema-scope-1", Config{}),
+		*GetUser("schema-scope-2", Config{}),
+	}
+
+	if err := DB.Create(&users).Error; err != nil {
+		t.Fatalf("errors happened when create users: %v", err)
+	}
+
+	var schema *schema.Schema
+	var tableName string
+	scope := func(db *gorm.DB) *gorm.DB {
+		schema = db.Statement.Schema
+		tableName = db.Statement.Table
+		return db
+	}
+
+	var results []User
+	if err := DB.Scopes(scope).Select("name", "age").Where("name like ?", "schema-scope-%").Find(&results).Error; err != nil {
+		t.Errorf("failed to query users, got error: %v", err)
+	}
+
+	expects := []User{
+		{Name: "schema-scope-1", Age: 18},
+		{Name: "schema-scope-2", Age: 18},
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("invalid results length found, expects: %v, got %v", len(expects), len(results))
+	}
+
+	expectedTableName := "users"
+	if tableName != expectedTableName {
+		t.Errorf("invalid table name found, expects: %v, got %v", expectedTableName, tableName)
+	}
+
+	if schema == nil {
+		t.Errorf("invalid schema found, expected non-nil schema")
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

[Original PR Ref](https://github.com/go-gorm/gorm/pull/5810)

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

I'm open to feedback if you think there is a better way to do it.

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

This PR executes scopes after parsing the model so `Statement.Schema` and `Statement.Table` are accessible from them. 

This PR defers from the first one by the fact it still allows the model to be set from scopes.

### User Case Description

<!-- Your use case -->
This would be useful in order to implement scopes that are re-usable across multiple models.

An example would be a scope that sorts by ID. The following would not work if there is a join or an ambiguity with the table name:
```go
func sortByID(db *gorm.DB) *gorm.DB) {
    return db.Sort("id")
}
```

Thanks to the change suggested in this PR, we would be able to do the following:
```go
func sortByID(db *gorm.DB) *gorm.DB) {
    return db.Sort(fmt.Sprintf("%s.id", db.Statement.Table))
}
```

This would also open a lot of possibilities for automatic query generation based on a schema. 