### PR TITLE
Fix begin in an exist transaction error

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -672,6 +672,8 @@ func (db *DB) Begin(opts ...*sql.TxOptions) *DB {
 		tx.Statement.ConnPool, err = beginner.BeginTx(tx.Statement.Context, opt)
 	case ConnPoolBeginner:
 		tx.Statement.ConnPool, err = beginner.BeginTx(tx.Statement.Context, opt)
+	case TxCommitter:
+		// ignore begin function to continue exist transaction
 	default:
 		err = ErrInvalidTransaction
 	}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Allow begin method call on a sql.Tx without a ErrInvalidTransaction error .
So  we can control the transaction manually with nested.

### User Case Description

```go
// here is an example to call begin in nested.

func f1(db *gorm.DB) {
	tx := db.Begin()
	var err error
	defer func() {
		if err != nil {
			tx.Commit()
		} else {
			tx.Rollback()
		}
	}()
}

func fr(db *gorm.DB) {
	tx := db.Begin()
	var err error
	defer func() {
		if err != nil {
			tx.Commit()
		} else {
			tx.Rollback()
		}
	}()

	f1(tx)
}

// code above is similar to :

	tx := context.Db.Begin()
	tx2 := tx.Begin()
        // now ,it's safe
	if nil != tx2.Error {
		err = tx2.Error
		panic(err)
	}

```
