### PR TITLE
fix: Open may panic when sql.Open return (nil, error)

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -181,7 +181,7 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 		err = config.Dialector.Initialize(db)
 
 		if err != nil {
-			if db, err := db.DB(); err == nil {
+			if db, err := db.DB(); err == nil && db != nil {
 				_ = db.Close()
 			}
 		}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Open() may panic if sql.Open() return (nil, error) when using with [go-gorm/mysql](https://github.com/go-gorm/mysql). This pull request tries to fix it.

### User Case Description
In my case, I use custom driver based on [go-sql-driver/mysql](https://github.com/go-sql-driver/mysql). Panic happens when OpenConnector() return (nil, err)