### PR TITLE
map insert support return increment id

### DIFF
--- a/callbacks/create.go
+++ b/callbacks/create.go
@@ -107,21 +107,23 @@ func Create(config *Config) func(db *gorm.DB) {
 			return
 		}
 
+		var (
+			pkField     *schema.Field
+			pkFieldName = "@id"
+		)
+		if db.Statement.Schema != nil {
+			if db.Statement.Schema.PrioritizedPrimaryField == nil || !db.Statement.Schema.PrioritizedPrimaryField.HasDefaultValue {
+				return
+			}
+			pkField = db.Statement.Schema.PrioritizedPrimaryField
+			pkFieldName = db.Statement.Schema.PrioritizedPrimaryField.DBName
+		}
+
 		insertID, err := result.LastInsertId()
 		insertOk := err == nil && insertID > 0
 		if !insertOk {
 			db.AddError(err)
 			return
-		}
-
-		var (
-			pkField     *schema.Field
-			pkFieldName = "@id"
-		)
-
-		if db.Statement.Schema != nil && db.Statement.Schema.PrioritizedPrimaryField != nil && db.Statement.Schema.PrioritizedPrimaryField.HasDefaultValue {
-			pkField = db.Statement.Schema.PrioritizedPrimaryField
-			pkFieldName = db.Statement.Schema.PrioritizedPrimaryField.DBName
 		}
 
 		// append @id column with value for auto-increment primary key

--- a/schema/field.go
+++ b/schema/field.go
@@ -49,6 +49,8 @@ const (
 	Bytes  DataType = "bytes"
 )
 
+const DefaultAutoIncrementIncrement int64 = 1
+
 // Field is the representation of model schema's field
 type Field struct {
 	Name                   string
@@ -119,7 +121,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		NotNull:                utils.CheckTruth(tagSetting["NOT NULL"], tagSetting["NOTNULL"]),
 		Unique:                 utils.CheckTruth(tagSetting["UNIQUE"]),
 		Comment:                tagSetting["COMMENT"],
-		AutoIncrementIncrement: 1,
+		AutoIncrementIncrement: DefaultAutoIncrementIncrement,
 	}
 
 	for field.IndirectFieldType.Kind() == reflect.Ptr {

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -580,7 +581,7 @@ func TestCreateWithAutoIncrementCompositeKey(t *testing.T) {
 	}
 }
 
