### PR TITLE
fix: remove `callback` from `callbacks` if `Remove()` called

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -186,21 +186,19 @@ func (p *processor) Replace(name string, fn func(*DB)) error {
 }
 
 func (p *processor) compile() (err error) {
-	var (
-		callbacks []*callback
-		removed   []string
-	)
+	var callbacks []*callback
+	removedMap := map[string]bool{}
 	for _, callback := range p.callbacks {
 		if callback.match == nil || callback.match(p.db) {
 			callbacks = append(callbacks, callback)
 		}
 		if callback.remove {
-			removed = append(removed, callback.name)
+			removedMap[callback.name] = true
 		}
 	}
 
-	if len(removed) > 0 {
-		callbacks = removeCallbacks(callbacks, removed)
+	if len(removedMap) > 0 {
+		callbacks = removeCallbacks(callbacks, removedMap)
 	}
 
 	p.callbacks = callbacks
@@ -351,10 +349,10 @@ func sortCallbacks(cs []*callback) (fns []func(*DB), err error) {
 	return
 }
 
-func removeCallbacks(cs []*callback, names []string) []*callback {
+func removeCallbacks(cs []*callback, nameMap map[string]bool) []*callback {
 	callbacks := make([]*callback, 0, len(cs))
 	for _, callback := range cs {
-		if utils.Contains(names, callback.name) {
+		if nameMap[callback.name] {
 			continue
 		}
 		callbacks = append(callbacks, callback)

--- a/callbacks.go
+++ b/callbacks.go
@@ -186,12 +186,23 @@ func (p *processor) Replace(name string, fn func(*DB)) error {
 }
 
 func (p *processor) compile() (err error) {
-	var callbacks []*callback
+	var (
+		callbacks []*callback
+		removed   []string
+	)
 	for _, callback := range p.callbacks {
 		if callback.match == nil || callback.match(p.db) {
 			callbacks = append(callbacks, callback)
 		}
+		if callback.remove {
+			removed = append(removed, callback.name)
+		}
 	}
+
+	if len(removed) > 0 {
+		callbacks = removeCallbacks(callbacks, removed)
+	}
+
 	p.callbacks = callbacks
 
 	if p.fns, err = sortCallbacks(p.callbacks); err != nil {
@@ -338,4 +349,15 @@ func sortCallbacks(cs []*callback) (fns []func(*DB), err error) {
 	}
 
 	return
+}
+
+func removeCallbacks(cs []*callback, names []string) []*callback {
+	callbacks := make([]*callback, 0, len(cs))
+	for _, callback := range cs {
+		if utils.Contains(names, callback.name) {
+			continue
+		}
+		callbacks = append(callbacks, callback)
+	}
+	return callbacks
 }

--- a/callbacks.go
+++ b/callbacks.go
@@ -200,7 +200,6 @@ func (p *processor) compile() (err error) {
 	if len(removedMap) > 0 {
 		callbacks = removeCallbacks(callbacks, removedMap)
 	}
-
 	p.callbacks = callbacks
 
 	if p.fns, err = sortCallbacks(p.callbacks); err != nil {

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -91,7 +91,7 @@ func TestCallbacks(t *testing.T) {
 		},
 		{
 			callbacks: []callback{{h: c1}, {h: c2, before: "c4", after: "c5"}, {h: c3}, {h: c4}, {h: c5}, {h: c2, remove: true}},
-			results:   []string{"c1", "c5", "c3", "c4"},
+			results:   []string{"c1", "c3", "c4", "c5"},
 		},
 		{
 			callbacks: []callback{{h: c1}, {name: "c", h: c2}, {h: c3}, {name: "c", h: c4, replace: true}},
@@ -203,6 +203,52 @@ func TestPluginCallbacks(t *testing.T) {
 
 	createCallback.After("*").Register("plugin_3_fn2", c6)
 	if ok, msg := assertCallbacks(createCallback, []string{"c5", "c3", "c1", "c2", "c4", "c6"}); !ok {
+		t.Errorf("callbacks tests failed, got %v", msg)
+	}
+}
+
+func TestCallbacksGet(t *testing.T) {
+	db, _ := gorm.Open(nil, nil)
+	createCallback := db.Callback().Create()
+
+	createCallback.Before("*").Register("c1", c1)
+	if cb := createCallback.Get("c1"); reflect.DeepEqual(cb, c1) {
+		t.Errorf("callbacks tests failed, got: %p, want: %p", cb, c1)
+	}
+
+	createCallback.Remove("c1")
+	if cb := createCallback.Get("c2"); cb != nil {
+		t.Errorf("callbacks test failed. got: %p, want: nil", cb)
+	}
+}
+
+func TestCallbacksRemove(t *testing.T) {
+	db, _ := gorm.Open(nil, nil)
+	createCallback := db.Callback().Create()
+
+	createCallback.Before("*").Register("c1", c1)
+	createCallback.After("*").Register("c2", c2)
+	createCallback.Before("c4").Register("c3", c3)
+	createCallback.After("c2").Register("c4", c4)
+
+	// callbacks: []string{"c1", "c3", "c4", "c2"}
+	createCallback.Remove("c1")
+	if ok, msg := assertCallbacks(createCallback, []string{"c3", "c4", "c2"}); !ok {
+		t.Errorf("callbacks tests failed, got %v", msg)
+	}
+
+	createCallback.Remove("c4")
+	if ok, msg := assertCallbacks(createCallback, []string{"c3", "c2"}); !ok {
+		t.Errorf("callbacks tests failed, got %v", msg)
+	}
+
+	createCallback.Remove("c2")
+	if ok, msg := assertCallbacks(createCallback, []string{"c3"}); !ok {
+		t.Errorf("callbacks tests failed, got %v", msg)
+	}
+
+	createCallback.Remove("c3")
+	if ok, msg := assertCallbacks(createCallback, []string{}); !ok {
 		t.Errorf("callbacks tests failed, got %v", msg)
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

ref: https://github.com/go-gorm/gorm/pull/6910#pullrequestreview-1945116356

Modified the `Remove()` method so that it not only sets the removed flag but also removes the `callback` from the `callbacks` within `compile()`. 
This resolves the following issues:

- The problem where the `Get()` method could retrieve callbacks that have already been removed.
- The problem where removed callbacks could still operate due to the `Remove()` method.

In addition, I have made some modifications to the existing tests.
Previously, the specified `before` and `after` for a `callback` continued to affect the overall order even after being `Remove()`d. I believe that continuing to have an effect after being removed is an unintended behavior.
What do you think? I would appreciate any advice.

### User Case Description

<!-- Your use case -->

#### The problem where the `Get()` method

If a callback named `cb1` is registered, it is expected that calling `Get("cb1")` after `Remove("cb1")` should return `nil`. However, a callback function registered as `cb1` is being returned instead.

```golang
db, _ := gorm.Open(nil, nil)
createCallback := db.Callback().Create()

createCallback.Register("cb1", func(*gorm.DB){})
createCallback.Remove("cb1")

cb := createCallback.Get("cb1") // not nil
```

#### The problem where the `Remove()` method

The expectation is that callbacks marked as removed via `Remove()` should not be executed. However, we encountered an issue where callbacks registered through methods like `Before("*").Register()` continue to operate even after being `Remove()`d. 
This typically occurs in scenarios such as the following:

```golang
db, _ := gorm.Open(nil, nil)
rawCallback := db.Callback().Raw()

rawCallback.Before("*").Register("cb1", func(*gorm.DB) { panic("Remove does not work") })
rawCallback.Remove("cb1")

db.Exec("SELECT 1") // panic
```

#### workaround

For your reference, using `Before("*").Remove()` can be mentioned as a workaround for the above issue.