### PR TITLE
Fix/concurrent migrations

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -108,4 +108,8 @@ type Migrator interface {
 	HasIndex(dst interface{}, name string) bool
 	RenameIndex(dst interface{}, oldName, newName string) error
 	GetIndexes(dst interface{}) ([]Index, error)
+
+	// Locking
+	ObtainLock() error
+	ReleaseLock() error
 }

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -119,6 +119,12 @@ func (m Migrator) AutoMigrate(values ...interface{}) error {
 			queryTx.DryRun = false
 			execTx = m.DB.Session(&gorm.Session{Logger: &printSQLLogger{Interface: m.DB.Logger}})
 		}
+
+		if err := execTx.Migrator().ObtainLock(); err != nil {
+			return err
+		}
+		defer execTx.Migrator().ReleaseLock()
+
 		if !queryTx.Migrator().HasTable(value) {
 			if err := execTx.Migrator().CreateTable(value); err != nil {
 				return err
@@ -984,4 +990,14 @@ func (m Migrator) GetTypeAliases(databaseTypeName string) []string {
 // TableType return tableType gorm.TableType and execErr error
 func (m Migrator) TableType(dst interface{}) (gorm.TableType, error) {
 	return nil, errors.New("not support")
+}
+
+// ObtainLock obtains a global migration lock
+func (m Migrator) ObtainLock() error {
+	return nil
+}
+
+// ReleaseLock releases the global migration lock
+func (m Migrator) ReleaseLock() error {
+	return nil
 }


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR makes the migrator obtain a driver-specific lock before migrating a table.

### User Case Description

This makes it possible to prevent auto-migrating from failing due to concurrent migrations in distributed systems and parallel tests.

A further explanation can be read in the issue #6618.