### PR TITLE
reafactor: add nil detection when sqldb return

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -379,7 +379,7 @@ func (db *DB) DB() (*sql.DB, error) {
 		return dbConnector.GetDBConn()
 	}
 
-	if sqldb, ok := connPool.(*sql.DB); ok {
+	if sqldb, ok := connPool.(*sql.DB); ok && sqldb != nil {
 		return sqldb, nil
 	}
 

--- a/gorm.go
+++ b/gorm.go
@@ -376,7 +376,9 @@ func (db *DB) DB() (*sql.DB, error) {
 	connPool := db.ConnPool
 
 	if dbConnector, ok := connPool.(GetDBConnector); ok && dbConnector != nil {
-		return dbConnector.GetDBConn()
+		if sqldb, err := dbConnector.GetDBConn(); sqldb != nil && err != nil {
+			return sqldb, err
+		}
 	}
 
 	if sqldb, ok := connPool.(*sql.DB); ok && sqldb != nil {

--- a/gorm.go
+++ b/gorm.go
@@ -181,7 +181,7 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 		err = config.Dialector.Initialize(db)
 
 		if err != nil {
-			if db, _ := db.DB(); db != nil {
+			if db, err := db.DB(); err == nil {
 				_ = db.Close()
 			}
 		}

--- a/gorm.go
+++ b/gorm.go
@@ -376,7 +376,7 @@ func (db *DB) DB() (*sql.DB, error) {
 	connPool := db.ConnPool
 
 	if dbConnector, ok := connPool.(GetDBConnector); ok && dbConnector != nil {
-		if sqldb, err := dbConnector.GetDBConn(); sqldb != nil && err != nil {
+		if sqldb, err := dbConnector.GetDBConn(); sqldb != nil || err != nil {
 			return sqldb, err
 		}
 	}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
This pull request addresses a bug that caused a panic when connecting to the database using an incorrect DSN. The bug has already been fixed in this commit (https://github.com/go-gorm/gorm/commit/c1ea73036715018a1bb55cdb8690441044e13a76). However, to prevent potential future bugs, I have refactored the code to include null detection during type assertion.
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->

https://github.com/go-gorm/gorm/blob/c1ea73036715018a1bb55cdb8690441044e13a76/gorm.go#L374-L387

Before merging this PR (c1ea730), `connPool.(*sql.DB)` returned `nil, nil` which had a negative impact on the called method.