### PR TITLE
save should be idempotent

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -106,7 +106,7 @@ func (db *DB) Save(value interface{}) (tx *DB) {
 		updateTx := tx.callbacks.Update().Execute(tx.Session(&Session{Initialized: true}))
 
 		if updateTx.Error == nil && updateTx.RowsAffected == 0 && !updateTx.DryRun && !selectedUpdate {
-			return tx.Create(value)
+			return tx.Clauses(clause.OnConflict{UpdateAll: true}).Create(value)
 		}
 
 		return updateTx

--- a/tests/update_test.go
+++ b/tests/update_test.go
@@ -610,6 +610,25 @@ func TestUpdateFromSubQuery(t *testing.T) {
 	}
 }
 
+func TestIdempotentSave(t *testing.T) {
+	create := Company{
+		Name: "company_idempotent",
+	}
+	DB.Create(&create)
+
+	var company Company
+	if err := DB.Find(&company, "id = ?", create.ID).Error; err != nil {
+		t.Fatalf("failed to find created company, got err: %v", err)
+	}
+
+	if err := DB.Save(&company).Error; err != nil || company.ID != create.ID {
+		t.Errorf("failed to save company, got err: %v", err)
+	}
+	if err := DB.Save(&company).Error; err != nil || company.ID != create.ID {
+		t.Errorf("failed to save company, got err: %v", err)
+	}
+}
+
 func TestSave(t *testing.T) {
 	user := *GetUser("save", Config{})
 	DB.Create(&user)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Save should be idempotent. #6139 #6134 

When call `Save` twice with the same object, `Save` should not raise an error.
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
```golang
var company Company
DB.Frist(&company)

DB.Save(&company)
DB.Save(&company) // should not create new record or rasise an error.
DB.Save(&company) // should not create new record or rasise an error.
```
