### PR TITLE
fix(migrator): Tag default:'null' always causes field migration #5953

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -487,7 +487,7 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 
 	// check default value
 	if !field.PrimaryKey {
-		currentDefaultNotNull := field.HasDefaultValue && !strings.EqualFold(field.DefaultValue, "NULL")
+		currentDefaultNotNull := field.HasDefaultValue && (field.DefaultValueInterface != nil || !strings.EqualFold(field.DefaultValue, "NULL"))
 		dv, dvNotNull := columnType.DefaultValue()
 		if dvNotNull && !currentDefaultNotNull {
 			// defalut value -> null

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -1205,8 +1205,8 @@ func TestMigrateSameEmbeddedFieldName(t *testing.T) {
 }
 
 func TestMigrateDefaultNullString(t *testing.T) {
-	if DB.Dialector.Name() == "sqlite" || DB.Dialector.Name() == "sqlserver" {
-		// sqlite and sqlserver driver treats NULL and 'NULL' the same
+	if DB.Dialector.Name() == "sqlserver" {
+		// sqlserver driver treats NULL and 'NULL' the same
 		t.Skip("skip sqlite and sqlserver")
 	}
 

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -1265,11 +1265,6 @@ func TestMigrateDefaultNullString(t *testing.T) {
 	columnType, err = findColumnType(tableName, "content")
 	AssertEqual(t, err, nil)
 
-	if DB.Dialector.Name() == "postgres" {
-		// TODO postgres migrator.AlterColumn has a bug that it treats 'NULL' and NULL the same
-		// see https://github.com/go-gorm/postgres/blob/915abc3969652fd88d6f4133edaba9af2894e3b2/migrator.go#L329
-		return
-	}
 	defVal, ok = columnType.DefaultValue()
 	AssertEqual(t, defVal, "")
 	AssertEqual(t, ok, false)

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -1207,7 +1207,7 @@ func TestMigrateSameEmbeddedFieldName(t *testing.T) {
 func TestMigrateDefaultNullString(t *testing.T) {
 	if DB.Dialector.Name() == "sqlserver" {
 		// sqlserver driver treats NULL and 'NULL' the same
-		t.Skip("skip sqlite and sqlserver")
+		t.Skip("skip sqlserver")
 	}
 
 	type NullModel struct {


### PR DESCRIPTION

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

fix #5953 

### User Case Description

Tag `default:'null'` is treated as same as `default:null` when migrating.
