### PR TITLE
feat: add handling for the interface field, when an Interface field i…

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jinzhu/now"
+
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/utils"
 )
@@ -120,6 +121,16 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		Unique:                 utils.CheckTruth(tagSetting["UNIQUE"]),
 		Comment:                tagSetting["COMMENT"],
 		AutoIncrementIncrement: 1,
+	}
+
+	if field.IndirectFieldType.Kind() == reflect.Interface {
+		f := schema.ModelValue.FieldByName(fieldStruct.Name)
+		if f.IsValid() {
+			e := f.Elem()
+			if e.IsValid() {
+				field.IndirectFieldType = e.Type()
+			}
+		}
 	}
 
 	for field.IndirectFieldType.Kind() == reflect.Ptr {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -115,7 +115,6 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 		value = reflect.New(value.Type().Elem())
 	}
 
-	modelValue := reflect.Indirect(value)
 	modelType := reflect.Indirect(value).Type()
 
 	if modelType.Kind() == reflect.Interface {
@@ -150,6 +149,7 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 		return s, s.err
 	}
 
+	modelValue := reflect.New(modelType)
 	tableName := namer.TableName(modelType.Name())
 	if tabler, ok := modelValue.Interface().(Tabler); ok {
 		tableName = tabler.TableName()
@@ -166,7 +166,7 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 
 	schema := &Schema{
 		Name:             modelType.Name(),
-		ModelValue:       modelValue,
+		ModelValue:       reflect.Indirect(value),
 		ModelType:        modelType,
 		Table:            tableName,
 		FieldsByName:     map[string]*Field{},

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -18,6 +18,7 @@ var ErrUnsupportedDataType = errors.New("unsupported data type")
 
 type Schema struct {
 	Name                      string
+	ModelValue                reflect.Value
 	ModelType                 reflect.Type
 	Table                     string
 	PrioritizedPrimaryField   *Field
@@ -113,6 +114,8 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 	if value.Kind() == reflect.Ptr && value.IsNil() {
 		value = reflect.New(value.Type().Elem())
 	}
+
+	modelValue := reflect.Indirect(value)
 	modelType := reflect.Indirect(value).Type()
 
 	if modelType.Kind() == reflect.Interface {
@@ -147,7 +150,6 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 		return s, s.err
 	}
 
-	modelValue := reflect.New(modelType)
 	tableName := namer.TableName(modelType.Name())
 	if tabler, ok := modelValue.Interface().(Tabler); ok {
 		tableName = tabler.TableName()
@@ -164,6 +166,7 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 
 	schema := &Schema{
 		Name:             modelType.Name(),
+		ModelValue:       modelValue,
 		ModelType:        modelType,
 		Table:            tableName,
 		FieldsByName:     map[string]*Field{},

--- a/tests/interface_test.go
+++ b/tests/interface_test.go
@@ -1,0 +1,23 @@
+package tests_test
+
+import (
+	"testing"
+
+	"gorm.io/gorm/utils/tests"
+	. "gorm.io/gorm/utils/tests"
+)
+
+func TestInterface(t *testing.T) {
+	vehicleWrite := &tests.Vehicle{Meta: &tests.MotorMeta{Power: "electric"}}
+
+	if err := DB.Create(vehicleWrite).Error; err != nil {
+		t.Fatalf("fail to create region %v", err)
+	}
+
+	vehicleRead := &tests.Vehicle{Meta: &tests.MotorMeta{}}
+	if err := DB.Debug().First(vehicleRead, "id = ?", vehicleWrite.ID).Error; err != nil {
+		t.Fatalf("fail to find vehicle %v", err)
+	} else {
+		AssertEqual(t, vehicleWrite.Meta.(*tests.MotorMeta).Power, vehicleRead.Meta.(*tests.MotorMeta).Power)
+	}
+}

--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/driver/sqlserver"
+
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 	. "gorm.io/gorm/utils/tests"
@@ -107,7 +108,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Coupon{}, &CouponProduct{}, &Order{}, &Parent{}, &Child{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Coupon{}, &CouponProduct{}, &Order{}, &Parent{}, &Child{}, &Vehicle{Meta: &MotorMeta{}}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 


### PR DESCRIPTION
feat: add handling for the interface field, when an Interface field is an object that has already been instantiated, use the type of the instantiated object itself instead of interface{}.

```go
type BaseMeta interface {
    // Scan....
}
type Meta1 struct {
}
// meta1 Scan ...
type Meta2 struct {
}
// meta2 Scan ...
type Hello struct {
    Meta BaseMeta `gorm:"type:JSON;column:meta"`
}

// ...
// hello := &Hello{ Meta: &Meta1{} }
// db.First(hello).Error...
```

