### PR TITLE
fix: avoid panic when open fails

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -181,7 +181,7 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 		err = config.Dialector.Initialize(db)
 
 		if err != nil {
-			if db, err := db.DB(); err == nil {
+			if db, _ := db.DB(); db != nil {
 				_ = db.Close()
 			}
 		}

--- a/tests/gorm_test.go
+++ b/tests/gorm_test.go
@@ -3,8 +3,18 @@ package tests_test
 import (
 	"testing"
 
+	"gorm.io/driver/mysql"
+
 	"gorm.io/gorm"
 )
+
+func TestOpen(t *testing.T) {
+	dsn := "gorm:gorm@tcp(localhost:9910)/gorm?loc=Asia%2FHongKong" // invalid loc
+	_, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	if err == nil {
+		t.Fatalf("should returns error but got nil")
+	}
+}
 
 func TestReturningWithNullToZeroValues(t *testing.T) {
 	dialect := DB.Dialector.Name()


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
When the open fails (e.g. wrong loc), gorm try to close `sql.db`.  #6249
But db may be nil, we should avoid panic. 
Close #6359 

### User Case Description

<!-- Your use case -->
