### PR TITLE
Fixed error message when dialector fails to initialize

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -181,7 +181,7 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 		err = config.Dialector.Initialize(db)
 
 		if err != nil {
-			if db, err := db.DB(); err == nil {
+			if db, _ := db.DB(); db != nil {
 				_ = db.Close()
 			}
 		}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Dialector initialize error leads to closing DB connection. However if DB connection is not even created, code inside gorm provides `nil` as an error even though `db` doesn't exist (is nil), so it tries to close what can't be closed and results to panic.
`panic: runtime error: invalid memory address or nil pointer dereference`

This fix now doesn't attempt to close non-existant database connection and instead continues, so the proper error is shown.

### User Case Description

When I provide this example DSN (I am aware that this is wrong, it's a purpose to showcase this problem):
`test:test@localhost/test?charset=utf8mb4&parseTime=True&loc=Local`

To this piece of code:
`db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})`

I got:
`panic: runtime error: invalid memory address or nil pointer dereference`

With this fix I get proper error:
`[error] failed to initialize database, got error default addr for network 'localhost' unknown`

This error is now in `err` variable in my app, instead of it failing inside gorm.