### PR TITLE
Automigration fails for existing table if model has a boolean field.

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -455,7 +455,7 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 
 	var (
 		alterColumn bool
-		isSameType  = fullDataType == realDataType
+		isSameType  = strings.HasPrefix(fullDataType, realDataType)
 	)
 
 	if !field.PrimaryKey {

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -456,10 +456,10 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 
 	var (
 		alterColumn bool
-		isSameType  = strings.HasPrefix(fullDataType, realDataType)
+		isSameType  = fullDataType == realDataType
 	)
 
-	if !field.PrimaryKey {
+	if !isSameType && !field.PrimaryKey {
 		// check type
 		if !strings.HasPrefix(fullDataType, realDataType) {
 			// check type aliases
@@ -474,6 +474,8 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 			if !isSameType {
 				alterColumn = true
 			}
+		} else {
+			isSameType = true
 		}
 	}
 


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [X] Tested: project's unit tests and on connection to real Cockroach DB.

### What did this pull request do?

The PR fixes how the MigrateColumn() method calculates an initial value of the isSameType flag.

### User Case Description
Environment: 
Go 1.21
DB: Cockroach DB ()
used versions

	github.com/jackc/pgx/v5 v5.5.5
	gorm.io/driver/postgres v1.5.7
	gorm.io/gorm v1.25.8


#### Issue reproduction:

If you have a model that contains a boolean field, e.g.

	Model struct {
	  Id int
	  TestBool bool
	}

And call 

	gorm.AutoMigrate(&Model{})

then
If the table does not exist in a DB yet - then the auto-migration logic just creates it and it works fine,
BUT
If the table exists in a DB: the auto-migration logic analyzes new vs. existing column configurations. And in this case, it crashes if the model contains boolean fields. Here is except the trace


panic({0xc44060?, 0x1432f00?})

	/usr/local/go/src/runtime/panic.go:914 +0x21f

database/sql.(*ColumnType).DecimalSize(...)

	/usr/local/go/src/database/sql/sql.go:3175

gorm.io/gorm/migrator.ColumnType.DecimalSize(...)

	/home/sio/go/pkg/mod/gorm.io/gorm@v1.25.8/migrator/column_type.go:75

gorm.io/gorm/migrator.Migrator.MigrateColumn({{0x40?, 0xc000328330?, {0xe8e948?, 0xc0002bc900?}}}, {0xd1ea00, 0xc00039c050}, 0xc0004663c0, {0xe8fc88, 0xc0002e72b0})

	/home/sio/go/pkg/mod/gorm.io/gorm@v1.25.8/migrator/migrator.go:497 +0x402

gorm.io/driver/postgres.Migrator.MigrateColumn({{{0xa0?, 0xc000328330?, {0xe8e948?, 0xc0002bc900?}}}}, {0xd1ea00, 0xc00039c050}, 0xc0004663c0, {0xe8fc88?, 0xc0002e72b0?})

	/home/sio/go/pkg/mod/gorm.io/driver/postgres@v1.5.7/migrator.go:268 +0x89

gorm.io/gorm/migrator.Migrator.AutoMigrate.func1(0xc00046e8c0)

	/home/sio/go/pkg/mod/gorm.io/gorm@v1.25.8/migrator/migrator.go:156 +0x231

gorm.io/gorm/migrator.Migrator.RunWithValue({{0x20?, 0xc000290750?, {0xe8e948?, 0xc0002bc900?}}}, {0xd1ea00?, 0xc00039c050}, 0xc0002afb70)

	/home/sio/go/pkg/mod/gorm.io/gorm@v1.25.8/migrator/migrator.go:74 +0x137

gorm.io/gorm/migrator.Migrator.AutoMigrate({{0x0?, 0xc000290750?, {0xe8e948?, 0xc0002bc900?}}}, {0xc0002b4300?, 0x0?, 0x0?})

	/home/sio/go/pkg/mod/gorm.io/gorm@v1.25.8/migrator/migrator.go:129 +0x1be

gorm.io/gorm.(*DB).AutoMigrate(0xc000328cf0?, {0xc0002b4300, 0x1, 0x1})

	/home/sio/go/pkg/mod/gorm.io/gorm@v1.25.8/migrator.go:24 +0x42
