### PR TITLE
feat(tests): support pure-go sqlite driver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
   sqlite:
     strategy:
       matrix:
-        go: ['1.19', '1.18']
+        go: ['^1', '1.19', '1.18']
         platform: [ubuntu-latest] # can not run in windows OS
     runs-on: ${{ matrix.platform }}
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,18 +1,49 @@
 module gorm.io/gorm/tests
 
-go 1.16
+go 1.18
+
+replace gorm.io/driver/sqlite => github.com/aymanbagabas/sqlite v1.5.3-0.20230705235344-744e464ebb48
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/jackc/pgx/v5 v5.3.1 // indirect
 	github.com/jinzhu/now v1.1.5
-	github.com/lib/pq v1.10.8
-	github.com/mattn/go-sqlite3 v1.14.16 // indirect
-	gorm.io/driver/mysql v1.5.0
-	gorm.io/driver/postgres v1.5.0
-	gorm.io/driver/sqlite v1.5.0
+	github.com/lib/pq v1.10.9
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.2
 	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gorm v1.25.1
+	gorm.io/gorm v1.25.2-0.20230530020048-26663ab9bf55
+)
+
+require (
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
+	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
+	github.com/jackc/pgx/v5 v5.4.1 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-sqlite3 v1.14.17 // indirect
+	github.com/microsoft/go-mssqldb v1.3.0 // indirect
+	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	golang.org/x/crypto v0.11.0 // indirect
+	golang.org/x/mod v0.12.0 // indirect
+	golang.org/x/sys v0.10.0 // indirect
+	golang.org/x/text v0.11.0 // indirect
+	golang.org/x/tools v0.11.0 // indirect
+	lukechampine.com/uint128 v1.3.0 // indirect
+	modernc.org/cc/v3 v3.41.0 // indirect
+	modernc.org/ccgo/v3 v3.16.14 // indirect
+	modernc.org/libc v1.24.1 // indirect
+	modernc.org/mathutil v1.6.0 // indirect
+	modernc.org/memory v1.6.0 // indirect
+	modernc.org/opt v0.1.3 // indirect
+	modernc.org/sqlite v1.23.1 // indirect
+	modernc.org/strutil v1.1.3 // indirect
+	modernc.org/token v1.1.0 // indirect
 )
 
 replace gorm.io/gorm => ../

--- a/tests/tests_all.sh
+++ b/tests/tests_all.sh
@@ -3,59 +3,71 @@
 dialects=("sqlite" "mysql" "postgres" "sqlserver" "tidb")
 
 if [[ $(pwd) == *"gorm/tests"* ]]; then
-  cd ..
+	cd ..
 fi
 
-if [ -d tests ]
-then
-  cd tests
-  go get -u -t ./...
-  go mod download
-  go mod tidy
-  cd ..
+if [ -d tests ]; then
+	cd tests
+	go get -u -t ./...
+	go mod download
+	go mod tidy
+	cd ..
 fi
 
 # SqlServer for Mac M1
 if [[ -z $GITHUB_ACTION ]]; then
-  if [ -d tests ]
-  then
-    cd tests
-    if [[ $(uname -a) == *" arm64" ]]; then
-      MSSQL_IMAGE=mcr.microsoft.com/azure-sql-edge docker-compose start || true
-      go install github.com/microsoft/go-sqlcmd/cmd/sqlcmd@latest || true
-      SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF DB_ID('gorm') IS NULL CREATE DATABASE gorm" > /dev/null || true
-      SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF SUSER_ID (N'gorm') IS NULL CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';" > /dev/null || true
-      SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF USER_ID (N'gorm') IS NULL CREATE USER gorm FROM LOGIN gorm; ALTER SERVER ROLE sysadmin ADD MEMBER [gorm];" > /dev/null || true
-    else
-      docker-compose start
-    fi
-    cd ..
-  fi
+	if [ -d tests ]; then
+		cd tests
+		if [[ $(uname -a) == *" arm64" ]]; then
+			MSSQL_IMAGE=mcr.microsoft.com/azure-sql-edge docker-compose start || true
+			go install github.com/microsoft/go-sqlcmd/cmd/sqlcmd@latest || true
+			SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF DB_ID('gorm') IS NULL CREATE DATABASE gorm" >/dev/null || true
+			SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF SUSER_ID (N'gorm') IS NULL CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';" >/dev/null || true
+			SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF USER_ID (N'gorm') IS NULL CREATE USER gorm FROM LOGIN gorm; ALTER SERVER ROLE sysadmin ADD MEMBER [gorm];" >/dev/null || true
+		else
+			docker-compose start
+		fi
+		cd ..
+	fi
 fi
 
