### PR TITLE
allow setting config when you use your own logger implementation

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -128,6 +128,13 @@ func (l *logger) LogMode(level LogLevel) Interface {
 	return &newlogger
 }
 
+// SetConfig Allow setting configs for your own log implementation
+func (l *logger) SetConfig(config Config) Interface {
+	newlogger := *l
+	newlogger.Config = config
+	return &newlogger
+}
+
 // Info print info
 func (l logger) Info(ctx context.Context, msg string, data ...interface{}) {
 	if l.LogLevel >= Info {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Adding a setter to be able to change the standarad config offered by gorm

### User Case Description

**Context**
I am using my own implementation of the logger interface AKA Interface

**Use case**
I cannot set the config when I am using my own logger implementation.

 the issue is solved for example for logMode with the function LogMode,  
 this PR allows to solve the issue for the whole config, not only LogMode.
 
for instance  I need to set ParameterizedQueries to false, I cannot provide this information to gorm, unless I am using 
**New()**  function which uses the default implementation of gorm logger.


I m open for other design suggestions
