### PR TITLE
fix: begin transaction fail, rollback panic

### DIFF
--- a/prepare_stmt.go
+++ b/prepare_stmt.go
@@ -3,6 +3,7 @@ package gorm
 import (
 	"context"
 	"database/sql"
+	"reflect"
 	"sync"
 )
 
@@ -163,14 +164,14 @@ type PreparedStmtTX struct {
 }
 
 func (tx *PreparedStmtTX) Commit() error {
-	if tx.Tx != nil {
+	if tx.Tx != nil && !reflect.ValueOf(tx.Tx).IsNil() {
 		return tx.Tx.Commit()
 	}
 	return ErrInvalidTransaction
 }
 
 func (tx *PreparedStmtTX) Rollback() error {
-	if tx.Tx != nil {
+	if tx.Tx != nil && !reflect.ValueOf(tx.Tx).IsNil() {
 		return tx.Tx.Rollback()
 	}
 	return ErrInvalidTransaction


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

fix begin transaction fail, rollback panic

### User Case Description

```go
tx = db.Begin()  // when begin error

err := tx.Where(sql).Update(m).Err
if err = nil{
  tx.Rollback()   // will panic
  return err
}

tx.Commit()
```