### PR TITLE
Distinguish custom types

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -56,7 +56,7 @@ type Field struct {
 	BindNames              []string
 	DataType               DataType
 	GORMDataType           DataType
-	CustomDataType         DataType
+	IsTaggedType           bool
 	PrimaryKey             bool
 	AutoIncrement          bool
 	AutoIncrementIncrement int64
@@ -311,7 +311,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		default:
 			field.DataType = DataType(val)
 		}
-		field.CustomDataType = DataType(val)
+		field.IsTaggedType = true
 	}
 
 	if field.Size == 0 {

--- a/schema/field.go
+++ b/schema/field.go
@@ -56,6 +56,7 @@ type Field struct {
 	BindNames              []string
 	DataType               DataType
 	GORMDataType           DataType
+	CustomDataType         DataType
 	PrimaryKey             bool
 	AutoIncrement          bool
 	AutoIncrementIncrement int64
@@ -310,6 +311,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		default:
 			field.DataType = DataType(val)
 		}
+		field.CustomDataType = DataType(val)
 	}
 
 	if field.Size == 0 {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -23,9 +23,9 @@ func TestParseCustomTypeSchema(t *testing.T) {
 	}
 
 	fields := []schema.Field{
-		{Name: "Date", DBName: "date", BindNames: []string{"Date"}, DataType: "date", CustomDataType: "date", Tag: `gorm:"type:date"`, TagSettings: map[string]string{"TYPE": "date"}},
-		{Name: "Time", DBName: "time", BindNames: []string{"Time"}, DataType: schema.Time, CustomDataType: "time", Tag: `gorm:"type:time"`, TagSettings: map[string]string{"TYPE": "time"}},
-		{Name: "DateTime", DBName: "date_time", BindNames: []string{"DateTime"}, DataType: schema.Time},
+		{Name: "Date", DBName: "date", BindNames: []string{"Date"}, DataType: "date", IsTaggedType: true, Tag: `gorm:"type:date"`, TagSettings: map[string]string{"TYPE": "date"}},
+		{Name: "Time", DBName: "time", BindNames: []string{"Time"}, DataType: schema.Time, IsTaggedType: true, Tag: `gorm:"type:time"`, TagSettings: map[string]string{"TYPE": "time"}},
+		{Name: "DateTime", DBName: "date_time", BindNames: []string{"DateTime"}, DataType: schema.Time, IsTaggedType: false},
 	}
 	for i := range fields {
 		checkSchemaField(t, product, &fields[i], func(field *schema.Field) {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -27,11 +27,11 @@ func TestParseCustomTypeSchema(t *testing.T) {
 		{Name: "Time", DBName: "time", BindNames: []string{"Time"}, DataType: schema.Time, CustomDataType: "time", Tag: `gorm:"type:time"`, TagSettings: map[string]string{"TYPE": "time"}},
 		{Name: "DateTime", DBName: "date_time", BindNames: []string{"DateTime"}, DataType: schema.Time},
 	}
-	for _, f := range fields {
-		checkSchemaField(t, product, &f, func(field *schema.Field) {
-			f.Creatable = true
-			f.Updatable = true
-			f.Readable = true
+	for i := range fields {
+		checkSchemaField(t, product, &fields[i], func(field *schema.Field) {
+			field.Creatable = true
+			field.Updatable = true
+			field.Readable = true
 		})
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Distinguish between detected and custom type (#6033).
In driver, we will skip to `getSchemaCustomType` if `CustomDataType` is specified.
See [MySQL#109](https://github.com/go-gorm/mysql/pull/109) for more context.

### User Case Description

```go
type Test struct {
    Date time.Time `gorm:"type:date"`
    Time time.Time `gorm:"type:time"`
    DefaultDateTime time.Time
}
```
```sql
CREATE TABLE `tests` (`date` date,`time` time,`default_date_time` datetime)
```
