### PR TITLE
fix(migrator): ignore relationships when migrating #5913

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -37,6 +37,8 @@ type Config struct {
 	DisableAutomaticPing bool
 	// DisableForeignKeyConstraintWhenMigrating
 	DisableForeignKeyConstraintWhenMigrating bool
+	// IgnoreRelationshipsWhenMigrating
+	IgnoreRelationshipsWhenMigrating bool
 	// DisableNestedTransaction disable nested transaction
 	DisableNestedTransaction bool
 	// AllowGlobalUpdate allow global update


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

fix #5913 

### User Case Description

`DB.AutoMigrate` migrates related tables automatically, which is unexpected.

So I add a `IgnoreRelationshipsWhenMigrating` configuration to disable it. And make `-:migration` work properly on relationship fields.
