### PR TITLE
feat: keep result as nil when record not found & dest is nil

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -115,7 +115,8 @@ func (p *processor) Execute(db *DB) *DB {
 	if stmt.Dest != nil {
 		stmt.ReflectValue = reflect.ValueOf(stmt.Dest)
 		for stmt.ReflectValue.Kind() == reflect.Ptr {
-			if stmt.ReflectValue.IsNil() && stmt.ReflectValue.CanAddr() {
+			stmt.DestIsNil = stmt.ReflectValue.IsNil()
+			if stmt.DestIsNil && stmt.ReflectValue.CanAddr() {
 				stmt.ReflectValue.Set(reflect.New(stmt.ReflectValue.Type().Elem()))
 			}
 

--- a/gorm.go
+++ b/gorm.go
@@ -50,8 +50,6 @@ type Config struct {
 	CreateBatchSize int
 	// TranslateError enabling error translation
 	TranslateError bool
-	// NotFoundAsError set result is nil when no record found and result is ptr
-	NotFoundAsNilWhenPtr bool
 
 	// ClauseBuilders clause builder
 	ClauseBuilders map[string]clause.ClauseBuilder

--- a/gorm.go
+++ b/gorm.go
@@ -50,6 +50,8 @@ type Config struct {
 	CreateBatchSize int
 	// TranslateError enabling error translation
 	TranslateError bool
+	// NotFoundAsError set result is nil when no record found and result is ptr
+	NotFoundAsNilWhenPtr bool
 
 	// ClauseBuilders clause builder
 	ClauseBuilders map[string]clause.ClauseBuilder

--- a/scan.go
+++ b/scan.go
@@ -342,7 +342,7 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 
 	if db.RowsAffected == 0 && db.Statement.RaiseErrorOnNotFound && db.Error == nil {
 		db.AddError(ErrRecordNotFound)
-		if db.NotFoundAsNilWhenPtr && db.Statement.Dest != nil && reflect.ValueOf(db.Statement.Dest).Kind() == reflect.Ptr {
+		if db.Statement.DestIsNil {
 			// reset dest to nil
 			reflect.ValueOf(db.Statement.Dest).Elem().Set(reflect.Zero(reflect.ValueOf(db.Statement.Dest).Elem().Type()))
 		}

--- a/scan.go
+++ b/scan.go
@@ -342,5 +342,9 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 
 	if db.RowsAffected == 0 && db.Statement.RaiseErrorOnNotFound && db.Error == nil {
 		db.AddError(ErrRecordNotFound)
+		if db.NotFoundAsNilWhenPtr && db.Statement.Dest != nil && reflect.ValueOf(db.Statement.Dest).Kind() == reflect.Ptr {
+			// reset dest to nil
+			reflect.ValueOf(db.Statement.Dest).Elem().Set(reflect.Zero(reflect.ValueOf(db.Statement.Dest).Elem().Type()))
+		}
 	}
 }

--- a/statement.go
+++ b/statement.go
@@ -26,6 +26,7 @@ type Statement struct {
 	Model                interface{}
 	Unscoped             bool
 	Dest                 interface{}
+	DestIsNil            bool
 	ReflectValue         reflect.Value
 	Clauses              map[string]clause.Clause
 	BuildClauses         []string

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -206,7 +206,7 @@ func TestFind(t *testing.T) {
 		}
 	})
 
-	t.Run("NotFoundAsNil", func(t *testing.T) {
+	t.Run("KeepResultAsNil", func(t *testing.T) {
 		var first *User
 		if err := DB.Where("name = ?", "find not found").First(&first).Error; err != nil {
 			AssertEqual(t, err, gorm.ErrRecordNotFound)

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -208,13 +208,7 @@ func TestFind(t *testing.T) {
 
 	t.Run("NotFoundAsNil", func(t *testing.T) {
 		var first *User
-		if err := DB.Where("name = ?", "find-not-found").First(&first).Error; err != nil {
-			AssertEqual(t, err, gorm.ErrRecordNotFound)
-			AssertEqual(t, first == nil, false)
-		}
-
-		DB.Config.NotFoundAsNilWhenPtr = true
-		if err := DB.Where("name = ?", "find-not-found").First(&first).Error; err != nil {
+		if err := DB.Where("name = ?", "find not found").First(&first).Error; err != nil {
 			AssertEqual(t, err, gorm.ErrRecordNotFound)
 			AssertEqual(t, first, nil)
 		}

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -206,6 +206,20 @@ func TestFind(t *testing.T) {
 		}
 	})
 
+	t.Run("NotFoundAsNil", func(t *testing.T) {
+		var first *User
+		if err := DB.Where("name = ?", "find-not-found").First(&first).Error; err != nil {
+			AssertEqual(t, err, gorm.ErrRecordNotFound)
+			AssertEqual(t, first == nil, false)
+		}
+
+		DB.Config.NotFoundAsNilWhenPtr = true
+		if err := DB.Where("name = ?", "find-not-found").First(&first).Error; err != nil {
+			AssertEqual(t, err, gorm.ErrRecordNotFound)
+			AssertEqual(t, first, nil)
+		}
+	})
+
 	var models []User
 	if err := DB.Where("name in (?)", []string{"find"}).Find(&models).Error; err != nil || len(models) != 3 {
 		t.Errorf("errors happened when query find with in clause: %v, length: %v", err, len(models))


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [✔️ ] Do only one thing
- [ ] Non breaking API changes
- [✔️ ] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
当前版本的实现，在下面的代码里面，app 经过了 orm 之后从原本的值 nil 变成了一个非 nil 的结果（当没有查询到数据时）
```
func GetByName(name string) (*model.App, error) {
	var app *model.App
	err := db.Where(`name = ?`, name).First(&app).Error
	return app, err
}
```
当下面的函数进行调用时，我们需要判断是否有数据，仅仅判定不为 nil 是不可行的, 通常又不太想直接写 是否为gorm.ErrRecordNotFound，因为这个 model 数据很有可能传递给了另外一个函数，没有上下文的情况下只能进行 nil 的判定
```
app, err := store.App.GetByName(name)
if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
       return
}
if app != nil && app.ID != 0 {
     // do something
}
```

<!-- Your use case -->
