### PR TITLE
tests for sqilte: enable FOREIGN_KEYS inside OpenTestConnection

### DIFF
--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -43,9 +43,6 @@ func init() {
 		}
 
 		RunMigrations()
-		if DB.Dialector.Name() == "sqlite" {
-			DB.Exec("PRAGMA foreign_keys = ON")
-		}
 	}
 }
 
@@ -89,7 +86,10 @@ func OpenTestConnection(cfg *gorm.Config) (db *gorm.DB, err error) {
 		db, err = gorm.Open(mysql.Open(dbDSN), cfg)
 	default:
 		log.Println("testing sqlite3...")
-		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db?_foreign_keys=on")), cfg)
+		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), cfg)
+		if err == nil {
+			db.Exec("PRAGMA foreign_keys = ON")
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION


<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
As of now, the Foreign Key constraint is [OFF](https://www.sqlite.org/pragma.html#pragma_foreign_keys) by default in ```sqlite3```.
In GORM ```tests``` package the constraint is enabled by running following code:
https://github.com/go-gorm/gorm/blob/6bef318891b98263f3568c13093b5860245d2c52/tests/tests_test.go#L46-L48
for the global ```DB``` instance.

The problem is that this code is executed once inside ```init```, thus leaving other calls to ```OpenTestConnection``` not executing the same logic.

The code should be moved inside ```OpenTestConnection```, since some tests do not use the global ```DB``` instance, preferring to call ```OpenTestConnection``` for their own purpose.

The issue was solved the wrong way in https://github.com/go-gorm/gorm/commit/c10f807d3c0b2b3204c80d62cf7650e21d7e3316 by [changing](https://github.com/go-gorm/gorm/commit/c10f807d3c0b2b3204c80d62cf7650e21d7e3316#diff-e6060120fd60e25841122a6c7839035ef0b38ee3c856142ae3a864918b666b51R92) the connection string to ```"gorm.db?_foreign_keys=on"```, which is a syntax, specific to mattn's  [CGo driver](https://github.com/mattn/go-sqlite3), and caused regression in [CGo-free driver](https://github.com/glebarez/sqlite).

This PR addresses the issue in a unified way, compatible with all sqlite drivers for GORM.


### User Case Description

<!-- Your use case -->
