### PR TITLE
customize the time param format in SQL log

### DIFF
--- a/logger/sql.go
+++ b/logger/sql.go
@@ -13,10 +13,8 @@ import (
 	"gorm.io/gorm/utils"
 )
 
-var (
-	// TimeParamFormat defines the format of the time parameter in ExpalianSQL.
-	TimeParamFormat = "2006-01-02 15:04:05.999"
-)
+// TimeParamFormat defines the format of the time parameter in ExpalianSQL.
+var TimeParamFormat = "2006-01-02 15:04:05.999"
 
 const (
 	tmFmtZero = "0000-00-00 00:00:00"

--- a/logger/sql.go
+++ b/logger/sql.go
@@ -13,7 +13,7 @@ import (
 	"gorm.io/gorm/utils"
 )
 
-// TimeParamFormat defines the format of the time parameter in ExpalianSQL.
+// TimeParamFormat defines the format of the time parameter in ExplainSQL.
 var TimeParamFormat = "2006-01-02 15:04:05.999"
 
 const (

--- a/logger/sql.go
+++ b/logger/sql.go
@@ -13,10 +13,14 @@ import (
 	"gorm.io/gorm/utils"
 )
 
+var (
+	// TimeParamFormat defines the format of the time parameter in ExpalianSQL.
+	TimeParamFormat = "2006-01-02 15:04:05.999"
+)
+
 const (
-	tmFmtWithMS = "2006-01-02 15:04:05.999"
-	tmFmtZero   = "0000-00-00 00:00:00"
-	nullStr     = "NULL"
+	tmFmtZero = "0000-00-00 00:00:00"
+	nullStr   = "NULL"
 )
 
 func isPrintable(s string) bool {
@@ -47,14 +51,14 @@ func ExplainSQL(sql string, numericPlaceholder *regexp.Regexp, escaper string, a
 			if v.IsZero() {
 				vars[idx] = escaper + tmFmtZero + escaper
 			} else {
-				vars[idx] = escaper + v.Format(tmFmtWithMS) + escaper
+				vars[idx] = escaper + v.Format(TimeParamFormat) + escaper
 			}
 		case *time.Time:
 			if v != nil {
 				if v.IsZero() {
 					vars[idx] = escaper + tmFmtZero + escaper
 				} else {
-					vars[idx] = escaper + v.Format(tmFmtWithMS) + escaper
+					vars[idx] = escaper + v.Format(TimeParamFormat) + escaper
 				}
 			} else {
 				vars[idx] = nullStr

--- a/logger/sql_test.go
+++ b/logger/sql_test.go
@@ -118,9 +118,11 @@ func TestExplainSQL(t *testing.T) {
 
 		tnano := now.MustParse("2020-02-23T11:10:10.123456789+08:00")
 		var zt time.Time
+
 		sql := "create table users (name, create_at, update_at, delete_at, init_at) values (?, ?, ?, ?, ?)"
 		vars := []interface{}{"jinzhu", tnano, &tnano, zt, &zt}
 		expected := `create table users (name, create_at, update_at, delete_at, init_at) values ("jinzhu", "2020-02-23T11:10:10.123456789+08:00", "2020-02-23T11:10:10.123456789+08:00", "0000-00-00 00:00:00", "0000-00-00 00:00:00")`
+
 		if result := logger.ExplainSQL(sql, nil, `"`, vars...); result != expected {
 			t.Errorf("Explain SQL expects %v, but got %v", expected, result)
 		}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Add feature to allow customization of the time parameter format in the SQL log.

### User Case Description


