### PR TITLE
fix: logger.Default use os.Stderr instead of os.Stdout #5975

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -72,7 +72,7 @@ var (
 	// Discard Discard logger will print any log to io.Discard
 	Discard = New(log.New(io.Discard, "", log.LstdFlags), Config{})
 	// Default Default logger
-	Default = New(log.New(os.Stdout, "\r\n", log.LstdFlags), Config{
+	Default = New(log.New(os.Stderr, "\r\n", log.LstdFlags), Config{
 		SlowThreshold:             200 * time.Millisecond,
 		LogLevel:                  Warn,
 		IgnoreRecordNotFoundError: false,


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?
logger.Default use os.Stderr instead of os.Stdout
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
