### PR TITLE
feat: on soft delete, update additional fields from model/struct in the same update operation by using "updateOnSoftDelete" field tag

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -62,6 +62,7 @@ type Field struct {
 	Creatable              bool
 	Updatable              bool
 	Readable               bool
+	UpdateOnSoftDelete     bool
 	AutoCreateTime         TimeType
 	AutoUpdateTime         TimeType
 	HasDefaultValue        bool
@@ -113,6 +114,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		Creatable:              true,
 		Updatable:              true,
 		Readable:               true,
+		UpdateOnSoftDelete:     false,
 		PrimaryKey:             utils.CheckTruth(tagSetting["PRIMARYKEY"], tagSetting["PRIMARY_KEY"]),
 		AutoIncrement:          utils.CheckTruth(tagSetting["AUTOINCREMENT"]),
 		HasDefaultValue:        utils.CheckTruth(tagSetting["AUTOINCREMENT"]),
@@ -327,6 +329,10 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		case reflect.Int32, reflect.Uint32, reflect.Float32:
 			field.Size = 32
 		}
+	}
+
+	if _, ok := field.TagSettings["UPDATEONSOFTDELETE"]; ok {
+		field.UpdateOnSoftDelete = true
 	}
 
 	// setup permission


### PR DESCRIPTION


<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->


### What did this pull request do?
Added new feature - on soft delete, update additional fields from model/struct in the same update operation by using "updateOnSoftDelete" field tag

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

example:
```
const postgresDSN = "user=root password= dbname=gorm host=localhost port=26257 sslmode=disable TimeZone=Europe/Chisinau"

type User struct {
	ID uuid.UUID `gorm:"primaryKey;type:uuid;not null;->;default:gen_random_uuid()"`

	DeletedByID *uuid.UUID `gorm:"type:uuid;updateOnSoftDelete"`
	DeletedAt   *gorm.DeletedAt
}

func main() {
	db, err := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{})
	if err != nil {
		log.Fatalln(err)
	}

	var id = "60ea2d8f-4fac-42ba-b363-4536f6a8edf4"

	// Retrieve the user
	var user User
	result := db.First(&user, "id = ?", id)
	if result.Error != nil {
		log.Fatalln(result.Error)
	}

	// Set the user who will delete the record
	deletedByID := uuid.New()
	user.DeletedByID = &deletedByID

	// Delete
	result = db.Delete(&user)
	if result.Error != nil {
		log.Fatalln(result.Error)
	}
}
```
