### PR TITLE
issue #6098

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -144,7 +144,20 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 	}
 
 	if config.NamingStrategy == nil {
-		config.NamingStrategy = schema.NamingStrategy{}
+		// Set default value of IdentifierMaxLength according to the database type
+		identifierMaxLength := 64
+		switch dialector.Name() {
+		case "mysql":
+			identifierMaxLength = 64
+		case "postgres":
+			identifierMaxLength = 63
+		case "sqlite":
+			identifierMaxLength = 64
+		case "sqlserver":
+			identifierMaxLength = 128
+		}
+
+		config.NamingStrategy = schema.NamingStrategy{NamingStrategyConfig: schema.NamingStrategyConfig{IdentifierMaxLength: identifierMaxLength}}
 	}
 
 	if config.Logger == nil {

--- a/schema/check_test.go
+++ b/schema/check_test.go
@@ -15,7 +15,7 @@ type UserCheck struct {
 }
 
 func TestParseCheck(t *testing.T) {
-	user, err := schema.Parse(&UserCheck{}, &sync.Map{}, schema.NamingStrategy{})
+	user, err := schema.Parse(&UserCheck{}, &sync.Map{}, schema.NamingStrategy{NamingStrategyConfig: schema.NamingStrategyConfig{IdentifierMaxLength: 64}})
 	if err != nil {
 		t.Fatalf("failed to parse user check, got error %v", err)
 	}

--- a/schema/index_test.go
+++ b/schema/index_test.go
@@ -52,7 +52,7 @@ type CompIdxLevel2B struct {
 }
 
 func TestParseIndex(t *testing.T) {
-	user, err := schema.Parse(&UserIndex{}, &sync.Map{}, schema.NamingStrategy{})
+	user, err := schema.Parse(&UserIndex{}, &sync.Map{}, schema.NamingStrategy{NamingStrategyConfig: schema.NamingStrategyConfig{IdentifierMaxLength: 64}})
 	if err != nil {
 		t.Fatalf("failed to parse user index, got error %v", err)
 	}

--- a/schema/naming.go
+++ b/schema/naming.go
@@ -32,6 +32,17 @@ type NamingStrategy struct {
 	SingularTable bool
 	NameReplacer  Replacer
 	NoLowerCase   bool
+	NamingStrategyConfig
+}
+
+// This struct is used to configure the behavior NamingStrategy, according to DB.
+// For example, in MySQL, the maximum length of an identifier is 64 characters.
+// In PostgreSQL, the maximum length of an identifier is 63 characters.
+// In SQL Server, the maximum length of an identifier is 128 characters.
+// In SQLite, the maximum length of an identifier is unlimited.
+// In future, we may add more options to NamingStrategyConfig.
+type NamingStrategyConfig struct {
+	IdentifierMaxLength int
 }
 
 // TableName convert string to table name
@@ -89,12 +100,12 @@ func (ns NamingStrategy) formatName(prefix, table, name string) string {
 		prefix, table, name,
 	}, "_"), ".", "_")
 
-	if utf8.RuneCountInString(formattedName) > 64 {
+	if utf8.RuneCountInString(formattedName) > ns.IdentifierMaxLength {
 		h := sha1.New()
 		h.Write([]byte(formattedName))
 		bs := h.Sum(nil)
 
-		formattedName = formattedName[0:56] + hex.EncodeToString(bs)[:8]
+		formattedName = formattedName[0:ns.IdentifierMaxLength-8] + hex.EncodeToString(bs)[:8]
 	}
 	return formattedName
 }

--- a/schema/relationship_test.go
+++ b/schema/relationship_test.go
@@ -642,7 +642,7 @@ func TestParseConstraintNameWithSchemaQualifiedLongTableName(t *testing.T) {
 	s, err := schema.Parse(
 		&Book{},
 		&sync.Map{},
-		schema.NamingStrategy{},
+		schema.NamingStrategy{NamingStrategyConfig: schema.NamingStrategyConfig{IdentifierMaxLength: 64}},
 	)
 	if err != nil {
 		t.Fatalf("Failed to parse schema")


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [*] Do only one thing
- [*] Non breaking API changes
- [*] Tested

### What did this pull request do?
It solves the issue [Postgres Max Identifier length is 63 bytes](https://github.com/go-gorm/gorm/issues/6098) 
<!--
provide a general description of the code changes in your pull request
-->
NamingStrategyConfig struct is added in schema.NamingStrategy, for supporting Max Identifier Lengths in different databases
Identifier Length support is added for Mysql(64),MS Sql Server ( 128),Sqlite (it has unlimited but default 64 is used), Postgres (63)
### User Case Description

<!-- Your use case -->

All test cases are updated. All tests have passed
