### PR TITLE
Issue 6054: Unscoped not working with PreLoad on Joins

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -257,6 +257,7 @@ func Preload(db *gorm.DB) {
 			return
 		}
 		preloadDB.Statement.ReflectValue = db.Statement.ReflectValue
+		preloadDB.Statement.Unscoped = db.Statement.Unscoped
 
 		for _, name := range preloadNames {
 			if rel := preloadDB.Statement.Schema.Relationships.Relations[name]; rel != nil {

--- a/clause/select_test.go
+++ b/clause/select_test.go
@@ -49,16 +49,18 @@ func TestSelect(t *testing.T) {
 					Exprs: []clause.Expression{
 						clause.Expr{
 							SQL: "? as name",
-							Vars: []interface{}{clause.Eq{
-								Column: clause.Column{Name: "age"},
-								Value:  18,
-							},
+							Vars: []interface{}{
+								clause.Eq{
+									Column: clause.Column{Name: "age"},
+									Value:  18,
+								},
 							},
 						},
 					},
 				},
 			}, clause.From{}},
-			"SELECT `age` = ? as name FROM `users`", []interface{}{18},
+			"SELECT `age` = ? as name FROM `users`",
+			[]interface{}{18},
 		},
 	}
 

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -16,9 +16,7 @@ import (
 	"gorm.io/gorm/schema"
 )
 
