### PR TITLE
feat: add SQLConnector

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -375,6 +375,10 @@ func (db *DB) AddError(err error) error {
 func (db *DB) DB() (*sql.DB, error) {
 	connPool := db.ConnPool
 
+	if connector, ok := connPool.(SQLConnector); ok && connector != nil {
+		return connector.GetSQLConn(db)
+	}
+
 	if dbConnector, ok := connPool.(GetDBConnector); ok && dbConnector != nil {
 		return dbConnector.GetDBConn()
 	}

--- a/interfaces.go
+++ b/interfaces.go
@@ -77,6 +77,12 @@ type GetDBConnector interface {
 	GetDBConn() (*sql.DB, error)
 }
 
+// SQLConnector represents SQL db connector which takes into account the current
+// database context
+type SQLConnector interface {
+	GetSQLConn(db *DB) (*sql.DB, error)
+}
+
 // Rows rows interface
 type Rows interface {
 	Columns() ([]string, error)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested (**looks unnecessary**)

### What did this pull request do?

This PR adds ability to provide `*sql.DB` connector which can resolve current connect based on the database context. It works the same as `GetDBConnector` but additionally have `*gorm.DB` state.

### User Case Description

Since we use [DBResolver](https://gorm.io/docs/dbresolver.html) plugin to provide multiple databases support, sometimes it's necessary to get raw `*sql.DB`. At this moment all these statements return the same connection pool, ignoring provided clauses:

```go
db.DB()
db.Clauses(dbresolver.Write).DB()
db.Clauses(dbresolver.Read).DB()
db.Clauses(dbresolver.Use("slow")).DB()
```

However, it seems to us more logical behavior to return different connections based on the current database state.