### PR TITLE
feat: dryrun migration should only print not-select sqls

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -47,7 +47,9 @@ type printSQLLogger struct {
 
 func (l *printSQLLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error) {
 	sql, _ := fc()
-	fmt.Println(sql + ";")
+	if len(sql) < 6 || strings.ToUpper(sql[0:6]) != "SELECT" {
+		fmt.Println(sql + ";")
+	}
 	l.Interface.Trace(ctx, begin, fc, err)
 }
 


### PR DESCRIPTION
some driver migration may run select querys to compare schemal change, like postgresql. we should only print not-select sqls when dry run migration