### PR TITLE
fix: `limit(0).offset(b)` return all data, where b <= 0

### DIFF
--- a/clause/limit.go
+++ b/clause/limit.go
@@ -33,7 +33,7 @@ func (limit Limit) MergeClause(clause *Clause) {
 	clause.Name = ""
 
 	if v, ok := clause.Expression.(Limit); ok {
-		if (limit.Limit == nil || *limit.Limit == 0) && (v.Limit != nil && *v.Limit != 0) {
+		if (limit.Limit == nil || *limit.Limit == 0) && v.Limit != nil {
 			limit.Limit = v.Limit
 		}
 

--- a/clause/limit_test.go
+++ b/clause/limit_test.go
@@ -29,6 +29,10 @@ func TestLimit(t *testing.T) {
 			"SELECT * FROM `users` LIMIT 0", nil,
 		},
 		{
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Limit: &limit0}, clause.Limit{Offset: 0}},
+			"SELECT * FROM `users` LIMIT 0", nil,
+		},
+		{
 			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Offset: 20}},
 			"SELECT * FROM `users` OFFSET 20", nil,
 		},


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

fix for issue https://github.com/go-gorm/gorm/issues/6188#issue-1641432003



<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->


when execute `db.Limit(0).Offset(0).Where("id > ?", 10).Find(&users)`, it will return all data satified where condition. Namely, sql generated is `select * from users where id > 10`, but not `select * from users where id > 10 limit 0`, which is diff from sql semantics.


