### PR TITLE
fix update panic if has hook

### DIFF
--- a/callbacks/callmethod.go
+++ b/callbacks/callmethod.go
@@ -13,11 +13,18 @@ func callMethod(db *gorm.DB, fc func(value interface{}, tx *gorm.DB) bool) {
 		case reflect.Slice, reflect.Array:
 			db.Statement.CurDestIndex = 0
 			for i := 0; i < db.Statement.ReflectValue.Len(); i++ {
-				fc(reflect.Indirect(db.Statement.ReflectValue.Index(i)).Addr().Interface(), tx)
+				value := reflect.Indirect(db.Statement.ReflectValue.Index(i))
+				if value.CanAddr() {
+					fc(value.Addr().Interface(), tx)
+				} else {
+					fc(value.Interface(), tx)
+				}
 				db.Statement.CurDestIndex++
 			}
 		case reflect.Struct:
-			fc(db.Statement.ReflectValue.Addr().Interface(), tx)
+			if db.Statement.ReflectValue.CanAddr() {
+				fc(db.Statement.ReflectValue.Addr().Interface(), tx)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?
fix #5989  

By this way that if model is  not ptr and the hook is for ptr, the hook will be ignore and it will be not panic.

``` golang
DB.Model(User{}).Where("name = ?", "test").Update("name", "test1")

// will not be executed
func (*User) BeforeUpdate(*gorm.DB) error {
	return nil
}

// be executed
func (User) BeforeUpdate(*gorm.DB) error {
	return nil
}
```

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
