### PR TITLE
fix: join and select mytable.* not working

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -665,7 +665,7 @@ func (stmt *Statement) Changed(fields ...string) bool {
 	return false
 }
 
-var nameMatcher = regexp.MustCompile(`^(?:\W?(\w+?)\W?\.)?\W?(\w+?)\W?$`)
+var nameMatcher = regexp.MustCompile(`^(?:\W?(\w+?)\W?\.)?\W?(\w+?|\*)\W?$`)
 
 // SelectAndOmitColumns get select and omit columns, select -> true, omit -> false
 func (stmt *Statement) SelectAndOmitColumns(requireCreate, requireUpdate bool) (map[string]bool, bool) {

--- a/statement_test.go
+++ b/statement_test.go
@@ -56,9 +56,15 @@ func TestNameMatcher(t *testing.T) {
 		"`name_1`":           {"", "name_1"},
 		"`Name_1`":           {"", "Name_1"},
 		"`Table`.`nAme`":     {"Table", "nAme"},
+		"my_table.*":         {"my_table", "*"},
+		"`my_table`.*":       {"my_table", "*"},
+		"User__Company.*":    {"User__Company", "*"},
+		"`User__Company`.*":  {"User__Company", "*"},
+		`"User__Company".*`:  {"User__Company", "*"},
+		`"table"."*"`:        {"", ""},
 	} {
-		if matches := nameMatcher.FindStringSubmatch(k); len(matches) < 3 || matches[1] != v[0] || matches[2] != v[1] {
-			t.Errorf("failed to match value: %v, got %v, expect: %v", k, matches, v)
+		if table, column := matchName(k); table != v[0] || column != v[1] {
+			t.Errorf("failed to match value: %v, got %v, expect: %v", k, []string{table, column}, v)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ x ] Do only one thing
- [ x ] Non breaking API changes
- [ x ] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Fixes bug:

Code:

```go
db.InnerJoins("User.Company", db.Select("User__Company.*")).Take(&order)
```

Expected:

```sql
SELECT order.id, order.time, ..., User__Company.id, User__Company.name, User_Company... FROM ...
```

Actually before:

```sql
SELECT order.id, order.time, order... FROM
```

### User Case Description

<!-- Your use case -->
