### PR TITLE
fix(clause): clause equal empty array

### DIFF
--- a/clause/expression.go
+++ b/clause/expression.go
@@ -246,15 +246,19 @@ func (eq Eq) Build(builder Builder) {
 
 	switch eq.Value.(type) {
 	case []string, []int, []int32, []int64, []uint, []uint32, []uint64, []interface{}:
-		builder.WriteString(" IN (")
 		rv := reflect.ValueOf(eq.Value)
-		for i := 0; i < rv.Len(); i++ {
-			if i > 0 {
-				builder.WriteByte(',')
+		if rv.Len() == 0 {
+			builder.WriteString(" IN (NULL)")
+		} else {
+			builder.WriteString(" IN (")
+			for i := 0; i < rv.Len(); i++ {
+				if i > 0 {
+					builder.WriteByte(',')
+				}
+				builder.AddVar(builder, rv.Index(i).Interface())
 			}
-			builder.AddVar(builder, rv.Index(i).Interface())
+			builder.WriteByte(')')
 		}
-		builder.WriteByte(')')
 	default:
 		if eqNil(eq.Value) {
 			builder.WriteString(" IS NULL")
@@ -277,15 +281,19 @@ func (neq Neq) Build(builder Builder) {
 
 	switch neq.Value.(type) {
 	case []string, []int, []int32, []int64, []uint, []uint32, []uint64, []interface{}:
-		builder.WriteString(" NOT IN (")
 		rv := reflect.ValueOf(neq.Value)
-		for i := 0; i < rv.Len(); i++ {
-			if i > 0 {
-				builder.WriteByte(',')
+		if rv.Len() == 0 {
+			builder.WriteString(" NOT IN (NULL)")
+		} else {
+			builder.WriteString(" NOT IN (")
+			for i := 0; i < rv.Len(); i++ {
+				if i > 0 {
+					builder.WriteByte(',')
+				}
+				builder.AddVar(builder, rv.Index(i).Interface())
 			}
-			builder.AddVar(builder, rv.Index(i).Interface())
+			builder.WriteByte(')')
 		}
-		builder.WriteByte(')')
 	default:
 		if eqNil(neq.Value) {
 			builder.WriteString(" IS NOT NULL")

--- a/clause/expression_test.go
+++ b/clause/expression_test.go
@@ -201,6 +201,16 @@ func TestExpression(t *testing.T) {
 		Result:       "`column-name` NOT IN (?,?)",
 	}, {
 		Expressions: []clause.Expression{
+			clause.Eq{Column: column, Value: []string{}},
+		},
+		Result: "`column-name` IN (NULL)",
+	}, {
+		Expressions: []clause.Expression{
+			clause.Neq{Column: column, Value: []string{}},
+		},
+		Result: "`column-name` NOT IN (NULL)",
+	}, {
+		Expressions: []clause.Expression{
 			clause.Eq{Column: clause.Expr{SQL: "SUM(?)", Vars: []interface{}{clause.Column{Name: "id"}}}, Value: 100},
 		},
 		ExpectedVars: []interface{}{100},


### PR DESCRIPTION


<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?

when the value of `clause.Eq` is an empty array, the SQL should be `IN (NULL)`

### User Case Description
CASE: `clause.Eq{Column: column, Value: []string{}}`
ERROR: syntax error at or near \")\" (SQLSTATE 42601)
