### PR TITLE
Fix incorrect documentation comment (has many -> has one)

### DIFF
--- a/utils/tests/models.go
+++ b/utils/tests/models.go
@@ -11,7 +11,7 @@ import (
 // He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
-// NamedPet is a reference to a Named `Pets` (has many)
+// NamedPet is a reference to a named `Pet` (has one)
 type User struct {
 	gorm.Model
 	Name      string


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fixes an incorrect documentation comment. The comment says "NamedPet is a reference to a Named `Pets` (has many)", but it's actually a reference to a single Pet (`NamedPet  *Pet`)