### PR TITLE
refactor(scan.go): array index is out of bounds exits the for loop

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -311,8 +311,9 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 				db.scanIntoStruct(rows, elem, values, fields, joinFields)
 
 				if !update {
+					rows := int(db.RowsAffected)
 					// array index is out of bounds, exits the for loop
-					if isArrayKind && reflectValue.Len() < int(db.RowsAffected) {
+					if isArrayKind && reflectValue.Len() < rows {
 						break
 					}
 
@@ -320,7 +321,7 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 						elem = elem.Elem()
 					}
 					if isArrayKind {
-						reflectValue.Index(int(db.RowsAffected - 1)).Set(elem)
+						reflectValue.Index(rows - 1).Set(elem)
 					} else {
 						reflectValue = reflect.Append(reflectValue, elem)
 					}

--- a/scan.go
+++ b/scan.go
@@ -311,9 +311,8 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 				db.scanIntoStruct(rows, elem, values, fields, joinFields)
 
 				if !update {
-					rows := int(db.RowsAffected)
 					// array index is out of bounds, exits the for loop
-					if isArrayKind && reflectValue.Len() < rows {
+					if isArrayKind && reflectValue.Len() < int(db.RowsAffected) {
 						break
 					}
 
@@ -321,7 +320,7 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 						elem = elem.Elem()
 					}
 					if isArrayKind {
-						reflectValue.Index(rows - 1).Set(elem)
+						reflectValue.Index(int(db.RowsAffected - 1)).Set(elem)
 					} else {
 						reflectValue = reflect.Append(reflectValue, elem)
 					}

--- a/scan.go
+++ b/scan.go
@@ -311,13 +311,16 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 				db.scanIntoStruct(rows, elem, values, fields, joinFields)
 
 				if !update {
+					// array index is out of bounds, exits the for loop
+					if isArrayKind && reflectValue.Len() < int(db.RowsAffected) {
+						break
+					}
+
 					if !isPtr {
 						elem = elem.Elem()
 					}
 					if isArrayKind {
-						if reflectValue.Len() >= int(db.RowsAffected) {
-							reflectValue.Index(int(db.RowsAffected - 1)).Set(elem)
-						}
+						reflectValue.Index(int(db.RowsAffected - 1)).Set(elem)
 					} else {
 						reflectValue = reflect.Append(reflectValue, elem)
 					}

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -1428,3 +1428,14 @@ func TestQueryScanToArray(t *testing.T) {
 		t.Error("users[1] should be empty")
 	}
 }
+
+func TestQueryScanOfRowsGteArrayLength(t *testing.T) {
+	users := [1]*User{}
+	err := DB.Limit(2).Find(&users).Error
+	if err != nil {
+		t.Fatal(err)
+	}
+	if users[0] == nil {
+		t.Error("users[0] not found")
+	}
+}

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -1429,7 +1429,7 @@ func TestQueryScanToArray(t *testing.T) {
 	}
 }
 
-func TestQueryScanOfRowsGteArrayLength(t *testing.T) {
+func TestQueryScanOfRowsGtArrayLength(t *testing.T) {
 	users := [1]*User{}
 	err := DB.Limit(2).Find(&users).Error
 	if err != nil {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
传入的是数组，返回的行数超过数组长度，结束当前的扫描

array is passed in, and the number of rows returned exceeds the length of the array, ending the current scan.

### User Case Description

<!-- Your use case -->
