### PR TITLE
WIP fix(create): create error writes back the primary key value

### DIFF
--- a/callbacks/create.go
+++ b/callbacks/create.go
@@ -175,9 +175,33 @@ func Create(config *Config) func(db *gorm.DB) {
 							break
 						}
 
-						if _, isZero := pkField.ValueOf(db.Statement.Context, rv); isZero {
+						if field, isZero := pkField.ValueOf(db.Statement.Context, rv); isZero {
 							db.AddError(pkField.Set(db.Statement.Context, rv, insertID))
 							insertID += pkField.AutoIncrementIncrement
+						} else {
+							// If the primary key is set, the next primary key value is incremented from that primary key
+							switch f := field.(type) {
+							case int:
+								insertID = int64(f) + pkField.AutoIncrementIncrement
+							case int8:
+								insertID = int64(f) + pkField.AutoIncrementIncrement
+							case int16:
+								insertID = int64(f) + pkField.AutoIncrementIncrement
+							case int32:
+								insertID = int64(f) + pkField.AutoIncrementIncrement
+							case int64:
+								insertID = f + pkField.AutoIncrementIncrement
+							case uint:
+								insertID = int64(f) + pkField.AutoIncrementIncrement
+							case uint8:
+								insertID = int64(f) + pkField.AutoIncrementIncrement
+							case uint16:
+								insertID = int64(f) + pkField.AutoIncrementIncrement
+							case uint32:
+								insertID = int64(f) + pkField.AutoIncrementIncrement
+							case uint64:
+								insertID = int64(f) + pkField.AutoIncrementIncrement
+							}
 						}
 					}
 				}

--- a/schema/field.go
+++ b/schema/field.go
@@ -471,8 +471,7 @@ func (field *Field) setupValuerAndSetter() {
 				}
 			}
 
-			fv, zero := v.Interface(), v.IsZero()
-			return fv, zero
+			return v.Interface(), v.IsZero()
 		}
 	}
 

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -793,3 +793,30 @@ func TestCreateFromMapWithTable(t *testing.T) {
 		t.Fatal("failed to create data from map with table, @id != id")
 	}
 }
+
+func TestCreateWithSliceWritebackPrimaryKey(t *testing.T) {
+	users := []*User{
+		{
+			Age: 20,
+		},
+		{
+			Model: gorm.Model{
+				ID: 100000,
+			},
+			Age: 21,
+		},
+		{
+			Age: 22,
+		},
+	}
+	err := DB.Create(users).Error
+	if err != nil {
+		t.Fatal(err)
+	}
+	if users[1].ID != 100000 {
+		t.Errorf("users[1].ID should be 100000, but got %v", users[1].ID)
+	}
+	if users[2].ID != users[1].ID+1 {
+		t.Errorf("failed to write back primary key, users[2].ID should be %v, but got %v, %v", users[1].ID+1, users[2].ID, users[0].ID)
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
<img width="820" alt="image" src="https://github.com/go-gorm/gorm/assets/27986239/6fb9f2d5-45b1-404d-b3e8-1293bb77bb1e">
When writing back the primary key value during batch creation, if the primary key value is set in the middle field, it should be incremented from the changed primary key.

### User Case Description

<!-- Your use case -->
