### PR TITLE
Fix null setting on reused objects

### DIFF
--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -107,7 +107,7 @@ func OpenTestConnection(cfg *gorm.Config) (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Coupon{}, &CouponProduct{}, &Order{}, &Parent{}, &Child{}, &Tools{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Coupon{}, &CouponProduct{}, &Order{}, &Parent{}, &Child{}, &Tools{}, &NullValue{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/utils/tests/dummy_scanner.go
+++ b/utils/tests/dummy_scanner.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type DummyString struct {
+	value string
+}
+
+func NewDummyString(s string) DummyString {
+	return DummyString{
+		value: s,
+	}
+}
+
+func (d *DummyString) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case string:
+		d.value = v
+	default:
+		d.value = fmt.Sprintf("%v", value)
+	}
+
+	return nil
+}
+
+func (d DummyString) Value() (driver.Value, error) {
+	return d.value, nil
+}
+
+func (d DummyString) String() string {
+	return d.value
+}

--- a/utils/tests/models.go
+++ b/utils/tests/models.go
@@ -30,6 +30,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak;"`
 	Friends   []*User    `gorm:"many2many:user_friends;"`
 	Active    bool
+	Motto     *DummyString
 }
 
 type Account struct {
@@ -101,4 +102,14 @@ type Child struct {
 	Name     string
 	ParentID *uint
 	Parent   *Parent
+}
+
+type NullValue struct {
+	gorm.Model
+	ScannerValue     DummyString
+	NullScannerValue *DummyString
+	IntValue         int
+	NullIntValue     *int
+	TimeValue        time.Time
+	NullTimeValue    *time.Time
 }

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -126,3 +126,7 @@ func Now() *time.Time {
 	now := time.Now()
 	return &now
 }
+
+func ToPointer[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

Starting from v1.25.1 GORM seems to not reset null fields, causing incosistent behavior compared to the previous way GORM was working.

The fixes I have added are fixing this for Scanner interfaces and time.Time, however there's still a test failure in case of the int and most likely other primitive variables.

I am opening this PR just to illustrate the fixes, but I think we need to debate it further what's the expected behavior.

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
