### PR TITLE
Fix regression in db.Not introduced in v1.25.6.

### DIFF
--- a/clause/where.go
+++ b/clause/where.go
@@ -21,11 +21,11 @@ func (where Where) Name() string {
 
 // Build build where clause
 func (where Where) Build(builder Builder) {
-    if len(where.Exprs) == 1 {
-        if andCondition, ok := where.Exprs[0].(AndConditions); ok {
-           where.Exprs = andCondition.Exprs
-        }
-    }
+	if len(where.Exprs) == 1 {
+		if andCondition, ok := where.Exprs[0].(AndConditions); ok {
+			where.Exprs = andCondition.Exprs
+		}
+	}
 
 	// Switch position if the first query expression is a single Or condition
 	for idx, expr := range where.Exprs {
@@ -152,11 +152,6 @@ func (or OrConditions) Build(builder Builder) {
 func Not(exprs ...Expression) Expression {
 	if len(exprs) == 0 {
 		return nil
-	}
-	if len(exprs) == 1 {
-		if andCondition, ok := exprs[0].(AndConditions); ok {
-			exprs = andCondition.Exprs
-		}
 	}
 	return NotConditions{Exprs: exprs}
 }

--- a/clause/where_test.go
+++ b/clause/where_test.go
@@ -107,10 +107,11 @@ func TestWhere(t *testing.T) {
 		},
 		{
 			[]clause.Interface{clause.Select{}, clause.From{}, clause.Where{
-				Exprs: []clause.Expression{clause.Not(clause.And(clause.Eq{Column: clause.PrimaryColumn, Value: "1"}, clause.Expr{SQL: "`score` <= ?", Vars: []interface{}{100}, WithoutParentheses: false}))},
+				Exprs: []clause.Expression{clause.Not(clause.Expr{SQL: "`score` <= ?", Vars: []interface{}{100}},
+					clause.Expr{SQL: "`age` <= ?", Vars: []interface{}{60}})},
 			}},
-			"SELECT * FROM `users` WHERE NOT (`users`.`id` = ? AND `score` <= ?)",
-			[]interface{}{"1", 100},
+			"SELECT * FROM `users` WHERE NOT (`score` <= ? AND `age` <= ?)",
+			[]interface{}{100, 60},
 		},
 	}
 

--- a/clause/where_test.go
+++ b/clause/where_test.go
@@ -105,6 +105,13 @@ func TestWhere(t *testing.T) {
 			"SELECT * FROM `users` WHERE (`users`.`id` <> ? AND NOT `score` <= ?)",
 			[]interface{}{"1", 100},
 		},
+		{
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Where{
+				Exprs: []clause.Expression{clause.Not(clause.And(clause.Eq{Column: clause.PrimaryColumn, Value: "1"}, clause.Expr{SQL: "`score` <= ?", Vars: []interface{}{100}, WithoutParentheses: false}))},
+			}},
+			"SELECT * FROM `users` WHERE NOT (`users`.`id` = ? AND `score` <= ?)",
+			[]interface{}{"1", 100},
+		},
 	}
 
 	for idx, result := range results {

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -554,6 +554,11 @@ func TestNot(t *testing.T) {
 	if !regexp.MustCompile("SELECT \\* FROM .*users.* WHERE .*users.*..*name.* <> .+ AND .*users.*..*age.* <> .+").MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("Build NOT condition, but got %v", result.Statement.SQL.String())
 	}
+
+	result = dryDB.Not(DB.Where("manager IS NULL").Where("age >= ?", 20)).Find(&User{})
+	if !regexp.MustCompile("SELECT \\* FROM .*users.* WHERE NOT \\(manager IS NULL AND age >= .+\\) AND .users.\\..deleted_at. IS NULL").MatchString(result.Statement.SQL.String()) {
+		t.Fatalf("Build NOT condition, but got %v", result.Statement.SQL.String())
+	}
 }
 
 func TestNotWithAllFields(t *testing.T) {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fix #6845

Address a regression introduced in Gorm v1.25.6, specifically in commit 940358e.

The behavior of the `db.Not` method when used with multiple `Where` conditions has changed unexpectedly. Prior to v1.25.6, the query `db.Not(db.Where("a=1").Where("b=1"))` would correctly translate to SQL as `NOT (a=1 AND b=1)`. However, after the specified commit, the same query started translating to `(NOT a=1 AND NOT b=1)`, which is a significant alteration in the logic.

This PR reverts the `db.Not` method's behavior back to its original state when *gorm.DB passed as arguments.


### User Case Description

<!-- Your use case -->
