### PR TITLE
feat: order supports []clause.OrderByColumn

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -299,6 +299,7 @@ func (db *DB) Having(query interface{}, args ...interface{}) (tx *DB) {
 //
 //	db.Order("name DESC")
 //	db.Order(clause.OrderByColumn{Column: clause.Column{Name: "name"}, Desc: true})
+//	db.Order([]clause.OrderByColumn{{Column: clause.Column{Name: "name"}, Desc: true}})
 func (db *DB) Order(value interface{}) (tx *DB) {
 	tx = db.getInstance()
 
@@ -306,6 +307,10 @@ func (db *DB) Order(value interface{}) (tx *DB) {
 	case clause.OrderByColumn:
 		tx.Statement.AddClause(clause.OrderBy{
 			Columns: []clause.OrderByColumn{v},
+		})
+	case []clause.OrderByColumn:
+		tx.Statement.AddClause(clause.OrderBy{
+			Columns: v,
 		})
 	case string:
 		if v != "" {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR supports the []clause.OrderByColumn as input for the Order function.

### User Case Description

db.Order([]clause.OrderByColumn{{Column: clause.Column{Name: "name"}, Desc: true}})