### PR TITLE
fix: behavior when getting removed callback

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -154,8 +154,11 @@ func (p *processor) Execute(db *DB) *DB {
 
 func (p *processor) Get(name string) func(*DB) {
 	for i := len(p.callbacks) - 1; i >= 0; i-- {
-		if v := p.callbacks[i]; v.name == name && !v.remove {
-			return v.handler
+		if v := p.callbacks[i]; v.name == name {
+			if !v.remove {
+				return v.handler
+			}
+			return nil
 		}
 	}
 	return nil

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -212,7 +212,6 @@ func TestCallbacksRemoveAndGet(t *testing.T) {
 	createCallback := db.Callback().Create()
 
 	err := createCallback.Register("plugin_1_fn1", c1)
-
 	if err != nil {
 		t.Errorf("callbacks tests failed, got error: %v", err)
 	}

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -206,3 +206,25 @@ func TestPluginCallbacks(t *testing.T) {
 		t.Errorf("callbacks tests failed, got %v", msg)
 	}
 }
+
+func TestCallbacksRemoveAndGet(t *testing.T) {
+	db, _ := gorm.Open(nil, nil)
+	createCallback := db.Callback().Create()
+
+	err := createCallback.Register("plugin_1_fn1", c1)
+
+	if err != nil {
+		t.Errorf("callbacks tests failed, got error: %v", err)
+	}
+	if cb := createCallback.Get("plugin_1_fn1"); reflect.DeepEqual(cb, c1) {
+		t.Errorf("callbacks tests failed, got: %p, want: %p", cb, c1)
+	}
+
+	err = createCallback.Remove("plugin_1_fn1")
+	if err != nil {
+		t.Errorf("callbacks test failed, got error: %v", err)
+	}
+	if cb := createCallback.Get("plugin_1_fn1"); cb != nil {
+		t.Errorf("callbacks test failed. got: %p, want: nil", cb)
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Resolved the issue where `Get()` retrieves a callback that has been removed by `Remove()`. 
This was due to the search continuing even when a callback with `v.removed: true` was found, eventually reaching another callback of the same name with `v.removed: false`.

### User Case Description

<!-- Your use case -->


If a callback named `cb1` is registered, it is expected that calling `Get("cb1")` after `Remove("cb1")` should return `nil`. However, a callback function registered as `cb1` is being returned instead.

```golang
db, _ := gorm.Open(tests.DummyDialector{}, nil)
createCallback := db.Callback().Create()

_ = createCallback.Register("cb1", func(*gorm.DB){})
_ = createCallback.Remove("cb1")

cb := createCallback.Get("cb1") // not nil
```



