### PR TITLE
Masking the output of sensitive information in logs.

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -325,6 +325,14 @@ func (db *DB) Debug() (tx *DB) {
 	})
 }
 
+// Silent start silent mode
+func (db *DB) Silent() (tx *DB) {
+	tx = db.getInstance()
+	return tx.Session(&Session{
+		Logger: db.Logger.LogMode(logger.Silent),
+	})
+}
+
 // Set store value with key into current db instance's context
 func (db *DB) Set(key string, value interface{}) *DB {
 	tx := db.getInstance()


### PR DESCRIPTION
### What did this pull request do?
Masking the output of sensitive information in logs.

When opening a database, the default is to output SQL logs. However, for certain SQL statements that involve sensitive information, it is not desired to have them written into the logs.
