### PR TITLE
Fix: Composite primary key with auto-increment value returns 0 after insert

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -225,6 +225,16 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 		schema.PrioritizedPrimaryField = schema.PrimaryFields[0]
 	}
 
+	// If there are multiple primary keys, the AUTOINCREMENT field is prioritized
+	if schema.PrioritizedPrimaryField == nil && len(schema.PrimaryFields) > 1 {
+		for _, field := range schema.PrimaryFields {
+			if _, ok := field.TagSettings["AUTOINCREMENT"]; ok {
+				schema.PrioritizedPrimaryField = field
+				break
+			}
+		}
+	}
+
 	for _, field := range schema.PrimaryFields {
 		schema.PrimaryFieldDBNames = append(schema.PrimaryFieldDBNames, field.DBName)
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -221,16 +221,16 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 		}
 	}
 
-	if schema.PrioritizedPrimaryField == nil && len(schema.PrimaryFields) == 1 {
-		schema.PrioritizedPrimaryField = schema.PrimaryFields[0]
-	}
-
-	// If there are multiple primary keys, the AUTOINCREMENT field is prioritized
-	if schema.PrioritizedPrimaryField == nil && len(schema.PrimaryFields) > 1 {
-		for _, field := range schema.PrimaryFields {
-			if _, ok := field.TagSettings["AUTOINCREMENT"]; ok {
-				schema.PrioritizedPrimaryField = field
-				break
+	if schema.PrioritizedPrimaryField == nil {
+		if len(schema.PrimaryFields) == 1 {
+			schema.PrioritizedPrimaryField = schema.PrimaryFields[0]
+		} else if len(schema.PrimaryFields) > 1 {
+			// If there are multiple primary keys, the AUTOINCREMENT field is prioritized
+			for _, field := range schema.PrimaryFields {
+				if field.AutoIncrement {
+					schema.PrioritizedPrimaryField = field
+					break
+				}
 			}
 		}
 	}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -301,6 +301,12 @@ func TestCompositePrimaryKeyWithAutoIncrement(t *testing.T) {
 		Code         string
 		Name         string
 	}
+	type ProductNonAutoIncrement struct {
+		ProductID    uint `gorm:"primaryKey;autoIncrement:false"`
+		LanguageCode uint `gorm:"primaryKey"`
+		Code         string
+		Name         string
+	}
 
 	product, err := schema.Parse(&Product{}, &sync.Map{}, schema.NamingStrategy{})
 	if err != nil {
@@ -318,4 +324,13 @@ func TestCompositePrimaryKeyWithAutoIncrement(t *testing.T) {
 		f.Updatable = true
 		f.Readable = true
 	})
+
+	productNonAutoIncrement, err := schema.Parse(&ProductNonAutoIncrement{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("failed to parse productNonAutoIncrement struct with composite primary key, got error %v", err)
+	}
+
+	if productNonAutoIncrement.PrioritizedPrimaryField != nil {
+		t.Fatalf("PrioritizedPrimaryField of non autoincrement composite key should be nil")
+	}
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -293,3 +293,30 @@ func TestEmbeddedStructForCustomizedNamingStrategy(t *testing.T) {
 		})
 	}
 }
+
+func TestCompositePrimaryKeyWithAutoIncrement(t *testing.T) {
+	type Product struct {
+		ProductID    uint `gorm:"primaryKey;autoIncrement"`
+		LanguageCode uint `gorm:"primaryKey"`
+		Code         string
+		Name         string
+	}
+
+	product, err := schema.Parse(&Product{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("failed to parse product struct with composite primary key, got error %v", err)
+	}
+
+	prioritizedPrimaryField := schema.Field{
+		Name: "ProductID", DBName: "product_id", BindNames: []string{"ProductID"}, DataType: schema.Uint, PrimaryKey: true, Size: 64, HasDefaultValue: true, AutoIncrement: true, TagSettings: map[string]string{"PRIMARYKEY": "PRIMARYKEY", "AUTOINCREMENT": "AUTOINCREMENT"},
+	}
+
+	product.Fields = []*schema.Field{product.PrioritizedPrimaryField}
+
+	checkSchemaField(t, product, &prioritizedPrimaryField, func(f *schema.Field) {
+		f.Creatable = true
+		f.Updatable = true
+		f.Readable = true
+	})
+
+}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -318,5 +318,4 @@ func TestCompositePrimaryKeyWithAutoIncrement(t *testing.T) {
 		f.Updatable = true
 		f.Readable = true
 	})
-
 }

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -556,8 +556,7 @@ func TestCreateWithAutoIncrementCompositeKey(t *testing.T) {
 		Name         string
 	}
 
-	err := DB.Migrator().DropTable(&CompositeKeyProduct{})
-	if err = DB.AutoMigrate(&CompositeKeyProduct{}); err != nil {
+	if err := DB.AutoMigrate(&CompositeKeyProduct{}); err != nil {
 		t.Fatalf("failed to migrate, got error %v", err)
 	}
 


### PR DESCRIPTION
Fix #4930 workaround for databases that support auto-increment in composite primary key.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Fix issue https://github.com/go-gorm/gorm/issues/4930
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
In MySQL, you can have composite primary key with auto-increment 
For example:

https://github.com/nash90/playground/blob/7a82d16b1b1b626df01cf43089b302de7c2a6bd9/models.go#L63-L70
```go
type CompositeKeyProduct struct {
	ProductPointID int       `gorm:"primaryKey;autoIncrement:true;column:product_point_id"`
	LanguageCode   int       `gorm:"primaryKey;autoIncrement:false;column:language_code"`
	Code           string    `gorm:"column:code"`
	Name           string    `gorm:"column:name"`
	CreatedAt      time.Time `gorm:"column:created_at"`
	UpdatedAt      time.Time `gorm:"column:updated_at"`
}
```

Upon insert new record into `CompositeKeyProduct` with the following values:
https://github.com/nash90/playground/blob/7a82d16b1b1b626df01cf43089b302de7c2a6bd9/main_test.go#L26-L30
```go
prod := &CompositeKeyProduct{
		LanguageCode: 56,
		Code:         "56",
		Name:         "Test56",
}

res := DB.Create(prod)
```

expected 
```
prod.ProductPointID: 1
```

actual
```
prod.ProductPointID: 0
```

This Pull Request is aiming to fix the above case

<!-- Your use case -->
