### PR TITLE
Add test case for embedded value selects

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -65,7 +65,6 @@ func (db *DB) scanIntoStruct(rows Rows, reflectValue reflect.Value, values []int
 
 	db.RowsAffected++
 	db.AddError(rows.Scan(values...))
-
 	joinedSchemaMap := make(map[*schema.Field]interface{})
 	for idx, field := range fields {
 		if field == nil {
@@ -241,9 +240,8 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 		switch reflectValue.Kind() {
 		case reflect.Slice, reflect.Array:
 			var (
-				elem             reflect.Value
-				recyclableStruct = reflect.New(reflectValueType)
-				isArrayKind      = reflectValue.Kind() == reflect.Array
+				elem        reflect.Value
+				isArrayKind = reflectValue.Kind() == reflect.Array
 			)
 
 			if !update || reflectValue.Len() == 0 {
@@ -275,11 +273,7 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 						}
 					}
 				} else {
-					if isPtr && db.RowsAffected > 0 {
-						elem = reflect.New(reflectValueType)
-					} else {
-						elem = recyclableStruct
-					}
+					elem = reflect.New(reflectValueType)
 				}
 
 				db.scanIntoStruct(rows, elem, values, fields, joinFields)

--- a/tests/embedded_struct_test.go
+++ b/tests/embedded_struct_test.go
@@ -36,7 +36,7 @@ func TestEmbeddedStruct(t *testing.T) {
 
 	type EngadgetPost struct {
 		BasePost BasePost `gorm:"Embedded"`
-		Author   Author   `gorm:"Embedded;EmbeddedPrefix:author_"` // Embedded struct
+		Author   *Author  `gorm:"Embedded;EmbeddedPrefix:author_"` // Embedded struct
 		ImageUrl string
 	}
 
@@ -74,13 +74,27 @@ func TestEmbeddedStruct(t *testing.T) {
 		t.Errorf("embedded struct's value should be scanned correctly")
 	}
 
-	DB.Save(&EngadgetPost{BasePost: BasePost{Title: "engadget_news"}})
+	DB.Save(&EngadgetPost{BasePost: BasePost{Title: "engadget_news"}, Author: &Author{Name: "Edward"}})
+	DB.Save(&EngadgetPost{BasePost: BasePost{Title: "engadget_article"}, Author: &Author{Name: "George"}})
 	var egNews EngadgetPost
 	if err := DB.First(&egNews, "title = ?", "engadget_news").Error; err != nil {
 		t.Errorf("no error should happen when query with embedded struct, but got %v", err)
 	} else if egNews.BasePost.Title != "engadget_news" {
 		t.Errorf("embedded struct's value should be scanned correctly")
 	}
+
+	var egPosts []EngadgetPost
+	if err := DB.Order("author_name asc").Find(&egPosts).Error; err != nil {
+		t.Fatalf("no error should happen when query with embedded struct, but got %v", err)
+	}
+	expectAuthors := []string{"Edward", "George"}
+	for i, post := range egPosts {
+		t.Log(i, post)
+		if want := expectAuthors[i]; post.Author.Name != want {
+			t.Errorf("expected author %s got %s", post.Author.Name, want)
+		}
+	}
+
 }
 
 func TestEmbeddedPointerTypeStruct(t *testing.T) {

--- a/tests/embedded_struct_test.go
+++ b/tests/embedded_struct_test.go
@@ -89,9 +89,9 @@ func TestEmbeddedStruct(t *testing.T) {
 	}
 	expectAuthors := []string{"Edward", "George"}
 	for i, post := range egPosts {
-		t.Log(i, post)
+		t.Log(i, post.Author)
 		if want := expectAuthors[i]; post.Author.Name != want {
-			t.Errorf("expected author %s got %s", post.Author.Name, want)
+			t.Errorf("expected author %s got %s", want, post.Author.Name)
 		}
 	}
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

Adds a testcase for embedded fields when selecting multiple row values. Current behaviour returns the last row value for the embbed ptr to all the structs.

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Adds a testcase currently. Looking into the issue.

```
--- FAIL: TestEmbeddedStruct (0.01s)
    embedded_struct_test.go:92: 0 &{ George }
    embedded_struct_test.go:94: expected author Edward got George
    embedded_struct_test.go:92: 1 &{ George }
```

### User Case Description

<!-- Your use case -->
Fix embedded struct ptrs. Reverted the optimisation for reusing structs here: https://github.com/go-gorm/gorm/pull/5388 