### PR TITLE
fix cond in scopes

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -74,13 +74,7 @@ func (cs *callbacks) Raw() *processor {
 
 func (p *processor) Execute(db *DB) *DB {
 	// call scopes
-	for len(db.Statement.scopes) > 0 {
-		scopes := db.Statement.scopes
-		db.Statement.scopes = nil
-		for _, scope := range scopes {
-			db = scope(db)
-		}
-	}
+	db = db.executeScopes(false)
 
 	var (
 		curTime           = time.Now()

--- a/callbacks.go
+++ b/callbacks.go
@@ -74,7 +74,9 @@ func (cs *callbacks) Raw() *processor {
 
 func (p *processor) Execute(db *DB) *DB {
 	// call scopes
-	db = db.executeScopes(false)
+	for len(db.Statement.scopes) > 0 {
+		db = db.executeScopes()
+	}
 
 	var (
 		curTime           = time.Now()

--- a/chainable_api.go
+++ b/chainable_api.go
@@ -366,7 +366,7 @@ func (db *DB) Scopes(funcs ...func(*DB) *DB) (tx *DB) {
 	return tx
 }
 
-func (db *DB) executeScopes(keepScopes bool) (tx *DB) {
+func (db *DB) executeScopes() (tx *DB) {
 	tx = db.getInstance()
 	scopes := db.Statement.scopes
 	if len(scopes) == 0 {
@@ -392,9 +392,6 @@ func (db *DB) executeScopes(keepScopes bool) (tx *DB) {
 
 	for _, condition := range conditions {
 		tx.Statement.AddClause(condition)
-	}
-	if keepScopes {
-		tx.Statement.scopes = scopes
 	}
 	return tx
 }

--- a/chainable_api.go
+++ b/chainable_api.go
@@ -366,6 +366,39 @@ func (db *DB) Scopes(funcs ...func(*DB) *DB) (tx *DB) {
 	return tx
 }
 
+func (db *DB) executeScopes(keepScopes bool) (tx *DB) {
+	tx = db.getInstance()
+	scopes := db.Statement.scopes
+	if len(scopes) == 0 {
+		return tx
+	}
+	tx.Statement.scopes = nil
+
+	conditions := make([]clause.Interface, 0, 4)
+	if cs, ok := tx.Statement.Clauses["WHERE"]; ok && cs.Expression != nil {
+		conditions = append(conditions, cs.Expression.(clause.Interface))
+		cs.Expression = nil
+		tx.Statement.Clauses["WHERE"] = cs
+	}
+
+	for _, scope := range scopes {
+		tx = scope(tx)
+		if cs, ok := tx.Statement.Clauses["WHERE"]; ok && cs.Expression != nil {
+			conditions = append(conditions, cs.Expression.(clause.Interface))
+			cs.Expression = nil
+			tx.Statement.Clauses["WHERE"] = cs
+		}
+	}
+
+	for _, condition := range conditions {
+		tx.Statement.AddClause(condition)
+	}
+	if keepScopes {
+		tx.Statement.scopes = scopes
+	}
+	return tx
+}
+
 // Preload preload associations with given conditions
 //
 //	// get all users, and preload all non-cancelled orders

--- a/migrator.go
+++ b/migrator.go
@@ -12,7 +12,9 @@ func (db *DB) Migrator() Migrator {
 	tx := db.getInstance()
 
 	// apply scopes to migrator
-	tx.executeScopes(false)
+	for len(tx.Statement.scopes) > 0 {
+		tx = tx.executeScopes()
+	}
 
 	return tx.Dialector.Migrator(tx.Session(&Session{}))
 }

--- a/migrator.go
+++ b/migrator.go
@@ -12,13 +12,7 @@ func (db *DB) Migrator() Migrator {
 	tx := db.getInstance()
 
 	// apply scopes to migrator
-	for len(tx.Statement.scopes) > 0 {
-		scopes := tx.Statement.scopes
-		tx.Statement.scopes = nil
-		for _, scope := range scopes {
-			tx = scope(tx)
-		}
-	}
+	tx.executeScopes(false)
 
 	return tx.Dialector.Migrator(tx.Session(&Session{}))
 }

--- a/statement.go
+++ b/statement.go
@@ -324,7 +324,7 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 		case clause.Expression:
 			conds = append(conds, v)
 		case *DB:
-			v.executeScopes(true)
+			v.executeScopes()
 
 			if cs, ok := v.Statement.Clauses["WHERE"]; ok && cs.Expression != nil {
 				if where, ok := cs.Expression.(clause.Where); ok {

--- a/statement.go
+++ b/statement.go
@@ -324,11 +324,9 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 		case clause.Expression:
 			conds = append(conds, v)
 		case *DB:
-			for _, scope := range v.Statement.scopes {
-				v = scope(v)
-			}
+			v.executeScopes(true)
 
-			if cs, ok := v.Statement.Clauses["WHERE"]; ok {
+			if cs, ok := v.Statement.Clauses["WHERE"]; ok && cs.Expression != nil {
 				if where, ok := cs.Expression.(clause.Where); ok {
 					if len(where.Exprs) == 1 {
 						if orConds, ok := where.Exprs[0].(clause.OrConditions); ok {
@@ -336,8 +334,12 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 						}
 					}
 					conds = append(conds, clause.And(where.Exprs...))
-				} else if cs.Expression != nil {
+				} else {
 					conds = append(conds, cs.Expression)
+				}
+				if v.Statement == stmt {
+					cs.Expression = nil
+					stmt.Statement.Clauses["WHERE"] = cs
 				}
 			}
 		case map[interface{}]interface{}:

--- a/tests/scopes_test.go
+++ b/tests/scopes_test.go
@@ -72,3 +72,54 @@ func TestScopes(t *testing.T) {
 		t.Errorf("select max(id)")
 	}
 }
+
+func TestComplexScopes(t *testing.T) {
+	tests := []struct {
+		name     string
+		queryFn  func(tx *gorm.DB) *gorm.DB
+		expected string
+	}{
+		{
+			name: "depth_1",
+			queryFn: func(tx *gorm.DB) *gorm.DB {
+				return tx.Scopes(
+					func(d *gorm.DB) *gorm.DB { return d.Where("a = 1") },
+					func(d *gorm.DB) *gorm.DB { return d.Where(d.Or("b = 2").Or("c = 3")) },
+				).Find(&Language{})
+			},
+			expected: "SELECT * FROM `languages` WHERE a = 1 AND (b = 2 OR c = 3)",
+		}, {
+			name: "depth_1_pre_cond",
+			queryFn: func(tx *gorm.DB) *gorm.DB {
+				return tx.Where("z = 0").Scopes(
+					func(d *gorm.DB) *gorm.DB { return d.Where("a = 1") },
+					func(d *gorm.DB) *gorm.DB { return d.Or(d.Where("b = 2").Or("c = 3")) },
+				).Find(&Language{})
+			},
+			expected: "SELECT * FROM `languages` WHERE z = 0 AND a = 1 OR (b = 2 OR c = 3)",
+		}, {
+			name: "depth_2",
+			queryFn: func(tx *gorm.DB) *gorm.DB {
+				return tx.Scopes(
+					func(d *gorm.DB) *gorm.DB { return d.Model(&Language{}) },
+					func(d *gorm.DB) *gorm.DB {
+						return d.
+							Or(d.Scopes(
+								func(d *gorm.DB) *gorm.DB { return d.Where("a = 1") },
+								func(d *gorm.DB) *gorm.DB { return d.Where("b = 2") },
+							)).
+							Or("c = 3")
+					},
+					func(d *gorm.DB) *gorm.DB { return d.Where("d = 4") },
+				).Find(&Language{})
+			},
+			expected: "SELECT * FROM `languages` WHERE d = 4 OR c = 3 OR (a = 1 AND b = 2)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertEqualSQL(t, test.expected, DB.ToSQL(test.queryFn))
+		})
+	}
+}

--- a/tests/scopes_test.go
+++ b/tests/scopes_test.go
@@ -87,7 +87,7 @@ func TestComplexScopes(t *testing.T) {
 					func(d *gorm.DB) *gorm.DB { return d.Where(d.Or("b = 2").Or("c = 3")) },
 				).Find(&Language{})
 			},
-			expected: "SELECT * FROM `languages` WHERE a = 1 AND (b = 2 OR c = 3)",
+			expected: `SELECT * FROM "languages" WHERE a = 1 AND (b = 2 OR c = 3)`,
 		}, {
 			name: "depth_1_pre_cond",
 			queryFn: func(tx *gorm.DB) *gorm.DB {
@@ -96,7 +96,7 @@ func TestComplexScopes(t *testing.T) {
 					func(d *gorm.DB) *gorm.DB { return d.Or(d.Where("b = 2").Or("c = 3")) },
 				).Find(&Language{})
 			},
-			expected: "SELECT * FROM `languages` WHERE z = 0 AND a = 1 OR (b = 2 OR c = 3)",
+			expected: `SELECT * FROM "languages" WHERE z = 0 AND a = 1 OR (b = 2 OR c = 3)`,
 		}, {
 			name: "depth_2",
 			queryFn: func(tx *gorm.DB) *gorm.DB {
@@ -113,7 +113,7 @@ func TestComplexScopes(t *testing.T) {
 					func(d *gorm.DB) *gorm.DB { return d.Where("d = 4") },
 				).Find(&Language{})
 			},
-			expected: "SELECT * FROM `languages` WHERE d = 4 OR c = 3 OR (a = 1 AND b = 2)",
+			expected: `SELECT * FROM "languages" WHERE d = 4 OR c = 3 OR (a = 1 AND b = 2)`,
 		},
 	}
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

fix conditions in `Scope` #6148 

### User Case Description

```go
DB.Table("test").Scopes(
	func(d *gorm.DB) *gorm.DB {
		return d.Where("a = 1")
	},
	func(d *gorm.DB) *gorm.DB {
		return d.Where(d.Or("b = 2").Or("c = 3"))
	},
).Rows()
```
It should be:
```sql
SELECT * FROM `test` WHERE a = 1 AND (b = 2 OR c = 3)
```
But now it is:
```sql
SELECT * FROM `test` WHERE a = 1 OR b = 2 OR c = 3 AND (a = 1 OR b = 2 OR c = 3)
```
