### PR TITLE
Add generic error for serialiase/lock-timeout errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -49,4 +49,8 @@ var (
 	ErrDuplicatedKey = errors.New("duplicated key not allowed")
 	// ErrForeignKeyViolated occurs when there is a foreign key constraint violation
 	ErrForeignKeyViolated = errors.New("violates foreign key constraint")
+	// ErrLockTimeout occurs when a statement timed outs while waiting for row or table locks.
+	ErrLockTimeout = errors.New("lock wait timeout")
+	// ErrSerialisationFailure occurs when SERIALIZABLE tx can not be serialised with some other tx
+	ErrSerialisationFailure = errors.New("TX can not be serialized")
 )


### PR DESCRIPTION
- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

These are quite generic errors and drivers can translate into it. Will add translations to drivers in separate PRs.

### User Case Description

Both errors can be properly handled by user code - e.g. retried.