### PR TITLE
fix: endless loop in save

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -75,7 +75,7 @@ func (db *DB) Save(value interface{}) (tx *DB) {
 	tx.Statement.Dest = value
 
 	reflectValue := reflect.Indirect(reflect.ValueOf(value))
-	for reflectValue.Kind() == reflect.Ptr || reflectValue.Kind() == reflect.Interface {
+	for reflectValue.Kind() == reflect.Ptr {
 		reflectValue = reflect.Indirect(reflectValue)
 	}
 


### PR DESCRIPTION
- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Save attempts to dereference an interface using reflect.Indirect this doesn't work as that is only intended for pointers.
This change stops it from trying to do that. Trying to do this will instead result in an error.

I don't think this should cause any breaking changes, but I don't know why this code was written like.

This would close Issue #6799 but if another solution for the problem would be preferred feel free to close this pull request.

### User Case Description

While it might not be a supported case to call Save with a pointer to an interface it should not cause an endless loop.
