### PR TITLE
fix: remove table name alias from soft delete column (#5840)

### DIFF
--- a/soft_delete.go
+++ b/soft_delete.go
@@ -78,7 +78,7 @@ func (sd SoftDeleteQueryClause) ModifyStatement(stmt *Statement) {
 		}
 
 		stmt.AddClause(clause.Where{Exprs: []clause.Expression{
-			clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: sd.Field.DBName}, Value: nil},
+			clause.Eq{Column: clause.Column{Name: sd.Field.DBName}, Value: nil},
 		}})
 		stmt.Clauses["soft_delete_enabled"] = clause.Clause{}
 	}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

Remove use of the table name in the is null clause generated for soft delete model.s

### User Case Description

<!-- Your use case -->
See: https://github.com/go-gorm/gorm/issues/5840