### PR TITLE
ci: fix mariadb mysqladmin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
   mysql:
     strategy:
       matrix:
-        dbversion: ['mysql:latest', 'mysql:5.7', 'mariadb:latest']
+        dbversion: ['mysql:latest', 'mysql:5.7']
         go: ['1.19', '1.18']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
@@ -72,7 +72,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
 
-
     - name: go mod package cache
       uses: actions/cache@v3
       with:
@@ -81,6 +80,49 @@ jobs:
 
     - name: Tests
       run: GITHUB_ACTION=true GORM_DIALECT=mysql GORM_DSN="gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True" ./tests/tests_all.sh
+
+  mariadb:
+    strategy:
+      matrix:
+        dbversion: [ 'mariadb:latest' ]
+        go: [ '1.19', '1.18' ]
+        platform: [ ubuntu-latest ]
+    runs-on: ${{ matrix.platform }}
+
+    services:
+      mysql:
+        image: ${{ matrix.dbversion }}
+        env:
+          MYSQL_DATABASE: gorm
+          MYSQL_USER: gorm
+          MYSQL_PASSWORD: gorm
+          MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+        ports:
+          - 9910:3306
+        options: >-
+          --health-cmd "mariadb-admin ping -ugorm -pgorm"
+          --health-interval 10s
+          --health-start-period 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: go mod package cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('tests/go.mod') }}
+
+      - name: Tests
+        run: GITHUB_ACTION=true GORM_DIALECT=mysql GORM_DSN="gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True" ./tests/tests_all.sh
 
   postgres:
     strategy:


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

As of latest image for mariadb the mysqladmin command is gone. we should use mariadb-admin instead.
https://github.com/MariaDB/mariadb-docker/issues/512