+for dialect in "${dialects[@]}"; do
+	if [ "$GORM_DIALECT" = "" ] || [ "$GORM_DIALECT" = "${dialect}" ]; then
+		echo "testing ${dialect}..."
 
-for dialect in "${dialects[@]}" ; do
-  if [ "$GORM_DIALECT" = "" ] || [ "$GORM_DIALECT" = "${dialect}" ]
-  then
-    echo "testing ${dialect}..."
+		cmd="GORM_DIALECT=${dialect} go test"
+		tags=("")
 
-    if [ "$GORM_VERBOSE" = "" ]
-    then
-      GORM_DIALECT=${dialect} go test -race -count=1 ./...
-      if [ -d tests ]
-      then
-        cd tests
-        GORM_DIALECT=${dialect} go test -race -count=1 ./...
-        cd ..
-      fi
-    else
-      GORM_DIALECT=${dialect} go test -race -count=1 -v ./...
-      if [ -d tests ]
-      then
-        cd tests
-        GORM_DIALECT=${dialect} go test -race -count=1 -v ./...
-        cd ..
-      fi
-    fi
-  fi
+		if [ "$GORM_DIALECT" = "sqlite" ]; then
+			# Test SQLite pure-go driver
+			tags+=("pure")
+		fi
+
+		for tag in "${tags[@]}"; do
+			echo "testing ${dialect} with tag '${tag}'"
+
+			if [ -n "$tag" ]; then
+				cmd="$cmd -tags ${tag}"
+			fi
+
+			cmd="$cmd -race -count=1 ./..."
+
+
+			if [ "$GORM_VERBOSE" = "" ]; then
+				eval $cmd
+				if [ -d tests ]; then
+					cd tests
+					eval $cmd
+					cd ..
+				fi
+			else
+				eval $cmd
+				if [ -d tests ]; then
+					cd tests
+					eval $cmd
+					cd ..
+				fi
+			fi
+		done
+	fi
 done

--- a/tests/tests_cgo_test.go
+++ b/tests/tests_cgo_test.go
@@ -1,0 +1,13 @@
+//go:build cgo && !pure
+// +build cgo,!pure
+
+package tests_test
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var (
+	sqliteDSN	= filepath.Join(os.TempDir(), "gorm.db")
+)

--- a/tests/tests_pure_test.go
+++ b/tests/tests_pure_test.go
@@ -1,0 +1,13 @@
+//go:build !cgo || (cgo && pure)
+// +build !cgo cgo,pure
+
+package tests_test
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var (
+	sqliteDSN	= filepath.Join(os.TempDir(), "gorm.db?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)")
+)

--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"time"
 
 	"gorm.io/driver/mysql"
@@ -45,6 +44,7 @@ func init() {
 		RunMigrations()
 		if DB.Dialector.Name() == "sqlite" {
 			DB.Exec("PRAGMA foreign_keys = ON")
+			DB.Exec("PRAGMA busy_timeout = 5000")
 		}
 	}
 }
@@ -89,7 +89,7 @@ func OpenTestConnection(cfg *gorm.Config) (db *gorm.DB, err error) {
 		db, err = gorm.Open(mysql.Open(dbDSN), cfg)
 	default:
 		log.Println("testing sqlite3...")
-		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), cfg)
+		db, err = gorm.Open(sqlite.Open(sqliteDSN), cfg)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This tests the sqlite with/out CGO, updates the minimum tests go version to 1.18, and adds the latest go version `^1` to the sqlite CI tests.

Related: https://github.com/go-gorm/sqlite/pull/161

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Add tests to SQLite pure-go.

### User Case Description

<!-- Your use case -->

Needs https://github.com/go-gorm/sqlite/pull/161