### PR TITLE
Add ping method to satisy interface

### DIFF
--- a/prepare_stmt.go
+++ b/prepare_stmt.go
@@ -32,6 +32,15 @@ func (db *PreparedStmtDB) GetDBConn() (*sql.DB, error) {
 	return nil, ErrInvalidDB
 }
 
+func (db *PreparedStmtDB) Ping() error {
+	sqldb, err := db.GetDBConn()
+	if err != nil {
+		return err
+	}
+
+	return sqldb.Ping()
+}
+
 func (db *PreparedStmtDB) Close() {
 	db.Mux.Lock()
 	defer db.Mux.Unlock()


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

There is a issue when using Prepared Statments Caching and opening a DB.

`PreparedStmtDB` does not implement `Ping()` to satisfy the interface. This is allowing bad connection strings or a non reachable DB to never be caught when using prepared statements and calling `Open()` because `Ping()` will never be called. `Open()` returns a `*gomr.DB` and a `nil error`.

This implements the `Ping()` method on the `gorm.PreparedStmtDB` allowing us to catch connection failures. The way gorm checks interfaces is not the best in my opinion.  i.e. https://github.com/phenixrizen/gorm/blob/master/gorm.go#L203-L207

Fixes https://github.com/go-gorm/gorm/issues/6181

### User Case Description

I want to ping the db when using the  Prepared Statments Caching.


