### PR TITLE
Add support for returning in sqlserver

### DIFF
--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -206,9 +206,9 @@ func TestDeleteSliceWithAssociations(t *testing.T) {
 	}
 }
 
-// only sqlite, postgres support returning
+// only sqlite, postgres, sqlserver support returning
 func TestSoftDeleteReturning(t *testing.T) {
-	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" {
+	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "sqlserver" {
 		return
 	}
 
@@ -233,7 +233,7 @@ func TestSoftDeleteReturning(t *testing.T) {
 }
 
 func TestDeleteReturning(t *testing.T) {
-	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" {
+	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "sqlserver" {
 		return
 	}
 

--- a/tests/update_test.go
+++ b/tests/update_test.go
@@ -765,9 +765,9 @@ func TestSaveWithPrimaryValue(t *testing.T) {
 	}
 }
 
-// only sqlite, postgres support returning
+// only sqlite, postgres, sqlserver support returning
 func TestUpdateReturning(t *testing.T) {
-	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" {
+	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "sqlserver" {
 		return
 	}
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add sqlserver to the list of dialectors that support update returning and delete returning. This is possible thanks to https://github.com/go-gorm/sqlserver/pull/116. The new tests will not work until we use the new version of the sqlserver dialector but I don't know what flow do you follow in this case

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
