### PR TITLE
Improve scan performance

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -985,6 +985,6 @@ func (field *Field) setupNewValuePool() {
 	}
 
 	if field.NewValuePool == nil {
-		field.NewValuePool = poolInitializer(reflect.PtrTo(field.IndirectFieldType))
+		field.NewValuePool = poolInitializer(field.IndirectFieldType)
 	}
 }


### PR DESCRIPTION
This patch improves gorm's performance when scanning into a struct with primitive types.
- CPU utilisation -10% (on the test I did)
- Memory utilization -10%
- Allocation count -60%

Based on this testsuite. https://github.com/go-gorm/playground/pull/687

```
BenchmarkFetchAll-v1.25.6-12                  42          29634259 ns/op         9620758 B/op     329779 allocs/op
BenchmarkFetchAll-fix    -12                  40          26599070 ns/op         8578034 B/op     199774 allocs/op
```

# Background

In https://github.com/go-gorm/gorm/blob/master/schema/pool.go#L14 we have this:

```
var (
	normalPool      sync.Map
	poolInitializer = func(reflectType reflect.Type) FieldNewValuePool {
		v, _ := normalPool.LoadOrStore(reflectType, &sync.Pool{
			New: func() interface{} {
				return reflect.New(reflectType).Interface()
			},
		})
		return v.(FieldNewValuePool)
	}
)
```

Given that this is invoked in the old code like this:
```
field.NewValuePool = poolInitializer(reflect.PtrTo(field.IndirectFieldType))
```

During scanning, we will end up with a **<type> pointer. The issue with this is even if the builtin database package handles this properly it comes at a performance penalty.

The code is optimized for common use-cases here: https://cs.opensource.google/go/go/+/master:src/database/sql/convert.go;l=219-318

This means that if we are scanning into *<type> variables, not **<type> variables no reflection is used in the database/sql package.

# profiling


## memory

Before the fix the benchmark included there behaved like this (memory):
![image](https://github.com/go-gorm/gorm/assets/26857795/7b0d77c2-bf5b-45f7-b4c7-0fc4742a0147)

After the fix:
![image](https://github.com/go-gorm/gorm/assets/26857795/930b8b0d-197a-48f2-b0f2-1a7a2a97fa43)


## cpu
Before the fix:
![image](https://github.com/go-gorm/gorm/assets/26857795/9370d7ff-5c42-4c78-abba-d32c3f0c143b)

after the fix:
![image](https://github.com/go-gorm/gorm/assets/26857795/bc8a183c-7e0a-4f7a-aa1b-ec51c9892f58)



- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested
