### PR TITLE
fix: issue #5752 Field should be unique but is not

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -113,7 +113,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		AutoIncrement:          utils.CheckTruth(tagSetting["AUTOINCREMENT"]),
 		HasDefaultValue:        utils.CheckTruth(tagSetting["AUTOINCREMENT"]),
 		NotNull:                utils.CheckTruth(tagSetting["NOT NULL"], tagSetting["NOTNULL"]),
-		Unique:                 utils.CheckTruth(tagSetting["UNIQUE"]),
+		Unique:                 utils.CheckTruth(tagSetting["UNIQUE"], tagSetting["UNIQUEINDEX"]),
 		Comment:                tagSetting["COMMENT"],
 		AutoIncrementIncrement: 1,
 	}


### PR DESCRIPTION
causing unnecessary ALTER TABLE executions

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

On cockroachdb, auto migrating a table with a field like:

    PublicKey string      `gorm:"uniqueIndex" json:"public_key"`

Will create the table and then create the unique index, and then do an alter to create the unique index again which causes an error.  This change fixes that.

### User Case Description

auto migrating a table with a field with a uniqueIndex tag.
