### PR TITLE
fix(nested transaction): SavePoint SQL Statement not support in Prepared Statements

### DIFF
--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -57,6 +57,19 @@ func TestTransaction(t *testing.T) {
 	if err := DB.First(&User{}, "name = ?", "transaction-2").Error; err != nil {
 		t.Fatalf("Should be able to find committed record, but got %v", err)
 	}
+
+	t.Run("this is test nested transaction and prepareStmt coexist case", func(t *testing.T) {
+		// enable prepare statement
+		tx3 := DB.Session(&gorm.Session{PrepareStmt: true})
+		if err := tx3.Transaction(func(tx4 *gorm.DB) error {
+			// nested transaction
+			return tx4.Transaction(func(tx5 *gorm.DB) error {
+				return tx5.First(&User{}, "name = ?", "transaction-2").Error
+			})
+		}); err != nil {
+			t.Fatalf("prepare statement and nested transcation coexist" + err.Error())
+		}
+	})
 }
 
 func TestCancelTransaction(t *testing.T) {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
fix(nested transaction): SavePoint SQL Statement not support in Prepared Statements

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
Nested transactions are implemented through savepoint, but savepoint does not support precompiled statements, and if the session is enabled for precompilation, nested transactions will fail
<!-- Your use case -->
