### PR TITLE
fix: many2many association with duplicate belongs to elem

### DIFF
--- a/callbacks/associations.go
+++ b/callbacks/associations.go
@@ -51,25 +51,40 @@ func SaveBeforeAssociations(create bool) func(db *gorm.DB) {
 					}
 
 					elems := reflect.MakeSlice(reflect.SliceOf(fieldType), 0, 10)
+					distinctElems := reflect.MakeSlice(reflect.SliceOf(fieldType), 0, 10)
+					identityMap := map[string]bool{}
 					for i := 0; i < rValLen; i++ {
 						obj := db.Statement.ReflectValue.Index(i)
 						if reflect.Indirect(obj).Kind() != reflect.Struct {
 							break
 						}
-
 						if _, zero := rel.Field.ValueOf(db.Statement.Context, obj); !zero { // check belongs to relation value
 							rv := rel.Field.ReflectValueOf(db.Statement.Context, obj) // relation reflect value
+							if !isPtr {
+								rv = rv.Addr()
+							}
 							objs = append(objs, obj)
-							if isPtr {
-								elems = reflect.Append(elems, rv)
-							} else {
-								elems = reflect.Append(elems, rv.Addr())
+							elems = reflect.Append(elems, rv)
+
+							relPrimaryValues := make([]interface{}, 0, len(rel.FieldSchema.PrimaryFields))
+							for _, pf := range rel.FieldSchema.PrimaryFields {
+								if pfv, ok := pf.ValueOf(db.Statement.Context, rv); !ok {
+									relPrimaryValues = append(relPrimaryValues, pfv)
+								}
+							}
+							cacheKey := utils.ToStringKey(relPrimaryValues...)
+							if len(relPrimaryValues) != len(rel.FieldSchema.PrimaryFields) || !identityMap[cacheKey] {
+								if cacheKey != "" { // has primary fields
+									identityMap[cacheKey] = true
+								}
+
+								distinctElems = reflect.Append(distinctElems, rv)
 							}
 						}
 					}
 
 					if elems.Len() > 0 {
-						if saveAssociations(db, rel, elems, selectColumns, restricted, nil) == nil {
+						if saveAssociations(db, rel, distinctElems, selectColumns, restricted, nil) == nil {
 							for i := 0; i < elems.Len(); i++ {
 								setupReferences(objs[i], elems.Index(i))
 							}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Extends https://github.com/go-gorm/gorm/pull/5473 to `many2many` models with `belongs to` associations.
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
Using the following models that have `many2many` and `belongs to` associations:
```
type Application struct {
	ID        string `gorm:"primarykey"`
	Name      string
	Resources []Resource 
}

type Resource struct {
	ID       string `gorm:"primarykey"`
	Name     string
	OwnerId  string
	Owner    Owner 
}

type Owner struct {
	ID   string `gorm:"primarykey"`
	Name string
}
```
In cases where two resources share the same `Owner`, attempting to update an `Application` using `FullSaveAssociations: true` will result in an error. GORM tries to insert the same `Owner` multiple times in a single INSERT command: 
```
INSERT INTO "owner" ("id","name") VALUES ('1','owner-1'),('1','owner-1') ON CONFLICT ("id") DO UPDATE SET "name"="excluded"."name"
ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time (SQLSTATE 21000)
```
After the fix, GORM will identify and insert only the unique owner(s):
```
INSERT INTO "owner" ("id","name") VALUES ('1','owner-1') ON CONFLICT ("id") DO UPDATE SET "name"="excluded"."name"
```
<!-- Your use case -->