-var (
-	regFullDataType = regexp.MustCompile(`\D*(\d+)\D?`)
-)
+var regFullDataType = regexp.MustCompile(`\D*(\d+)\D?`)
 
 // Migrator m struct
 type Migrator struct {

--- a/model.go
+++ b/model.go
@@ -4,9 +4,10 @@ import "time"
 
 // Model a basic GoLang struct which includes the following fields: ID, CreatedAt, UpdatedAt, DeletedAt
 // It may be embedded into your model or you may build your own model without it
-//    type User struct {
-//      gorm.Model
-//    }
+//
+//	type User struct {
+//	  gorm.Model
+//	}
 type Model struct {
 	ID        uint `gorm:"primarykey"`
 	CreatedAt time.Time

--- a/schema/field.go
+++ b/schema/field.go
@@ -174,7 +174,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		field.DataType = String
 		field.Serializer = v
 	} else {
-		var serializerName = field.TagSettings["JSON"]
+		serializerName := field.TagSettings["JSON"]
 		if serializerName == "" {
 			serializerName = field.TagSettings["SERIALIZER"]
 		}

--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -123,16 +123,17 @@ func (schema *Schema) parseRelation(field *Field) *Relationship {
 }
 
 // User has many Toys, its `Polymorphic` is `Owner`, Pet has one Toy, its `Polymorphic` is `Owner`
-//     type User struct {
-//       Toys []Toy `gorm:"polymorphic:Owner;"`
-//     }
-//     type Pet struct {
-//       Toy Toy `gorm:"polymorphic:Owner;"`
-//     }
-//     type Toy struct {
-//       OwnerID   int
-//       OwnerType string
-//     }
+//
+//	type User struct {
+//	  Toys []Toy `gorm:"polymorphic:Owner;"`
+//	}
+//	type Pet struct {
+//	  Toy Toy `gorm:"polymorphic:Owner;"`
+//	}
+//	type Toy struct {
+//	  OwnerID   int
+//	  OwnerType string
+//	}
 func (schema *Schema) buildPolymorphicRelation(relation *Relationship, field *Field, polymorphic string) {
 	relation.Polymorphic = &Polymorphic{
 		Value:           schema.Table,
@@ -427,7 +428,7 @@ func (schema *Schema) guessRelation(relation *Relationship, field *Field, cgl gu
 			foreignFields = append(foreignFields, f)
 		}
 	} else {
-		var primarySchemaName = primarySchema.Name
+		primarySchemaName := primarySchema.Name
 		if primarySchemaName == "" {
 			primarySchemaName = relation.FieldSchema.Name
 		}

--- a/schema/serializer.go
+++ b/schema/serializer.go
@@ -70,8 +70,7 @@ type SerializerValuerInterface interface {
 }
 
 // JSONSerializer json serializer
-type JSONSerializer struct {
-}
+type JSONSerializer struct{}
 
 // Scan implements serializer interface
 func (JSONSerializer) Scan(ctx context.Context, field *Field, dst reflect.Value, dbValue interface{}) (err error) {
@@ -110,8 +109,7 @@ func (JSONSerializer) Value(ctx context.Context, field *Field, dst reflect.Value
 }
 
 // UnixSecondSerializer json serializer
-type UnixSecondSerializer struct {
-}
+type UnixSecondSerializer struct{}
 
 // Scan implements serializer interface
 func (UnixSecondSerializer) Scan(ctx context.Context, field *Field, dst reflect.Value, dbValue interface{}) (err error) {
@@ -141,8 +139,7 @@ func (UnixSecondSerializer) Value(ctx context.Context, field *Field, dst reflect
 }
 
 // GobSerializer gob serializer
-type GobSerializer struct {
-}
+type GobSerializer struct{}
 
 // Scan implements serializer interface
 func (GobSerializer) Scan(ctx context.Context, field *Field, dst reflect.Value, dbValue interface{}) (err error) {

--- a/tests/connpool_test.go
+++ b/tests/connpool_test.go
@@ -48,9 +48,11 @@ func (c *wrapperConnPool) Ping() error {
 }
 
 // If you use BeginTx returned *sql.Tx as shown below then you can't record queries in a transaction.
-// func (c *wrapperConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
-//	 return c.db.BeginTx(ctx, opts)
-// }
+//
+//	func (c *wrapperConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+//		 return c.db.BeginTx(ctx, opts)
+//	}
+//
 // You should use BeginTx returned gorm.Tx which could wrap *sql.Tx then you can record all queries.
 func (c *wrapperConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (gorm.ConnPool, error) {
 	tx, err := c.db.BeginTx(ctx, opts)

--- a/tests/embedded_struct_test.go
+++ b/tests/embedded_struct_test.go
@@ -94,7 +94,6 @@ func TestEmbeddedStruct(t *testing.T) {
 			t.Errorf("expected author %s got %s", want, post.Author.Name)
 		}
 	}
-
 }
 
 func TestEmbeddedPointerTypeStruct(t *testing.T) {

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -1,13 +1,14 @@
 package tests_test
 
 import (
-	"gorm.io/gorm"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"gorm.io/gorm"
 
 	. "gorm.io/gorm/utils/tests"
 )

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -75,7 +75,6 @@ func TestMigrate(t *testing.T) {
 			t.Fatalf("Failed to find index for many2many for %v %v", indexes[0], indexes[1])
 		}
 	}
-
 }
 
 func TestAutoMigrateInt8PG(t *testing.T) {
@@ -1267,7 +1266,7 @@ func (mm mockMigrator) AlterColumn(dst interface{}, field string) error {
 }
 
 func TestMigrateDonotAlterColumn(t *testing.T) {
-	var wrapMockMigrator = func(m gorm.Migrator) mockMigrator {
+	wrapMockMigrator := func(m gorm.Migrator) mockMigrator {
 		return mockMigrator{
 			Migrator: m,
 		}

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -158,10 +158,11 @@ func (UserWithTableNamer) TableName(namer schema.Namer) string {
 }
 
 func TestTableWithNamer(t *testing.T) {
-	var db, _ = gorm.Open(tests.DummyDialector{}, &gorm.Config{
+	db, _ := gorm.Open(tests.DummyDialector{}, &gorm.Config{
 		NamingStrategy: schema.NamingStrategy{
 			TablePrefix: "t_",
-		}})
+		},
+	})
 
 	sql := db.ToSQL(func(tx *gorm.DB) *gorm.DB {
 		return tx.Model(&UserWithTableNamer{}).Find(&UserWithTableNamer{})


### PR DESCRIPTION
See https://github.com/go-gorm/gorm/issues/6054

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fixed use of `Unscoped()` on `Preload(..)`.

### User Case Description

Retrieval of models with `Unscoped()` and `Preload(..)` does not include soft-deleted records.

Use of `Unscoped()` should [include](https://gorm.io/docs/delete.html#Find-soft-deleted-records) soft-deleted records. 