### PR TITLE
fix: nested preload with join panic when find

### DIFF
--- a/tests/preload_test.go
+++ b/tests/preload_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	. "gorm.io/gorm/utils/tests"
@@ -362,6 +364,14 @@ func TestNestedPreloadWithNestedJoin(t *testing.T) {
 		t.Errorf("failed to find value, got err: %v", err)
 	}
 	AssertEqual(t, find2, value)
+
+	var finds []Value
+	err = DB.Joins("Nested.Join").Joins("Nested").Preload("Nested.Preloads").Find(&finds).Error
+	if err != nil {
+		t.Errorf("failed to find value, got err: %v", err)
+	}
+	require.Len(t, finds, 1)
+	AssertEqual(t, finds[0], value)
 }
 
 func TestEmbedPreload(t *testing.T) {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

When query with nested preload and nested join, the `preloadEntryPoint` ignored the slice type, so it panic.
See and close #6834 


### User Case Description

<!-- Your use case -->
```
DB.Joins("Update.Repo").Joins("Update").Preload("Update.DispatchRecords").Find(&deviceUpdates)
```

