### PR TITLE
Fix: Add unused argument Introduced compatibility issues

### DIFF
--- a/clause/expression.go
+++ b/clause/expression.go
@@ -68,7 +68,7 @@ func (expr Expr) Build(builder Builder) {
 		}
 	}
 
-	if idx < len(expr.Vars) {
+	if idx > 0 && idx < len(expr.Vars) {
 		for _, v := range expr.Vars[idx:] {
 			builder.AddVar(builder, sql.NamedArg{Value: v})
 		}


### PR DESCRIPTION
Fix: Add unused argument (#4871)
Breaking the previous compatibility. when idx=0, vars seems not to need.  
[Add unused argument](https://github.com/go-gorm/gorm/commit/b8f33a42a469f5a4ab64bb8937ef7c8e5524af7e)

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
