### PR TITLE
feat: add MapColumns method

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -185,6 +185,13 @@ func (db *DB) Omit(columns ...string) (tx *DB) {
 	return
 }
 
+// MapColumns specify column-to-field for customizing how database columns are assigned to struct fields during querying
+func (db *DB) MapColumns(m map[string]string) (tx *DB) {
+	tx = db.getInstance()
+	tx.Statement.ColumnMapping = m
+	return
+}
+
 // Where add conditions
 //
 // See the [docs] for details on the various formats that where clauses can take. By default, where clauses chain with AND.

--- a/scan.go
+++ b/scan.go
@@ -131,6 +131,15 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 		onConflictDonothing = mode&ScanOnConflictDoNothing != 0
 	)
 
+	if len(db.Statement.ColumnMapping) > 0 {
+		for i, column := range columns {
+			v, ok := db.Statement.ColumnMapping[column]
+			if ok {
+				columns[i] = v
+			}
+		}
+	}
+
 	db.RowsAffected = 0
 
 	switch dest := db.Statement.Dest.(type) {

--- a/statement.go
+++ b/statement.go
@@ -30,8 +30,9 @@ type Statement struct {
 	Clauses              map[string]clause.Clause
 	BuildClauses         []string
 	Distinct             bool
-	Selects              []string // selected columns
-	Omits                []string // omit columns
+	Selects              []string          // selected columns
+	Omits                []string          // omit columns
+	ColumnMapping        map[string]string // map columns
 	Joins                []join
 	Preloads             map[string][]interface{}
 	Settings             sync.Map


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Add `MapColumns` method: specify column-to-field for customizing how database columns are assigned to struct fields during querying

### User Case Description

<!-- Your use case -->
I recently used gorm to do aggregation queries based on timescaledb. For example, the following query:   
```
SELECT
    symbol,
    '5min' AS timeframe,
    TRUE AS adj,
    time_bucket('5 minute', t, 'America/New_York') AS bucket,
    time_bucket('5 minute', t, 'America/New_York') AS t,
    FIRST(o, t) AS o,
    MAX(h) AS h,
    MIN(l) AS l,
    LAST(c, t) AS c,
    SUM(v) AS v,
    SUM(n) AS n,
    SUM(v*c)/SUM(v) AS vw
FROM
    market.candle
WHERE
    adj = TRUE AND
    timeframe = '1min' AND 
    symbol = 'AAPL' AND
    time_bucket('5 minute', t, 'America/New_York') > '2023-03-03 17:01:00+08'
GROUP BY
    symbol, bucket
ORDER BY
    symbol, bucket ASC
LIMIT 10000;
```
```
bucketWidth := timeFrameToBucketWidth(req.TimeFrame)
db = db.Select(`
	symbol,
	? AS timeframe,
	TRUE AS adj,
	time_bucket(?, t, ?) AS bucket,
	time_bucket(?, t, ?) AS t,
	FIRST(o, t) AS o,
	MAX(h) AS h,
	MIN(l) AS l,
	LAST(c, t) AS c,
	SUM(v) AS v,
	SUM(n) AS n,
	SUM(v*c)/SUM(v) AS vw
`, req.TimeFrame.String(), bucketWidth, s.locationName, bucketWidth, s.locationName)
db = db.Where(`symbol IN ? AND timeframe = '1min' AND adj = ?`, req.Symbols, req.Adjustment)
if !req.Start.IsZero() {
	db = db.Where(fmt.Sprintf("time_bucket(?, t, ?) %s ?", startCompare), bucketWidth, s.locationName, req.Start)
}
if !req.End.IsZero() {
	db = db.Where("time_bucket(?, t, ?) < ?", bucketWidth, s.locationName, req.End)
}
db = db.Group("symbol, bucket")
db = db.Order("symbol ASC, bucket ASC")
```

The result will be an error `ERROR: column "candle.t" must appear in the GROUP BY clause or be used in an aggregate function (SQLSTATE 42803)`.
However, I cannot put `t` in `Group`, which will affect the correct result. So I tried using `db = db.Group("symbol, time_bucket('5 minute', t, 'America/New_York')")` which unfortunately returns the same error.
So I can only give up returning the `t` column in the result set, but then I need to customize a nested structure to supplement a `bucket` column, and then manually assign it to `MarketCandle.T`. This is very inconvenient.
So I added the `MapColumns` method. I think this may be a requirement that also exists in other scenarios, especially when `GROUP BY` is used.   