### PR TITLE
fix: avoid coroutine leaks when the dialecter initialization fails.

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -179,6 +179,12 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 
 	if config.Dialector != nil {
 		err = config.Dialector.Initialize(db)
+
+		if err != nil {
+			if db, err := db.DB(); err == nil {
+				_ = db.Close()
+			}
+		}
 	}
 
 	preparedStmt := &PreparedStmtDB{


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

When calling `gorm.Open`, there is the following code:

```go
if config.Dialector != nil {
	err = config.Dialector.Initialize(db)
}
``` 

`config.Dialector.Initialize(db)` typically calls [`sql.OpenDB`][sql-opendb] to create an `*sql.DB`, and starts an goroutine `db.connectionOpener(ctx)`.

Next, a typical database driver will attempt to connect to the schema specified in the DSN. If an error occurs at this time (such as the specified schema not existing), it will cause `config.Dialector.Initialize(db)` to return an error. However, after receiving this error, GORM does not attempt to close `*sql.DB`. This causes the `db.connectionOpener(ctx)` goroutine to leak.

In my scenario, I used the wrong schema and retried calling `gorm.Open` multiple times. By observing the dumped goroutine, I found that there were a large number of `db.connectionOpener(ctx)` goroutines. After applying this code fix, these goroutines are no longer leaked.

This pull request try to close the `*sql.DB` variable if possible.

[sql-opendb]: https://github.com/golang/go/blob/go1.20.3/src/database/sql/sql.go#L781

### User Case Description

Same as above.
