### PR TITLE
fix error time (previously wrong time) when select multiple nullable tim…

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -824,6 +824,8 @@ func (field *Field) setupValuerAndSetter() {
 				case **time.Time:
 					if data != nil && *data != nil {
 						field.Set(ctx, value, *data)
+					}else{
+						field.Set(ctx, value, nil)
 					}
 				case time.Time:
 					field.ReflectValueOf(ctx, value).Set(reflect.ValueOf(v))


### PR DESCRIPTION
fix error time (previously wrong time) when select multiple nullable tim…

When the column type allows for optional datetime fields, if we set the field type as time.Time and there is a scenario where one record in the query result has this field while another does not, it may lead to the occurrence of dirty data where the field value of the second record is the same as the field value of the first record


