### PR TITLE
quotes on docker-compose.yml ports

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   mysql:
     image: 'mysql/mysql-server:latest'
     ports:
-      - 9910:3306
+      - "9910:3306"
     environment:
       - MYSQL_DATABASE=gorm
       - MYSQL_USER=gorm
@@ -13,7 +13,7 @@ services:
   postgres:
     image: 'postgres:latest'
     ports:
-      - 9920:5432
+      - "9920:5432"
     environment:
       - TZ=Asia/Shanghai
       - POSTGRES_DB=gorm
@@ -22,7 +22,7 @@ services:
   mssql:
     image: '${MSSQL_IMAGE:-mcmoe/mssqldocker}:latest'
     ports:
-      - 9930:1433
+      - "9930:1433"
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=LoremIpsum86
@@ -32,5 +32,5 @@ services:
   tidb:
     image: 'pingcap/tidb:v6.5.0'
     ports:
-      - 9940:4000
+      - "9940:4000"
     command: /tidb-server -store unistore -path "" -lease 0s > tidb.log 2>&1 &


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
quotes on docker-compose.yml ports

### User Case Description
https://docs.docker.com/compose/compose-file/compose-file-v3/#ports

> When mapping ports in the HOST:CONTAINER format, you may experience erroneous results when using a container port lower than 60, because YAML parses numbers in the format xx:yy as a base-60 value. For this reason, we recommend always explicitly specifying your port mappings as strings.
