### PR TITLE
feat: allow priority tag in composite PK

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -127,16 +127,21 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 	}
 
 	if field.PrimaryKey {
+		// default priority is 10, to be consistent with composite index
 		field.PrimaryKeyPriority = 10
-	}
 
-	if field.TagSettings["PRIMARYKEY,PRIORITY"] != "" {
-		primaryKeyPriority, err := strconv.Atoi(tagSetting["PRIMARYKEY,PRIORITY"])
-		if err == nil {
-			field.PrimaryKeyPriority = primaryKeyPriority
+		priority := ParseTagSetting(field.TagSettings["PRIMARYKEY"], ",")["PRIORITY"]
+		if priority == "" {
+			priority = ParseTagSetting(field.TagSettings["PRIMARY_KEY"], ",")["PRIORITY"]
+		}
+
+		if priority != "" {
+			primaryKeyPriority, err := strconv.Atoi(priority)
+			if err == nil {
+				field.PrimaryKeyPriority = primaryKeyPriority
+			}
 		}
 	}
-
 	for field.IndirectFieldType.Kind() == reflect.Ptr {
 		field.IndirectFieldType = field.IndirectFieldType.Elem()
 	}

--- a/schema/field_test.go
+++ b/schema/field_test.go
@@ -334,27 +334,27 @@ func TestTypeAliasField(t *testing.T) {
 }
 
 type UserWithCompositePrimaryKey struct {
-	Foo uint `gorm:"primaryKey,priority:2;autoIncrement:false"`
-	Bar uint `gorm:"primaryKey,priority:1"`
+	Foo uint `gorm:"primaryKey:,priority:2;autoIncrement:false"`
+	Bar uint `gorm:"primaryKey:,priority:1"`
 	Baz uint `gorm:"primaryKey"`
 }
 
 func TestParseFieldWithCompositePrimaryKey(t *testing.T) {
 	user, err := schema.Parse(&UserWithCompositePrimaryKey{}, &sync.Map{}, schema.NamingStrategy{})
 	if err != nil {
-		t.Fatalf("Failed to parse user with permission, got error %v", err)
+		t.Fatalf("Failed to parse user with composite key, got error %v", err)
 	}
 
 	fields := []*schema.Field{
 		{
 			Name: "Foo", DBName: "foo", BindNames: []string{"Foo"}, DataType: schema.Uint, PrimaryKey: true,
 			PrimaryKeyPriority: 2, Creatable: true, Updatable: true, Readable: true, Size: 64,
-			TagSettings: map[string]string{"AUTOINCREMENT": "false", "PRIMARYKEY,PRIORITY": "2"},
+			TagSettings: map[string]string{"AUTOINCREMENT": "false", "PRIMARYKEY": ",priority:2"},
 		},
 		{
 			Name: "Bar", DBName: "bar", BindNames: []string{"Bar"}, DataType: schema.Uint, PrimaryKey: true,
 			PrimaryKeyPriority: 1, Creatable: true, Updatable: true, Readable: true, Size: 64,
-			TagSettings: map[string]string{"PRIMARYKEY,PRIORITY": "1"},
+			TagSettings: map[string]string{"PRIMARYKEY": ",priority:1"},
 		},
 		{Name: "Baz", DBName: "baz", BindNames: []string{"Baz"}, DataType: schema.Uint, PrimaryKey: true,
 			PrimaryKeyPriority: 10, Creatable: true, Updatable: true, Readable: true, Size: 64,

--- a/schema/field_test.go
+++ b/schema/field_test.go
@@ -332,3 +332,37 @@ func TestTypeAliasField(t *testing.T) {
 		checkSchemaField(t, alias, f, func(f *schema.Field) {})
 	}
 }
+
+type UserWithCompositePrimaryKey struct {
+	Foo uint `gorm:"primaryKey,priority:2;autoIncrement:false"`
+	Bar uint `gorm:"primaryKey,priority:1"`
+	Baz uint `gorm:"primaryKey"`
+}
+
+func TestParseFieldWithCompositePrimaryKey(t *testing.T) {
+	user, err := schema.Parse(&UserWithCompositePrimaryKey{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("Failed to parse user with permission, got error %v", err)
+	}
+
+	fields := []*schema.Field{
+		{
+			Name: "Foo", DBName: "foo", BindNames: []string{"Foo"}, DataType: schema.Uint, PrimaryKey: true,
+			PrimaryKeyPriority: 2, Creatable: true, Updatable: true, Readable: true, Size: 64,
+			TagSettings: map[string]string{"AUTOINCREMENT": "false", "PRIMARYKEY,PRIORITY": "2"},
+		},
+		{
+			Name: "Bar", DBName: "bar", BindNames: []string{"Bar"}, DataType: schema.Uint, PrimaryKey: true,
+			PrimaryKeyPriority: 1, Creatable: true, Updatable: true, Readable: true, Size: 64,
+			TagSettings: map[string]string{"PRIMARYKEY,PRIORITY": "1"},
+		},
+		{Name: "Baz", DBName: "baz", BindNames: []string{"Baz"}, DataType: schema.Uint, PrimaryKey: true,
+			PrimaryKeyPriority: 10, Creatable: true, Updatable: true, Readable: true, Size: 64,
+			TagSettings: map[string]string{"PRIMARYKEY": "PRIMARYKEY"},
+		},
+	}
+
+	for _, f := range fields {
+		checkSchemaField(t, user, f, func(f *schema.Field) {})
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fixes [issue#6755](https://github.com/go-gorm/gorm/issues/6755) to allow priority tag for composite primary key, similar to unique index.

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
```
type Bad struct {
	A   ItemA
	AId uint `gorm:"primaryKey,priority:2;autoIncrement:false"`
	B   ItemB
	BId uint `gorm:"primaryKey,priority:1;autoIncrement:false"`
}
```
Composite primary key will be created and it follows ordering specified by priority tag:
![image](https://github.com/go-gorm/gorm/assets/19641445/48100c8b-7781-469c-b54f-10fd7a7128e2)

