### PR TITLE
refactor: remove unnecessary prepared statement allocation

### DIFF
--- a/prepare_stmt.go
+++ b/prepare_stmt.go
@@ -21,6 +21,15 @@ type PreparedStmtDB struct {
 	ConnPool
 }
 
+func NewPreparedStmtDB(connPool ConnPool) *PreparedStmtDB {
+	return &PreparedStmtDB{
+		ConnPool:    connPool,
+		Stmts:       make(map[string]*Stmt),
+		Mux:         &sync.RWMutex{},
+		PreparedSQL: make([]string, 0, 100),
+	}
+}
+
 func (db *PreparedStmtDB) GetDBConn() (*sql.DB, error) {
 	if dbConnector, ok := db.ConnPool.(GetDBConnector); ok && dbConnector != nil {
 		return dbConnector.GetDBConn()


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR removes unnecessary allocation of prepared statements when initializing a database connection.
