### PR TITLE
fix: ignore .gen.go suffix in logger to get the real caller when using gen

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -35,7 +35,8 @@ func FileWithLineNum() string {
 	// the second caller usually from gorm internal, so set i start from 2
 	for i := 2; i < 15; i++ {
 		_, file, line, ok := runtime.Caller(i)
-		if ok && (!strings.HasPrefix(file, gormSourceDir) || strings.HasSuffix(file, "_test.go")) {
+		if ok && (!strings.HasPrefix(file, gormSourceDir) || strings.HasSuffix(file, "_test.go")) &&
+			!strings.HasSuffix(file, ".gen.go") {
 			return file + ":" + strconv.FormatInt(int64(line), 10)
 		}
 	}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
When using gen, the logger always print the caller from xxx.gen.go, this is not convenient for user to debug.
<img width="670" alt="截屏2024-01-08 下午12 55 50" src="https://github.com/go-gorm/gorm/assets/13096985/cb01d51e-1e30-4062-8349-1ba362e42745">


There is an issue also mention this problem #6697.

After ignore this suffix, we can get the real caller in our project from log.
<img width="767" alt="截屏2024-01-08 下午12 52 55" src="https://github.com/go-gorm/gorm/assets/13096985/37a5e31d-135f-49cb-b6a6-546bd21c8f84">


