### PR TITLE
fix(migrator) Tag `uniqueIndex` always causes a field migration #5957

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -113,7 +113,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		AutoIncrement:          utils.CheckTruth(tagSetting["AUTOINCREMENT"]),
 		HasDefaultValue:        utils.CheckTruth(tagSetting["AUTOINCREMENT"]),
 		NotNull:                utils.CheckTruth(tagSetting["NOT NULL"], tagSetting["NOTNULL"]),
-		Unique:                 utils.CheckTruth(tagSetting["UNIQUE"]),
+		Unique:                 utils.CheckTruth(tagSetting["UNIQUE"], tagSetting["UNIQUEINDEX"]),
 		Comment:                tagSetting["COMMENT"],
 		AutoIncrementIncrement: 1,
 	}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fix 5957

<!--
provide a general description of the code changes in your pull request
-->


### User Case Description

<!-- Your use case -->
