### PR TITLE
feat: add IF NOT EXISTS config for migrator

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -35,6 +35,7 @@ type Migrator struct {
 // Config schema config
 type Config struct {
 	CreateIndexAfterCreateTable bool
+	CreateTableUseIfNotExists   bool
 	DB                          *gorm.DB
 	gorm.Dialector
 }
@@ -212,6 +213,10 @@ func (m Migrator) CreateTable(values ...interface{}) error {
 				values                  = []interface{}{m.CurrentTable(stmt)}
 				hasPrimaryKeyInDataType bool
 			)
+
+			if m.CreateTableUseIfNotExists {
+				createTableSQL = "CREATE TABLE IF NOT EXISTS ? ("
+			}
 
 			for _, dbName := range stmt.Schema.DBNames {
 				field := stmt.Schema.FieldsByDBName[dbName]

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -35,8 +35,8 @@ type Migrator struct {
 // Config schema config
 type Config struct {
 	CreateIndexAfterCreateTable bool
-	CreateTableUseIfNotExists   bool
-	DB                          *gorm.DB
+	// CreateTableUseIfNotExists   bool
+	DB *gorm.DB
 	gorm.Dialector
 }
 
@@ -214,9 +214,9 @@ func (m Migrator) CreateTable(values ...interface{}) error {
 				hasPrimaryKeyInDataType bool
 			)
 
-			if m.CreateTableUseIfNotExists {
-				createTableSQL = "CREATE TABLE IF NOT EXISTS ? ("
-			}
+			// if m.CreateTableUseIfNotExists {
+			// 	createTableSQL = "CREATE TABLE IF NOT EXISTS ? ("
+			// }
 
 			for _, dbName := range stmt.Schema.DBNames {
 				field := stmt.Schema.FieldsByDBName[dbName]

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,7 +10,7 @@ require (
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
 	gorm.io/driver/sqlite v1.5.3
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
-	gorm.io/gorm v1.25.5
+	gorm.io/gorm v1.25.3
 )
 
 require (

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/lib/pq v1.10.9
 	gorm.io/driver/mysql v1.5.2-0.20230612053416-48b6526a21f0
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
-	gorm.io/driver/sqlite v1.5.3
+	gorm.io/driver/sqlite v1.5.4
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
-	gorm.io/gorm v1.25.3
+	gorm.io/gorm v1.25.4
 )
 
 require (

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lib/pq v1.10.9
 	gorm.io/driver/mysql v1.5.2-0.20230612053416-48b6526a21f0
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
-	gorm.io/driver/sqlite v1.5.3
+	gorm.io/driver/sqlite v1.5.4
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
 	gorm.io/gorm v1.25.4
 )

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/lib/pq v1.10.9
 	gorm.io/driver/mysql v1.5.2-0.20230612053416-48b6526a21f0
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
-	gorm.io/driver/sqlite v1.5.4
+	gorm.io/driver/sqlite v1.5.2
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
-	gorm.io/gorm v1.25.4
+	gorm.io/gorm v1.25.2
 )
 
 require (

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/lib/pq v1.10.9
 	gorm.io/driver/mysql v1.5.2-0.20230612053416-48b6526a21f0
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
-	gorm.io/driver/sqlite v1.5.4
+	gorm.io/driver/sqlite v1.5.3
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
-	gorm.io/gorm v1.25.2
+	gorm.io/gorm v1.25.3
 )
 
 require (

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,7 +10,7 @@ require (
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
 	gorm.io/driver/sqlite v1.5.3
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
-	gorm.io/gorm v1.25.4
+	gorm.io/gorm v1.25.5
 )
 
 require (

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lib/pq v1.10.9
 	gorm.io/driver/mysql v1.5.2-0.20230612053416-48b6526a21f0
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
-	gorm.io/driver/sqlite v1.5.2
+	gorm.io/driver/sqlite v1.5.4
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
 	gorm.io/gorm v1.25.2
 )

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,7 +10,7 @@ require (
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
 	gorm.io/driver/sqlite v1.5.4
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
-	gorm.io/gorm v1.25.4
+	gorm.io/gorm v1.25.5
 )
 
 require (

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,7 +10,7 @@ require (
 	gorm.io/driver/postgres v1.5.3-0.20230607070428-18bc84b75196
 	gorm.io/driver/sqlite v1.5.3
 	gorm.io/driver/sqlserver v1.5.2-0.20230613072041-6e2cde390b0a
-	gorm.io/gorm v1.25.3
+	gorm.io/gorm v1.25.4
 )
 
 require (


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
When migrator needs to be executed concurrently, it is not enough to judge by ```HasTable()```, which will cause ```CreateTable()``` to return the ```table is already exist``` error. To avoid this error, hopefully use the ```IF NOT EXISTS``` statement. This change is forward compatible and will not cause changes to existing code.

### User Case Description
Assume that in an APP, user login, registration, browsing, click and other events need to be processed, and these events need to be recorded in the table, then the table needs to be dynamically divided according to user_id. In a distributed scenario, when browsing and clicking events are processed concurrently, When, it may cause Migrator to be abnormal.
