### PR TITLE
The primary key type is not int, but string or uuid

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -120,8 +120,9 @@ func (db *DB) First(dest interface{}, conds ...interface{}) (tx *DB) {
 		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey},
 	})
 	if len(conds) > 0 {
-		if len(conds) == 1 {
-			cond := []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{conds[0]}}}
+		pkValue, ok := conds[0].(string)
+		if len(conds) == 1 && ok {
+			cond := []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{pkValue}}}
 			tx.Statement.AddClause(clause.Where{Exprs: cond})
 		} else {
 			if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {
@@ -432,8 +433,9 @@ func (db *DB) UpdateColumns(values interface{}) (tx *DB) {
 func (db *DB) Delete(value interface{}, conds ...interface{}) (tx *DB) {
 	tx = db.getInstance()
 	if len(conds) > 0 {
-		if len(conds) == 1 {
-			cond := []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{conds[0]}}}
+		pkValue, ok := conds[0].(string)
+		if len(conds) == 1 && ok {
+			cond := []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{pkValue}}}
 			tx.Statement.AddClause(clause.Where{Exprs: cond})
 		} else {
 			if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -139,8 +139,14 @@ func (db *DB) First(dest interface{}, conds ...interface{}) (tx *DB) {
 func (db *DB) Take(dest interface{}, conds ...interface{}) (tx *DB) {
 	tx = db.Limit(1)
 	if len(conds) > 0 {
-		if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {
-			tx.Statement.AddClause(clause.Where{Exprs: exprs})
+		pkValue, ok := conds[0].(string)
+		if len(conds) == 1 && ok {
+			cond := []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{pkValue}}}
+			tx.Statement.AddClause(clause.Where{Exprs: cond})
+		} else {
+			if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {
+				tx.Statement.AddClause(clause.Where{Exprs: exprs})
+			}
 		}
 	}
 	tx.Statement.RaiseErrorOnNotFound = true
@@ -155,8 +161,14 @@ func (db *DB) Last(dest interface{}, conds ...interface{}) (tx *DB) {
 		Desc:   true,
 	})
 	if len(conds) > 0 {
-		if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {
-			tx.Statement.AddClause(clause.Where{Exprs: exprs})
+		pkValue, ok := conds[0].(string)
+		if len(conds) == 1 && ok {
+			cond := []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{pkValue}}}
+			tx.Statement.AddClause(clause.Where{Exprs: cond})
+		} else {
+			if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {
+				tx.Statement.AddClause(clause.Where{Exprs: exprs})
+			}
 		}
 	}
 	tx.Statement.RaiseErrorOnNotFound = true

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -120,8 +120,13 @@ func (db *DB) First(dest interface{}, conds ...interface{}) (tx *DB) {
 		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey},
 	})
 	if len(conds) > 0 {
-		if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {
-			tx.Statement.AddClause(clause.Where{Exprs: exprs})
+		if len(conds) == 1 {
+			cond := []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{conds[0]}}}
+			tx.Statement.AddClause(clause.Where{Exprs: cond})
+		} else {
+			if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {
+				tx.Statement.AddClause(clause.Where{Exprs: exprs})
+			}
 		}
 	}
 	tx.Statement.RaiseErrorOnNotFound = true
@@ -427,8 +432,13 @@ func (db *DB) UpdateColumns(values interface{}) (tx *DB) {
 func (db *DB) Delete(value interface{}, conds ...interface{}) (tx *DB) {
 	tx = db.getInstance()
 	if len(conds) > 0 {
-		if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {
-			tx.Statement.AddClause(clause.Where{Exprs: exprs})
+		if len(conds) == 1 {
+			cond := []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{conds[0]}}}
+			tx.Statement.AddClause(clause.Where{Exprs: cond})
+		} else {
+			if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {
+				tx.Statement.AddClause(clause.Where{Exprs: exprs})
+			}
 		}
 	}
 	tx.Statement.Dest = value

--- a/statement.go
+++ b/statement.go
@@ -287,7 +287,12 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 				return nil
 			}
 
-			if len(args) == 0 || (len(args) > 0 && strings.Contains(s, "?")) {
+			// The primary key type is not int, but string or uuid (#5984)
+			if len(args) == 0 {
+				return []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{s}}}
+			}
+
+			if len(args) > 0 && strings.Contains(s, "?") {
 				// looks like a where condition
 				return []clause.Expression{clause.Expr{SQL: s, Vars: args}}
 			}

--- a/statement.go
+++ b/statement.go
@@ -287,7 +287,12 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 				return nil
 			}
 
-			// The primary key type is not int, but string or uuid (#5984)
+			//The primary key type is not int, but string or uuid (#5984)
+			if len(args) == 0 && (!strings.Contains(s, "?") && !strings.Contains(s, "@")) {
+				// if it is a string, then treats it as primary key
+				return []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{s}}}
+			}
+
 			if len(args) == 0 || (len(args) > 0 && strings.Contains(s, "?")) {
 				// looks like a where condition
 				return []clause.Expression{clause.Expr{SQL: s, Vars: args}}

--- a/statement.go
+++ b/statement.go
@@ -288,11 +288,11 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 			}
 
 			// The primary key type is not int, but string or uuid (#5984)
-			if len(args) == 0 {
-				return []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{s}}}
-			}
+			//if len(args) == 0 {
+			//	return []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{s}}}
+			//}
 
-			if len(args) > 0 && strings.Contains(s, "?") {
+			if len(args) == 0 || len(args) > 0 && strings.Contains(s, "?") {
 				// looks like a where condition
 				return []clause.Expression{clause.Expr{SQL: s, Vars: args}}
 			}

--- a/statement.go
+++ b/statement.go
@@ -288,10 +288,6 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 			}
 
 			// The primary key type is not int, but string or uuid (#5984)
