### PR TITLE
Added support of "Violates Foreign Key Constraint"

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -48,5 +48,5 @@ var (
 	// ErrDuplicatedKey occurs when there is a unique key constraint violation
 	ErrDuplicatedKey = errors.New("duplicated key not allowed")
 	// ErrForeignKeyViolated occurs when there is a foreign key constraint violation
-	ErrForeignKeyViolated = errors.New("Violates foreign key constraint")
+	ErrForeignKeyViolated = errors.New("violates foreign key constraint")
 )

--- a/errors.go
+++ b/errors.go
@@ -47,4 +47,6 @@ var (
 	ErrPreloadNotAllowed = errors.New("preload is not allowed when count is used")
 	// ErrDuplicatedKey occurs when there is a unique key constraint violation
 	ErrDuplicatedKey = errors.New("duplicated key not allowed")
+	// ErrForeignKeyViolated occurs when there is a foreign key constraint violation
+	ErrForeignKeyViolated = errors.New("Violates foreign key constraint")
 )


### PR DESCRIPTION

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [Y ] Do only one thing
- [ Y] Non breaking API changes
- [ Y] Tested

### What did this pull request do?
Updated the translator and added the support of "foreign key constraint violation". For this, this error type is needed here.

<!--
This pull request adds the support for translator to translate pgerrcode 23503 to the native gorm error, ErrForeignKeyViolated (in this PR).
-->

### User Case Description
Lets say I have a struct RoleAssignment having RoleID as a foreign key

```
type RoleAssignment struct {
	RoleID      int         `gorm:"type:INTEGER;NOT NULL"`
	Locations   string      `gorm:"type:VARCHAR(255);NOT NULL"`
	SubjectID   int         `gorm:"type:INTEGER;NOT NULL"`
	SubjectType SubjectType `gorm:"type:VARCHAR(255);NOT NULL"`
	Role        Role
}
```

and I want to insert a record having role_id which does not exist in Role table, here gorm is throwing pgerror which should be translated to gorm error. As suggested below:
```
result := tx.Create(&roleAssignment)
		if result.Error != nil {
			if errors.Is(result.Error, gorm.ErrForeignKeyViolated) {
				// return Custom Error from here 
			}
		}
```

[Pull Request](https://github.com/go-gorm/postgres/pull/185) for https://github.com/go-gorm created.