### PR TITLE
Create and drop view

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -23,6 +23,8 @@ var (
 	ErrModelValueRequired = errors.New("model value required")
 	// ErrModelAccessibleFieldsRequired model accessible fields required
 	ErrModelAccessibleFieldsRequired = errors.New("model accessible fields required")
+	// ErrSubQueryRequired sub query required
+	ErrSubQueryRequired = errors.New("sub query required")
 	// ErrInvalidData unsupported data
 	ErrInvalidData = errors.New("unsupported data")
 	// ErrUnsupportedDriver unsupported driver

--- a/migrator.go
+++ b/migrator.go
@@ -30,8 +30,8 @@ func (db *DB) AutoMigrate(dst ...interface{}) error {
 
 // ViewOption view option
 type ViewOption struct {
-	Replace     bool
-	CheckOption string
+	Replace     bool   // CREATE [ OR REPLACE ]
+	CheckOption string // WITH [ CASCADED | LOCAL ] CHECK OPTION
 	Query       *DB
 }
 

--- a/migrator.go
+++ b/migrator.go
@@ -30,9 +30,9 @@ func (db *DB) AutoMigrate(dst ...interface{}) error {
 
 // ViewOption view option
 type ViewOption struct {
-	Replace     bool   // CREATE [ OR REPLACE ]
-	CheckOption string // WITH [ CASCADED | LOCAL ] CHECK OPTION
-	Query       *DB
+	Replace     bool   // If true, exec `CREATE`. If false, exec `CREATE OR REPLACE`
+	CheckOption string // optional. e.g. `WITH [ CASCADED | LOCAL ] CHECK OPTION`
+	Query       *DB    // required subquery.
 }
 
 // ColumnType column type interface

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -559,12 +559,28 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 
 // CreateView create view
 func (m Migrator) CreateView(name string, option gorm.ViewOption) error {
-	return gorm.ErrNotImplemented
+	sql := new(strings.Builder)
+	sql.WriteString("CREATE ")
+	if option.Replace {
+		sql.WriteString("OR REPLACE ")
+	}
+	sql.WriteString("VIEW ")
+	m.QuoteTo(sql, name)
+	sql.WriteString(" AS ")
+
+	m.DB.Statement.AddVar(sql, option.Query)
+
+	if option.CheckOption != "" {
+		sql.WriteString(" WITH ")
+		sql.WriteString(option.CheckOption)
+		sql.WriteString(" CHECK OPTION")
+	}
+	return m.DB.Exec(sql.String()).Error
 }
 
 // DropView drop view
 func (m Migrator) DropView(name string) error {
-	return gorm.ErrNotImplemented
+	return m.DB.Exec("DROP VIEW IF EXISTS ?", clause.Table{Name: name}).Error
 }
 
 func buildConstraint(constraint *schema.Constraint) (sql string, results []interface{}) {

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -571,9 +571,7 @@ func (m Migrator) CreateView(name string, option gorm.ViewOption) error {
 	m.DB.Statement.AddVar(sql, option.Query)
 
 	if option.CheckOption != "" {
-		sql.WriteString(" WITH ")
 		sql.WriteString(option.CheckOption)
-		sql.WriteString(" CHECK OPTION")
 	}
 	return m.DB.Exec(sql.String()).Error
 }

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -571,6 +571,7 @@ func (m Migrator) CreateView(name string, option gorm.ViewOption) error {
 	m.DB.Statement.AddVar(sql, option.Query)
 
 	if option.CheckOption != "" {
+		sql.WriteString(" ")
 		sql.WriteString(option.CheckOption)
 	}
 	return m.DB.Exec(sql.String()).Error

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -644,6 +644,27 @@ func TestMigrateColumns(t *testing.T) {
 	}
 }
 
+func TestMigrateView(t *testing.T) {
+	DB.Save(GetUser("joins-args-db", Config{Pets: 2}))
+
+	query := DB.Model(&User{}).
+		Select("users.id as users_id, users.name as users_name, pets.id as pets_id, pets.name as pets_name").
+		Joins("inner join pets on pets.user_id = users.id")
+
+	if err := DB.Migrator().CreateView("users_pets", gorm.ViewOption{Query: query}); err != nil {
+		t.Fatalf("Failed to crate view, got %v", err)
+	}
+
+	var count int64
+	if err := DB.Table("users_pets").Count(&count).Error; err != nil {
+		t.Fatalf("should found created view")
+	}
+
+	if err := DB.Migrator().DropView("users_pets"); err != nil {
+		t.Fatalf("Failed to drop view, got %v", err)
+	}
+}
+
 func TestMigrateConstraint(t *testing.T) {
 	names := []string{"Account", "fk_users_account", "Pets", "fk_users_pets", "Company", "fk_users_company", "Team", "fk_users_team", "Languages", "fk_users_languages"}
 

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -644,27 +644,6 @@ func TestMigrateColumns(t *testing.T) {
 	}
 }
 
-func TestMigrateView(t *testing.T) {
-	DB.Save(GetUser("joins-args-db", Config{Pets: 2}))
-
-	query := DB.Model(&User{}).
-		Select("users.id as users_id, users.name as users_name, pets.id as pets_id, pets.name as pets_name").
-		Joins("inner join pets on pets.user_id = users.id")
-
-	if err := DB.Migrator().CreateView("users_pets", gorm.ViewOption{Query: query}); err != nil {
-		t.Fatalf("Failed to crate view, got %v", err)
-	}
-
-	var count int64
-	if err := DB.Table("users_pets").Count(&count).Error; err != nil {
-		t.Fatalf("should found created view")
-	}
-
-	if err := DB.Migrator().DropView("users_pets"); err != nil {
-		t.Fatalf("Failed to drop view, got %v", err)
-	}
-}
-
 func TestMigrateConstraint(t *testing.T) {
 	names := []string{"Account", "fk_users_account", "Pets", "fk_users_pets", "Company", "fk_users_company", "Team", "fk_users_team", "Languages", "fk_users_languages"}
 
@@ -1528,5 +1507,26 @@ func TestMigrateIgnoreRelations(t *testing.T) {
 	_, err = findColumnType(&RelationModel2{}, "id")
 	if err == nil {
 		t.Errorf("RelationModel2 should not be migrated")
+	}
+}
+
+func TestMigrateView(t *testing.T) {
+	DB.Save(GetUser("joins-args-db", Config{Pets: 2}))
+
+	query := DB.Model(&User{}).
+		Select("users.id as users_id, users.name as users_name, pets.id as pets_id, pets.name as pets_name").
+		Joins("inner join pets on pets.user_id = users.id")
+
+	if err := DB.Migrator().CreateView("users_pets", gorm.ViewOption{Query: query}); err != nil {
+		t.Fatalf("Failed to crate view, got %v", err)
+	}
+
+	var count int64
+	if err := DB.Table("users_pets").Count(&count).Error; err != nil {
+		t.Fatalf("should found created view")
+	}
+
+	if err := DB.Migrator().DropView("users_pets"); err != nil {
+		t.Fatalf("Failed to drop view, got %v", err)
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
create view #4966 

It's different from issue's suggestion.
I found the unimplemented `CreateView` function in `Migrator`,
then I implemented it.

About `ViewOption`:
- `Query` is a [subquey](https://gorm.io/docs/advanced_query.html#SubQuery)
- If `Replace` is true, exec `CREATE OR REPLACE`. sqlite may not support this.
- If `CheckOption` is not empty, append to sql, e.g. `WITH LOCAL CHECK OPTION`

### User Case Description

```go
DB.Migrator().CreateView("users_pets", gorm.ViewOption{Query: DB.Model(&User{}).Select("users.id, users.name")})
```

```sql
CREATE VIEW `users_pets` AS SELECT users.id, users.name FROM `users`
```
