### PR TITLE
Making locking parameters more intuitive

### DIFF
--- a/clause/locking.go
+++ b/clause/locking.go
@@ -1,23 +1,16 @@
 package clause
 
-type LockingStrength string
-
 const (
-	LockingStrengthUpdate = LockingStrength("UPDATE")
-	LockingStrengthShare  = LockingStrength("SHARE")
-)
-
-type LockingOptions string
-
-const (
-	LockingOptionsSkipLocked = LockingOptions("SKIP LOCKED")
-	LockingOptionsNoWait     = LockingOptions("NOWAIT")
+	LockingStrengthUpdate    = "UPDATE"
+	LockingStrengthShare     = "SHARE"
+	LockingOptionsSkipLocked = "SKIP LOCKED"
+	LockingOptionsNoWait     = "NOWAIT"
 )
 
 type Locking struct {
-	Strength LockingStrength
+	Strength string
 	Table    Table
-	Options  LockingOptions
+	Options  string
 }
 
 // Name where clause name
@@ -27,7 +20,7 @@ func (locking Locking) Name() string {
 
 // Build build where clause
 func (locking Locking) Build(builder Builder) {
-	builder.WriteString(string(locking.Strength))
+	builder.WriteString(locking.Strength)
 	if locking.Table.Name != "" {
 		builder.WriteString(" OF ")
 		builder.WriteQuoted(locking.Table)
@@ -35,7 +28,7 @@ func (locking Locking) Build(builder Builder) {
 
 	if locking.Options != "" {
 		builder.WriteByte(' ')
-		builder.WriteString(string(locking.Options))
+		builder.WriteString(locking.Options)
 	}
 }
 

--- a/clause/locking.go
+++ b/clause/locking.go
@@ -1,9 +1,23 @@
 package clause
 
+type LockingStrength string
+
+const (
+	LockingStrengthUpdate = LockingStrength("UPDATE")
+	LockingStrengthShare  = LockingStrength("SHARE")
+)
+
+type LockingOptions string
+
+const (
+	LockingOptionsSkipLocked = LockingOptions("SKIP LOCKED")
+	LockingOptionsNoWait     = LockingOptions("NOWAIT")
+)
+
 type Locking struct {
-	Strength string
+	Strength LockingStrength
 	Table    Table
-	Options  string
+	Options  LockingOptions
 }
 
 // Name where clause name
@@ -13,7 +27,7 @@ func (locking Locking) Name() string {
 
 // Build build where clause
 func (locking Locking) Build(builder Builder) {
-	builder.WriteString(locking.Strength)
+	builder.WriteString(string(locking.Strength))
 	if locking.Table.Name != "" {
 		builder.WriteString(" OF ")
 		builder.WriteQuoted(locking.Table)
@@ -21,7 +35,7 @@ func (locking Locking) Build(builder Builder) {
 
 	if locking.Options != "" {
 		builder.WriteByte(' ')
-		builder.WriteString(locking.Options)
+		builder.WriteString(string(locking.Options))
 	}
 }
 

--- a/clause/locking_test.go
+++ b/clause/locking_test.go
@@ -14,16 +14,20 @@ func TestLocking(t *testing.T) {
 		Vars    []interface{}
 	}{
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Locking{Strength: "UPDATE"}},
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Locking{Strength: clause.LockingStrengthUpdate}},
 			"SELECT * FROM `users` FOR UPDATE", nil,
 		},
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Locking{Strength: "SHARE", Table: clause.Table{Name: clause.CurrentTable}}},
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Locking{Strength: clause.LockingStrengthShare, Table: clause.Table{Name: clause.CurrentTable}}},
 			"SELECT * FROM `users` FOR SHARE OF `users`", nil,
 		},
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Locking{Strength: "UPDATE"}, clause.Locking{Strength: "UPDATE", Options: "NOWAIT"}},
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Locking{Strength: clause.LockingStrengthUpdate, Options: clause.LockingOptionsNoWait}},
 			"SELECT * FROM `users` FOR UPDATE NOWAIT", nil,
+		},
+		{
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Locking{Strength: clause.LockingStrengthUpdate, Options: clause.LockingOptionsSkipLocked}},
+			"SELECT * FROM `users` FOR UPDATE SKIP LOCKED", nil,
 		},
 	}
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
This PR provides constants for locking strength and locking option to make it easier to "guess". Partially solves https://github.com/go-gorm/gorm/issues/6720

### User Case Description

```
db.Clauses(clause.Locking{
  Strength: clause.LockingStrengthUpdate,
  Options: clause.LockingOptionsNoWait,
}).Find(&users)
```
