### PR TITLE
fix: sqlite dialector cannot apply `PRIMARY KEY AUTOINCREMENT` type

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -217,7 +217,7 @@ func (m Migrator) CreateTable(values ...interface{}) error {
 				field := stmt.Schema.FieldsByDBName[dbName]
 				if !field.IgnoreMigration {
 					createTableSQL += "? ?"
-					hasPrimaryKeyInDataType = hasPrimaryKeyInDataType || strings.Contains(strings.ToUpper(string(field.DataType)), "PRIMARY KEY")
+					hasPrimaryKeyInDataType = hasPrimaryKeyInDataType || strings.Contains(strings.ToUpper(m.DataTypeOf(field)), "PRIMARY KEY")
 					values = append(values, clause.Column{Name: dbName}, m.DB.Migrator().FullDataTypeOf(field))
 					createTableSQL += ","
 				}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lib/pq v1.10.9
 	gorm.io/driver/mysql v1.5.2-0.20230612053416-48b6526a21f0
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
-	gorm.io/driver/sqlite v1.5.4-0.20231008025214-74475fc966dd
+	gorm.io/driver/sqlite v1.5.4
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
 	gorm.io/gorm v1.25.4
 )

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lib/pq v1.10.9
 	gorm.io/driver/mysql v1.5.2-0.20230612053416-48b6526a21f0
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
-	gorm.io/driver/sqlite v1.5.3
+	gorm.io/driver/sqlite v1.5.4-0.20231008025214-74475fc966dd
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
 	gorm.io/gorm v1.25.4
 )
@@ -22,9 +22,9 @@ require (
 	github.com/jackc/pgx/v5 v5.4.3 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
+	github.com/microsoft/go-mssqldb v1.6.0 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 )
 
 replace gorm.io/gorm => ../


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fix #4760. Currently, sqlite dialector can't apply `AUTOINCREMENT` to the field type. The reason this method cannot work is if a field is marked as `AutoIncrement` and `PrimaryKey` at the same time, when we apply `AUTOINCREMENT` to data type, it will create SQL like the following:

```sql
CREATE TABLE `example_table` (`id` integer PRIMARY KEY AUTOINCREMENT, ..., PRIMARY KEY (`id`))'
```

This can cause `SQL logic error: table "example_table" has more than one primary key (1)` error, because there is two `PRIMARY KEY` definition in this statement. The root cause is `hasPrimaryKeyInDataType` doesn't check the result of `Dialector.DataTypeOf` method.

 By checking the result of `Dialector.DataTypeOf` method, a dialector can define its behavior for `AUTOINCREMENT & PRIMARY KEY` situation.

### User Case Description

The following struct:

```go
type ExampleTable struct {
	ID     int64  `gorm:"primaryKey;autoIncrement" json:"id,omitempty"`
	...
}
```

Used to generate table DDL as:

```sql
CREATE TABLE `example_table` (`id` integer, ..., PRIMARY KEY (`id`))'
```

Which doesn't mark `id` field as `AUTOINCREMENT`. Currently, the `id` field roughly acts like `AUTOINCREMENT,` but it doesn't in many areas. This implementation may cause some issues like id reusing when deleting rows.

Now, it will generate table DDL as (if sqlite dialector is also changed):

```sql
CREATE TABLE `example_table` (`id` integer PRIMARY KEY AUTOINCREMENT, ...)'
```
