### PR TITLE
fix: `unsupported data` on nested joins with preloads

### DIFF
--- a/callbacks/preload.go
+++ b/callbacks/preload.go
@@ -130,7 +130,7 @@ func preloadEntryPoint(db *gorm.DB, joins []string, relationships *schema.Relati
 							return err
 						}
 					}
-				case reflect.Struct:
+				case reflect.Struct, reflect.Pointer:
 					reflectValue := rel.Field.ReflectValueOf(db.Statement.Context, rv)
 					tx := preloadDB(db, reflectValue, reflectValue.Interface())
 					if err := preloadEntryPoint(tx, nestedJoins, &tx.Statement.Schema.Relationships, preloadMap[name], associationsConds); err != nil {

--- a/tests/preload_test.go
+++ b/tests/preload_test.go
@@ -485,7 +485,7 @@ func TestNestedPreloadWithPointerJoin(t *testing.T) {
 	}
 
 	var find1 Value
-	err := DB.Table("Values").Joins("Nested").Joins("Nested.Join").Preload("Nested.Join.Preload").First(&find1).Error
+	err := DB.Table("values").Joins("Nested").Joins("Nested.Join").Preload("Nested.Join.Preload").First(&find1).Error
 	if err != nil {
 		t.Errorf("failed to find value, got err: %v", err)
 	}

--- a/tests/preload_test.go
+++ b/tests/preload_test.go
@@ -374,6 +374,58 @@ func TestNestedPreloadWithNestedJoin(t *testing.T) {
 	AssertEqual(t, finds[0], value)
 }
 
+func TestNestedPreloadWithPointerJoin(t *testing.T) {
+	type (
+		Preload struct {
+			ID     uint
+			Value  string
+			JoinID uint
+		}
+		Join struct {
+			ID       uint
+			Value    string
+			Preload  Preload
+			NestedID uint
+		}
+		Nested struct {
+			ID      uint
+			Join    Join
+			ValueID uint
+		}
+		Value struct {
+			ID     uint
+			Name   string
+			Nested *Nested
+		}
+	)
+
+	DB.Migrator().DropTable(&Preload{}, &Join{}, &Nested{}, &Value{})
+	DB.Migrator().AutoMigrate(&Preload{}, &Join{}, &Nested{}, &Value{})
+
+	value := Value{
+		Name: "value",
+		Nested: &Nested{
+			Join: Join{
+				Value: "j1",
+				Preload: Preload{
+					Value: "p1",
+				},
+			},
+		},
+	}
+
+	if err := DB.Create(&value).Error; err != nil {
+		t.Errorf("failed to create value, got err: %v", err)
+	}
+
+	var find1 Value
+	err := DB.Table("Values").Joins("Nested").Joins("Nested.Join").Preload("Nested.Join.Preload").First(&find1).Error
+	if err != nil {
+		t.Errorf("failed to find value, got err: %v", err)
+	}
+	AssertEqual(t, find1, value)
+}
+
 func TestEmbedPreload(t *testing.T) {
 	type Country struct {
 		ID   int `gorm:"primaryKey"`


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR fixes issue #6956.

It adds `reflect.Pointer` as an valid reflect target for preloads.
This seems to be required for preloads of nested optional joins with preload targets.

I am not 100% sure of the broader implications of this change. But the implementation before #6877 also allowed this usecase.

### User Case Description

We have complex queries with nested joins and preloads that worked on version 1.25.5 but do not work with the current version.
