### PR TITLE
Fix handling of unknown column types

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -257,9 +257,11 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 								continue
 							}
 						}
-						values[idx] = &sql.RawBytes{}
+						var val interface{}
+						values[idx] = &val
 					} else {
-						values[idx] = &sql.RawBytes{}
+						var val interface{}
+						values[idx] = &val
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

When using the go clickhouse driver, scanning into sql.RawBytes is not supported for most columns. I think the database/sql standard only [guarantees](https://pkg.go.dev/database/sql#Rows.Scan) that all columns can be converted to *interface{}, not RawBytes, so gorm should not make this assumption.

This issue doesn't affect most drivers like sqlite, mysql, postgres, but it does affect clickhouse. The following test will pass once this change is merged: https://github.com/go-gorm/clickhouse/pull/128

### User Case Description

<!-- Your use case -->
