### PR TITLE
Allow filtering/hiding SQL params when using a custom logger implementation

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -66,6 +66,7 @@ type Interface interface {
 	Warn(context.Context, string, ...interface{})
 	Error(context.Context, string, ...interface{})
 	Trace(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error)
+	ParamsFilter(ctx context.Context, sql string, params ...interface{}) (string, []interface{})
 }
 
 var (
@@ -125,13 +126,6 @@ type logger struct {
 func (l *logger) LogMode(level LogLevel) Interface {
 	newlogger := *l
 	newlogger.LogLevel = level
-	return &newlogger
-}
-
-// SetConfig Allow setting configs for your own log implementation
-func (l *logger) SetConfig(config Config) Interface {
-	newlogger := *l
-	newlogger.Config = config
 	return &newlogger
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -128,6 +128,13 @@ func (l *logger) LogMode(level LogLevel) Interface {
 	return &newlogger
 }
 
+// SetConfig Allow setting configs for your own log implementation
+func (l *logger) SetConfig(config Config) Interface {
+	newlogger := *l
+	newlogger.Config = config
+	return &newlogger
+}
+
 // Info print info
 func (l logger) Info(ctx context.Context, msg string, data ...interface{}) {
 	if l.LogLevel >= Info {


### PR DESCRIPTION
- [X] Do only one thing
- [ ] Non breaking API changes
- [X] Tested

### What did this pull request do?

adding a function to interface definition

### User Case Description

I have my own implementation of the logger interface, but in my logging I want to hide params when logging in PROD

### More

I didn't find a way to set the ParameterizedQueries in config when using my own Logger implementation.

