### PR TITLE
*datatypes.JSON in model causes panic on tx.Statement.Changed

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -89,19 +89,28 @@ func Contains(elems []string, elem string) bool {
 	return false
 }
 
-func AssertEqual(src, dst interface{}) bool {
-	if !reflect.DeepEqual(src, dst) {
-		if valuer, ok := src.(driver.Valuer); ok {
-			src, _ = valuer.Value()
-		}
-
-		if valuer, ok := dst.(driver.Valuer); ok {
-			dst, _ = valuer.Value()
-		}
-
-		return reflect.DeepEqual(src, dst)
+func AssertEqual(x, y interface{}) bool {
+	if reflect.DeepEqual(x, y) {
+		return true
 	}
-	return true
+	if x == nil || y == nil {
+		return false
+	}
+	xval := reflect.ValueOf(x)
+	yval := reflect.ValueOf(y)
+	if xval.Kind() == reflect.Ptr && xval.IsNil() ||
+		yval.Kind() == reflect.Ptr && yval.IsNil() {
+		return false
+	}
+
+	if valuer, ok := x.(driver.Valuer); ok {
+		x, _ = valuer.Value()
+	}
+
+	if valuer, ok := y.(driver.Valuer); ok {
+		y, _ = valuer.Value()
+	}
+	return reflect.DeepEqual(x, y)
 }
 
 func ToString(value interface{}) string {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -96,6 +96,7 @@ func AssertEqual(x, y interface{}) bool {
 	if x == nil || y == nil {
 		return false
 	}
+
 	xval := reflect.ValueOf(x)
 	yval := reflect.ValueOf(y)
 	if xval.Kind() == reflect.Ptr && xval.IsNil() ||
@@ -106,7 +107,6 @@ func AssertEqual(x, y interface{}) bool {
 	if valuer, ok := x.(driver.Valuer); ok {
 		x, _ = valuer.Value()
 	}
-
 	if valuer, ok := y.(driver.Valuer); ok {
 		y, _ = valuer.Value()
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -91,12 +91,8 @@ func (n ModifyAt) Value() (driver.Value, error) {
 
 type datatypesJSON json.RawMessage
 
-// Value return json value, implement driver.Valuer interface
 func (j datatypesJSON) Value() (driver.Value, error) {
-	if len(j) == 0 {
-		return nil, nil
-	}
-	return []byte(j), nil
+	return nil, nil
 }
 
 func TestAssertEqual(t *testing.T) {
@@ -104,10 +100,16 @@ func TestAssertEqual(t *testing.T) {
 		Raw *datatypesJSON
 	}
 
+	// copied from your code
+	// would be the same as var i1 *datatypesJSON
 	m1 := model{}
 	f1 := reflect.Indirect(reflect.ValueOf(m1)).Field(0)
 	i1 := f1.Interface()
 
+	// copied from your code
+	// would be the same as
+	//  k := datatypesJSON("dreggn")
+	//  i2 := &k
 	raw := datatypesJSON("dreggn")
 	m2 := model{Raw: &raw}
 	f2 := reflect.Indirect(reflect.ValueOf(m2)).Field(0)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -3,10 +3,8 @@ package utils
 import (
 	"database/sql"
 	"database/sql/driver"
-	"encoding/json"
 	"errors"
 	"math"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -89,32 +87,7 @@ func (n ModifyAt) Value() (driver.Value, error) {
 	return n.Time.Unix(), nil
 }
 
-type datatypesJSON json.RawMessage
-
-func (j datatypesJSON) Value() (driver.Value, error) {
-	return nil, nil
-}
-
 func TestAssertEqual(t *testing.T) {
-	type model struct {
-		Raw *datatypesJSON
-	}
-
-	// copied from your code
-	// would be the same as var i1 *datatypesJSON
-	m1 := model{}
-	f1 := reflect.Indirect(reflect.ValueOf(m1)).Field(0)
-	i1 := f1.Interface()
-
-	// copied from your code
-	// would be the same as
-	//  k := datatypesJSON("dreggn")
-	//  i2 := &k
-	raw := datatypesJSON("dreggn")
-	m2 := model{Raw: &raw}
-	f2 := reflect.Indirect(reflect.ValueOf(m2)).Field(0)
-	i2 := f2.Interface()
-
 	now := time.Now()
 	assertEqualTests := []struct {
 		name     string
@@ -125,7 +98,7 @@ func TestAssertEqual(t *testing.T) {
 		{"error not equal", errors.New("1"), errors.New("2"), false},
 		{"driver.Valuer equal", ModifyAt{Time: now, Valid: true}, ModifyAt{Time: now, Valid: true}, true},
 		{"driver.Valuer not equal", ModifyAt{Time: now, Valid: true}, ModifyAt{Time: now.Add(time.Second), Valid: true}, false},
-		{"driver.Valuer equal (ptr to nil ptr)", i1, i2, false},
+		{"driver.Valuer equal (ptr to nil ptr)", (*ModifyAt)(nil), &ModifyAt{}, false},
 	}
 	for _, test := range assertEqualTests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### User Case Description

I got the following panic

```
panic: value method gorm.io/datatypes.JSON.Value called using nil *JSON pointer

goroutine 134 [running]:
gorm.io/datatypes.(*JSON).Value(0x135c7c0?)
        <autogenerated>:1 +0x56
gorm.io/gorm/utils.AssertEqual({0x135c7c0, 0xc0007e06f0}, {0x135c7c0, 0x0})
        /home/mgoeppe/go/pkg/mod/gorm.io/gorm@v1.25.2/utils/utils.go:99 +0x9f
gorm.io/gorm.(*Statement).Changed.func1(0xc0003eaf00)
        /home/mgoeppe/go/pkg/mod/gorm.io/gorm@v1.25.2/statement.go:643 +0x251
gorm.io/gorm.(*Statement).Changed(0xc0007e4a80, {0xc00079c4c8, 0x1, 0x41123d?})
        /home/mgoeppe/go/pkg/mod/gorm.io/gorm@v1.25.2/statement.go:658 +0x298
```

when using a `*datatypes.JSON` model field where the *datatypes.JSON is not nil but refers to a []byte which is nil. The panic is raised when valuer.Value() is called.

>**NOTE:** It might be questionable using a `*datatypes.JSON` as the underlying json.RawMessage byte slice already is a pointer type, but still the code should not panic I guess.

### What did this pull request do?

I added a test reproduce the issue taking the exact same reflection steps as done in the `Changed` func. I also provided a fix of the `AssertEqual` func itself but I am not sure if the problem resides in the reflection code of the `Changed` func itself - to be honest I do not understand all details here.

I am looking forward to your reply. Thanks a lot!


<sub>Mathias Zeller <mathias.zeller@mercedes-benz.com> Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))
</sub>