### PR TITLE
fix: support zeroValue tag on DeletedAt

### DIFF
--- a/soft_delete.go
+++ b/soft_delete.go
@@ -50,18 +50,12 @@ func (DeletedAt) QueryClauses(f *schema.Field) []clause.Interface {
 }
 
 func parseZeroValueTag(f *schema.Field) sql.NullString {
-	// parse zeroValue tag if not nil
-	tagSetting := schema.ParseTagSetting(f.Tag.Get("gorm"), ";")
-	zeroValueTag := tagSetting["ZEROVALUE"]
-	zeroValue := sql.NullString{Valid: false}
-	if len(zeroValueTag) > 0 {
-		// validate it
-		_, err := now.Parse(zeroValueTag)
-		if err == nil {
-			zeroValue = sql.NullString{String: zeroValueTag, Valid: true}
+	if v, ok := f.TagSettings["ZEROVALUE"]; ok {
+		if _, err := now.Parse(v); err == nil {
+			return sql.NullString{String: v, Valid: true}
 		}
 	}
-	return zeroValue
+	return sql.NullString{Valid: false}
 }
 
 type SoftDeleteQueryClause struct {

--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -100,7 +100,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Coupon{}, &CouponProduct{}, &Order{}, &Parent{}, &Child{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Coupon{}, &CouponProduct{}, &Order{}, &Parent{}, &Child{}, &Book{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -100,7 +100,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Coupon{}, &CouponProduct{}, &Order{}, &Parent{}, &Child{}, &Book{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Coupon{}, &CouponProduct{}, &Order{}, &Parent{}, &Child{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 


### PR DESCRIPTION
```
type Book struct {
	ID        uint
	Name      string
	Pages     uint
	DeletedAt gorm.DeletedAt `gorm:"zeroValue:'1970-01-01 00:00:01'"`
}
```
it may be necessary for us to set the type of delete_at datetime. and if delete_at is null, we can not add it into the composite index. so we can use 1970-01-01 00:00:01 (or other values you like)as zero value.

if we query books, gorm can generate the sql automatically
```
select * from books where delete_at = '1970-01-01 00:00:01'
```
if we delete books, gorm can generate the sql automatically
```
update books set  delete_at = 'xx' where delete_at = '1970-01-01 00:00:01'
```