-			//if len(args) == 0 {
-			//	return []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{s}}}
-			//}
-
 			if len(args) == 0 || (len(args) > 0 && strings.Contains(s, "?")) {
 				// looks like a where condition
 				return []clause.Expression{clause.Expr{SQL: s, Vars: args}}

--- a/statement.go
+++ b/statement.go
@@ -287,11 +287,6 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 				return nil
 			}
 
-			if len(args) == 0 && (!strings.Contains(s, "?") && !strings.Contains(s, "@")) {
-				// The primary key type is not int, but string or uuid (#5984)
-				return []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{s}}}
-			}
-
 			if len(args) == 0 || (len(args) > 0 && strings.Contains(s, "?")) {
 				// looks like a where condition
 				return []clause.Expression{clause.Expr{SQL: s, Vars: args}}

--- a/statement.go
+++ b/statement.go
@@ -287,9 +287,8 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 				return nil
 			}
 
-			//The primary key type is not int, but string or uuid (#5984)
 			if len(args) == 0 && (!strings.Contains(s, "?") && !strings.Contains(s, "@")) {
-				// if it is a string, then treats it as primary key
+				// The primary key type is not int, but string or uuid (#5984)
 				return []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{s}}}
 			}
 

--- a/statement.go
+++ b/statement.go
@@ -292,7 +292,7 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 			//	return []clause.Expression{clause.IN{Column: clause.PrimaryColumn, Values: []interface{}{s}}}
 			//}
 
-			if len(args) == 0 || len(args) > 0 && strings.Contains(s, "?") {
+			if len(args) == 0 || (len(args) > 0 && strings.Contains(s, "?")) {
 				// looks like a where condition
 				return []clause.Expression{clause.Expr{SQL: s, Vars: args}}
 			}


### PR DESCRIPTION
…#5984)

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x]  Do only one thing

- [x] Non breaking API changes

- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
For this issue: https://github.com/go-gorm/gorm/issues/5984

### User Case Description

<!-- Your use case -->

## repairing
```bash
gorm_test.go:54: SELECT * FROM `users` WHERE `users`.`id` = '257b218c-5031-45a1-8061-209180499a93' AND `users`.`deleted_at` IS NULL ORDER BY `users`.`id` LIMIT 1
gorm_test.go:60: SELECT * FROM `users` WHERE `users`.`id` = '257b218c-5031-45a1-8061-209180499a93' AND `users`.`deleted_at` IS NULL ORDER BY `users`.`id` LIMIT 1
gorm_test.go:66: UPDATE `users` SET `deleted_at`='2023-01-16 11:14:29.319' WHERE `users`.`id` = '257b218c-5031-45a1-8061-209180499a93' AND `users`.`deleted_at` IS NULL
gorm_test.go:72: UPDATE `users` SET `deleted_at`='2023-01-16 11:14:29.319' WHERE `users`.`id` = '257b218c-5031-45a1-8061-209180499a93' AND `users`.`deleted_at` IS NULL
```

### test

```go
// gorm_test.go
package test

import (
	"github.com/aide-cloud/gorm"
	"github.com/aide-cloud/gorm/mysql/driver"
	"testing"
)

type BaseModel struct {
	CreatedAt int64          `gorm:"autoCreateTime:nano"`
	UpdatedAt int64          `gorm:"autoUpdateTime:nano"`
	DeletedAt gorm.DeletedAt `gorm:"index"`
}

type UUIDModel struct {
	BaseModel
	ID string `gorm:"primarykey;type:varchar(36);not null;uniqueIndex;comment:主键ID;colum:id"`
}

type User struct {
	UUIDModel
	Username string `gorm:"type:varchar(32);not null;unique;comment:用户名"`
	Password string `gorm:"type:varchar(255);not null;comment:密码"`
	Email    string `gorm:"type:varchar(64);not null;unique;comment:邮箱"`
	Phone    string `gorm:"type:varchar(16);not null;unique;comment:手机号"`
	Avatar   string `gorm:"type:varchar(255);not null;comment:头像"`
	Nickname string `gorm:"type:varchar(32);not null;comment:昵称"`
}

const dsn = "root:12345678@tcp(lcaolhsot:3060)/gorm_test?charset=utf8mb4&parseTime=True&loc=Local"

var db *gorm.DB

func init() {
	conn, err := gorm.Open(mysql.Open(dsn))
	if err != nil {
		panic(err)
	}
	db = conn

	// 初始化表
	if err = db.AutoMigrate(&User{}); err != nil {
		panic(err)
	}
}

func TestGormP(t *testing.T) {
	uuidPK := "257b218c-5031-45a1-8061-209180499a93"
	var user User
	var sql string
	sql = db.ToSQL(func(tx *gorm.DB) *gorm.DB {
		return tx.Model(&user).First(&user, uuidPK)
	})
	t.Log(sql)

	sql = db.ToSQL(func(tx *gorm.DB) *gorm.DB {
		return tx.Model(&user).First(&User{}, []string{uuidPK})
	})

	t.Log(sql)

	sql = db.ToSQL(func(tx *gorm.DB) *gorm.DB {
		return tx.Model(&user).Delete(&user, uuidPK)
	})

	t.Log(sql)

	sql = db.ToSQL(func(tx *gorm.DB) *gorm.DB {
		return tx.Model(&user).Delete(&user, []string{uuidPK})
	})

	t.Log(sql)
}
```
