### PR TITLE
omit() support called in chain

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -178,9 +178,9 @@ func (db *DB) Omit(columns ...string) (tx *DB) {
 	tx = db.getInstance()
 
 	if len(columns) == 1 && strings.ContainsRune(columns[0], ',') {
-		tx.Statement.Omits = strings.FieldsFunc(columns[0], utils.IsValidDBNameChar)
+		tx.Statement.Omits = append(tx.Statement.Omits, strings.FieldsFunc(columns[0], utils.IsValidDBNameChar)...)
 	} else {
-		tx.Statement.Omits = columns
+		tx.Statement.Omits = append(tx.Statement.Omits, columns...)
 	}
 	return
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [✅] Do only one thing
- [✅] Non breaking API changes
- [✅] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Usually, function omit() is used in a huge database table to improve performance. We got an instinct that gorm support method chaining like where() clause, but omit() does not. When omit() was used, the next call would rewrite the content of the last one. It is dangerous, especially while updating, which could cause unexpected inserts. It is easy to make a fix to support method chaining calls as while as forward compatibility. Just use append().

### User Case Description
Table Doc has association tables "Versions" and "Team". When I tried to update a "Doc" record, gorm would help upsert Versions and Team. To avoid it, I use the function omit() like the following:
![image](https://user-images.githubusercontent.com/50512170/235052981-fcae815b-718e-4a3b-8755-ad037815b8d3.png)
Omit ("Versions") did overwrite by omit("Team"), which caused thousands of upsert request occurs every time I clicked the button on my site, and finally, my database broke down.
There was not any warning message or tips telling me it may be a wrong usage. 

<!-- Your use case -->
