### PR TITLE
fix:clickhouse error not capture(#6277)

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -533,6 +533,7 @@ func (db *DB) Scan(dest interface{}) (tx *DB) {
 			tx.ScanRows(rows, dest)
 		} else {
 			tx.RowsAffected = 0
+			tx.AddError(rows.Err())
 		}
 		tx.AddError(rows.Close())
 	}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

return err if the query exceed single select sql memory limit. [#6277 ](https://github.com/go-gorm/gorm/issues/6277)

### User Case Description

```go
type User struct {
	Name     string
	Age      uint64
	Birthday string
	Account  string
	Company  string
}
func TestGORM(t *testing.T) {

	// append data
	user := User{
		Name:     "ddddddddddddddddddddddddddddddddfsfdsfsd",
		Age:      0,
		Birthday: "dbdfbbbbbbbbbbbbbbbbbbbbbbbbbdfgfdgfdg",
		Account:  "apoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiwe",
		Company:  "apoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiwevvvapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiweapoiorpqwifpofpwiefpiweopfioeifoeifpwifpewifpwifpewifpewifpweifpiwefpiwepfiwpeifpwiefpiwe",
	}
	var users []User = make([]User, 0, 10000)
	for i := 0; i < 10000; i++ {
		users = append(users, user)
	}

	err := DB.CreateInBatches(users, len(users)).Error
	if err != nil {
		t.Errorf("Failed, got error: %v", err)
	}

	//execute will be fail; because exceed clickhouse query memory limit
	//should return err
	var result []*User = make([]*User, 0)
	err = DB.Raw("select * from users limit 10000 settings max_memory_usage = 2;").Scan(&result).Error
	if err == nil {
		t.Errorf("error not capture")
	}
}
``` 