-func TestCreateOnConfilctWithDefalutNull(t *testing.T) {
+func TestCreateOnConflictWithDefaultNull(t *testing.T) {
 	type OnConfilctUser struct {
 		ID     string
 		Name   string `gorm:"default:null"`
@@ -614,4 +615,158 @@ func TestCreateOnConfilctWithDefalutNull(t *testing.T) {
 	AssertEqual(t, u2.Name, "on-confilct-user-name-2")
 	AssertEqual(t, u2.Email, "on-confilct-user-email-2")
 	AssertEqual(t, u2.Mobile, "133xxxx")
+}
+
+func TestCreateFromMapWithoutPK(t *testing.T) {
+	if !isMysql() {
+		t.Skipf("This test case skipped, because of only supportting for mysql")
+	}
+	cases := []string{"create_from_map_with_schema1", "create_from_map_with_schema2"}
+	mapValue1 := map[string]interface{}{"name": cases[0], "age": 1}
+	mapValue2 := map[string]interface{}{"name": cases[1], "age": 1}
+
+	// case 1: one record
+	for i, c := range cases {
+		if i == 0 {
+			if err := DB.Model(&User{}).Create(mapValue1).Error; err != nil {
+				t.Fatalf("failed to create data from map, got error: %v", err)
+			}
+
+			if _, ok := mapValue1["id"]; !ok {
+				t.Fatal("failed to create data from map with table, returning map has no primary key")
+			}
+
+		} else {
+			if err := DB.Model(&User{}).Create(&mapValue2).Error; err != nil {
+				t.Fatalf("failed to create data from map, got error: %v", err)
+			}
+
+			if _, ok := mapValue2["id"]; !ok {
+				t.Fatal("failed to create data from map with table, returning map has no primary key")
+			}
+		}
+
+		var result User
+		if err := DB.Where("name = ?", c).First(&result).Error; err != nil || result.Age != 1 {
+			t.Fatalf("failed to create from map, got error %v", err)
+		}
+
+		var idVal int64
+		if i == 0 {
+			idVal = mapValue1["id"].(int64)
+		} else {
+			idVal = mapValue2["id"].(int64)
+		}
+
+		if int64(result.ID) != idVal {
+			t.Fatal("failed to create data from map with table, @id != id")
+		}
+	}
+
+	// case 2: records
+	values := []map[string]interface{}{
+		{"name": "create_from_map_with_schema11", "age": 1}, {"name": "create_from_map_with_schema12", "age": 1},
+	}
+
+	if err := DB.Model(&User{}).Create(&values).Error; err != nil {
+		t.Fatalf("failed to create data from map, got error: %v", err)
+	}
+
+	for i, _ := range values {
+		v, ok := values[i]["id"]
+		if !ok {
+			t.Fatal("failed to create data from map with table, returning map has no primary key")
+		}
+
+		var result User
+		if err := DB.Where("name = ?", fmt.Sprintf("create_from_map_with_schema1%d", i+1)).First(&result).Error; err != nil || result.Age != 1 {
+			t.Fatalf("failed to create from map, got error %v", err)
+		}
+		if int64(result.ID) != v.(int64) {
+			t.Fatal("failed to create data from map with table, @id != id")
+		}
+	}
+}
+
+func TestCreateFromMapWithTable(t *testing.T) {
+	if !isMysql() {
+		t.Skipf("This test case skipped, because of only supportting for mysql")
+	}
+	tableDB := DB.Table("`users`")
+
+	// case 1: create from map[string]interface{}
+	record := map[string]interface{}{"`name`": "create_from_map_with_table", "`age`": 18}
+	if err := tableDB.Create(record).Error; err != nil {
+		t.Fatalf("failed to create data from map with table, got error: %v", err)
+	}
+
+	if _, ok := record["@id"]; !ok {
+		t.Fatal("failed to create data from map with table, returning map has no key '@id'")
+	}
+
+	var res map[string]interface{}
+	if err := tableDB.Select([]string{"id", "name", "age"}).Where("name = ?", "create_from_map_with_table").Find(&res).Error; err != nil || res["age"] != int64(18) {
+		t.Fatalf("failed to create from map, got error %v", err)
+	}
+
+	if int64(res["id"].(uint64)) != record["@id"] {
+		t.Fatal("failed to create data from map with table, @id != id")
+	}
+
+	// case 2: create from *map[string]interface{}
+	record1 := map[string]interface{}{"name": "create_from_map_with_table_1", "age": 18}
+	tableDB2 := DB.Table("users")
+	if err := tableDB2.Create(&record1).Error; err != nil {
+		t.Fatalf("failed to create data from map, got error: %v", err)
+	}
+	if _, ok := record1["@id"]; !ok {
+		t.Fatal("failed to create data from map with table, returning map has no key '@id'")
+	}
+
+	var res1 map[string]interface{}
+	if err := tableDB2.Select([]string{"id", "name", "age"}).Where("name = ?", "create_from_map_with_table_1").Find(&res1).Error; err != nil || res1["age"] != int64(18) {
+		t.Fatalf("failed to create from map, got error %v", err)
+	}
+
+	if int64(res1["id"].(uint64)) != record1["@id"] {
+		t.Fatal("failed to create data from map with table, @id != id")
+	}
+
+	// case 3: create from []map[string]interface{}
+	records := []map[string]interface{}{
+		{"name": "create_from_map_with_table_2", "age": 19},
+		{"name": "create_from_map_with_table_3", "age": 20},
+	}
+
+	tableDB = DB.Table("users")
+	if err := tableDB.Create(&records).Error; err != nil {
+		t.Fatalf("failed to create data from slice of map, got error: %v", err)
+	}
+
+	if _, ok := records[0]["@id"]; !ok {
+		t.Fatal("failed to create data from map with table, returning map has no key '@id'")
+	}
+
+	if _, ok := records[1]["@id"]; !ok {
+		t.Fatal("failed to create data from map with table, returning map has no key '@id'")
+	}
+
+	var res2 map[string]interface{}
+	if err := tableDB.Select([]string{"id", "name", "age"}).Where("name = ?", "create_from_map_with_table_2").Find(&res2).Error; err != nil || res2["age"] != int64(19) {
+		t.Fatalf("failed to query data after create from slice of map, got error %v", err)
+	}
+
+	var res3 map[string]interface{}
+	if err := DB.Table("users").Select([]string{"id", "name", "age"}).Where("name = ?", "create_from_map_with_table_3").Find(&res3).Error; err != nil || res3["age"] != int64(20) {
+		t.Fatalf("failed to query data after create from slice of map, got error %v", err)
+	}
+
+	if int64(res2["id"].(uint64)) != records[0]["@id"] {
+		t.Fatal("failed to create data from map with table, @id != id")
+	}
+
+	if int64(res3["id"].(uint64)) != records[1]["@id"] {
+		t.Fatal("failed to create data from map with table, @id != id")
+	}
+
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- 

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
This pull request aims to support returning the primary key value, when using a map (or map list) to call GORM to insert record, in auto-increment primary key case. 

If the primary key value is not set, the returned map or map list will be filled with a custom column "@id".

### User Case Description

The following cases are all using **auto-increment primary key**
**Case 1:**
&ensp; Input: map or map list without primary key
&ensp; Output: map or map list will be filled with "@id"
**Case 2:**
&ensp; Input: map or map list with primary key
&ensp; Output: map or map list will be filled with "@id"

The following cases are all using **non-auto-increment primary key**
**Case 1:**
&ensp; Input: map or map list without primary key
&ensp; Output: error, the same as before.
**Case 2:**
&ensp; Input: map or map list with primary key
&ensp; Output: the same as before

Last but not least, it has no impact on non-auto-increment primary keys.


<!-- Your use case -->
