### PR TITLE
fix(scan): array element is set to a zero value

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -274,7 +274,11 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 
 			if !update || reflectValue.Len() == 0 {
 				update = false
-				if !isArrayKind {
+				if isArrayKind {
+					for i := 0; i < reflectValue.Len(); i++ {
+						reflectValue.Index(i).Set(reflect.Zero(reflectValue.Index(i).Type()))
+					}
+				} else {
 					// if the slice cap is externally initialized, the externally initialized slice is directly used here
 					if reflectValue.Cap() == 0 {
 						db.Statement.ReflectValue.Set(reflect.MakeSlice(reflectValue.Type(), 0, 20))

--- a/scan.go
+++ b/scan.go
@@ -275,9 +275,7 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 			if !update || reflectValue.Len() == 0 {
 				update = false
 				if isArrayKind {
-					for i := 0; i < reflectValue.Len(); i++ {
-						reflectValue.Index(i).Set(reflect.Zero(reflectValue.Index(i).Type()))
-					}
+					db.Statement.ReflectValue.Set(reflect.Zero(reflectValue.Type()))
 				} else {
 					// if the slice cap is externally initialized, the externally initialized slice is directly used here
 					if reflectValue.Cap() == 0 {

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -1410,21 +1410,21 @@ func TestQueryError(t *testing.T) {
 	AssertEqual(t, err, gorm.ErrModelValueRequired)
 }
 
-func TestQueryScanArray(t *testing.T) {
+func TestQueryScanToArray(t *testing.T) {
 	err := DB.Create(&User{Name: "testname1", Age: 10}).Error
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	users := [2]*User{{Name: "testname2"}, {Name: "testname3"}}
+	users := [2]*User{{Name: "1"}, {Name: "2"}}
 	err = DB.Model(&User{}).Where("name = ?", "testname1").Find(&users).Error
 	if err != nil {
 		t.Fatal(err)
 	}
-	if users[0].Name != "testname1" {
+	if users[0] == nil || users[0].Name != "testname1" {
 		t.Error("users[0] not covere")
 	}
-	if users[1].Name != "" {
+	if users[1] != nil {
 		t.Error("users[1] should be empty")
 	}
 }

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -1409,3 +1409,22 @@ func TestQueryError(t *testing.T) {
 	}, Value: 1}).Scan(&p2).Error
 	AssertEqual(t, err, gorm.ErrModelValueRequired)
 }
+
+func TestQueryScanArray(t *testing.T) {
+	err := DB.Create(&User{Name: "testname1", Age: 10}).Error
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	users := [2]*User{{Name: "testname2"}, {Name: "testname3"}}
+	err = DB.Model(&User{}).Where("name = ?", "testname1").Find(&users).Error
+	if err != nil {
+		t.Fatal(err)
+	}
+	if users[0].Name != "testname1" {
+		t.Error("users[0] not covere")
+	}
+	if users[1].Name != "" {
+		t.Error("users[1] should be empty")
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
<img width="776" alt="image" src="https://github.com/go-gorm/gorm/assets/27986239/bae5471e-c8d2-4f21-bda7-8da25dd6f301">
If you do not set a zero value, the number of queries is less than the length of the array, and the old value will be used

### User Case Description

<!-- Your use case -->
