### PR TITLE
feat(callback): add callback support for begin, commit, rollback

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -15,12 +15,15 @@ import (
 func initializeCallbacks(db *DB) *callbacks {
 	return &callbacks{
 		processors: map[string]*processor{
-			"create": {db: db},
-			"query":  {db: db},
-			"update": {db: db},
-			"delete": {db: db},
-			"row":    {db: db},
-			"raw":    {db: db},
+			"create":   {db: db},
+			"query":    {db: db},
+			"update":   {db: db},
+			"delete":   {db: db},
+			"row":      {db: db},
+			"raw":      {db: db},
+			"begin":    {db: db},
+			"rollback": {db: db},
+			"commit":   {db: db},
 		},
 	}
 }
@@ -46,6 +49,18 @@ type callback struct {
 	match     func(*DB) bool
 	handler   func(*DB)
 	processor *processor
+}
+
+func (cs *callbacks) Begin() *processor {
+	return cs.processors["begin"]
+}
+
+func (cs *callbacks) Rollback() *processor {
+	return cs.processors["rollback"]
+}
+
+func (cs *callbacks) Commit() *processor {
+	return cs.processors["commit"]
 }
 
 func (cs *callbacks) Create() *processor {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?
This adds a callback support for manual transaction `Begin,Commit,Rollback`
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
Simulate the same behavior on both database when double writing in a project where manual database control is used a lot.
<!-- Your use case -->
