### PR TITLE
Fix:  default string primary keys

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -299,6 +299,14 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 				field.HasDefaultValue = true
 				field.AutoIncrement = true
 			}
+		case String:
+			if _, ok := field.TagSettings["PRIMARYKEY"]; !ok {
+				if !field.HasDefaultValue || field.DefaultValueInterface != nil {
+					schema.FieldsWithDefaultDBValue = append(schema.FieldsWithDefaultDBValue, field)
+				}
+
+				field.HasDefaultValue = true
+			}
 		}
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -300,13 +300,11 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 				field.AutoIncrement = true
 			}
 		case String:
-			if _, ok := field.TagSettings["PRIMARYKEY"]; !ok {
-				if !field.HasDefaultValue || field.DefaultValueInterface != nil {
-					schema.FieldsWithDefaultDBValue = append(schema.FieldsWithDefaultDBValue, field)
-				}
-
-				field.HasDefaultValue = true
+			if !field.HasDefaultValue || field.DefaultValueInterface != nil {
+				schema.FieldsWithDefaultDBValue = append(schema.FieldsWithDefaultDBValue, field)
 			}
+
+			field.HasDefaultValue = true
 		}
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -300,11 +300,13 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 				field.AutoIncrement = true
 			}
 		case String:
-			if !field.HasDefaultValue || field.DefaultValueInterface != nil {
-				schema.FieldsWithDefaultDBValue = append(schema.FieldsWithDefaultDBValue, field)
-			}
+			if _, ok := field.TagSettings["PRIMARYKEY"]; !ok {
+				if !field.HasDefaultValue || field.DefaultValueInterface != nil {
+					schema.FieldsWithDefaultDBValue = append(schema.FieldsWithDefaultDBValue, field)
+				}
 
-			field.HasDefaultValue = true
+				field.HasDefaultValue = true
+			}
 		}
 	}
 

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -341,11 +341,6 @@ func TestStringPrimaryKeyDefault(t *testing.T) {
 		Code string
 		Name string
 	}
-	type ProductWithNamedPrimaryKey struct {
-		ProductID string `gorm:"primaryKey"`
-		Code      string
-		Name      string
-	}
 
 	product, err := schema.Parse(&Product{}, &sync.Map{}, schema.NamingStrategy{})
 	if err != nil {
@@ -361,21 +356,5 @@ func TestStringPrimaryKeyDefault(t *testing.T) {
 	}
 	if !isInDefault {
 		t.Errorf("ID should be fields with default")
-	}
-
-	productWithNamedPrimaryKey, err := schema.Parse(&ProductWithNamedPrimaryKey{}, &sync.Map{}, schema.NamingStrategy{})
-	if err != nil {
-		t.Fatalf("failed to parse product struct with composite primary key, got error %v", err)
-	}
-
-	isInDefault = false
-	for _, field := range productWithNamedPrimaryKey.FieldsWithDefaultDBValue {
-		if field.Name == "ProductID" {
-			isInDefault = true
-			break
-		}
-	}
-	if !isInDefault {
-		t.Errorf("ProductID should be fields with default")
 	}
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -334,3 +334,48 @@ func TestCompositePrimaryKeyWithAutoIncrement(t *testing.T) {
 		t.Fatalf("PrioritizedPrimaryField of non autoincrement composite key should be nil")
 	}
 }
+
+func TestStringPrimaryKeyDefault(t *testing.T) {
+	type Product struct {
+		ID   string
+		Code string
+		Name string
+	}
+	type ProductWithNamedPrimaryKey struct {
+		ProductID string `gorm:"primaryKey"`
+		Code      string
+		Name      string
+	}
+
+	product, err := schema.Parse(&Product{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("failed to parse product struct with composite primary key, got error %v", err)
+	}
+
+	isInDefault := false
+	for _, field := range product.FieldsWithDefaultDBValue {
+		if field.Name == "ID" {
+			isInDefault = true
+			break
+		}
+	}
+	if !isInDefault {
+		t.Errorf("ID should be fields with default")
+	}
+
+	productWithNamedPrimaryKey, err := schema.Parse(&ProductWithNamedPrimaryKey{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("failed to parse product struct with composite primary key, got error %v", err)
+	}
+
+	isInDefault = false
+	for _, field := range productWithNamedPrimaryKey.FieldsWithDefaultDBValue {
+		if field.Name == "ProductID" {
+			isInDefault = true
+			break
+		}
+	}
+	if !isInDefault {
+		t.Errorf("ProductID should be fields with default")
+	}
+}

--- a/tests/primary_key_uuid_test.go
+++ b/tests/primary_key_uuid_test.go
@@ -14,11 +14,6 @@ func TestStringPrimaryKeyDefault(t *testing.T) {
 		Code string
 		Name string
 	}
-	type ProductWithNamedPrimaryKey struct {
-		ProductID uuid.UUID `gorm:"primaryKey"`
-		Code      string
-		Name      string
-	}
 
 	product, err := schema.Parse(&Product{}, &sync.Map{}, schema.NamingStrategy{})
 	if err != nil {
@@ -34,21 +29,5 @@ func TestStringPrimaryKeyDefault(t *testing.T) {
 	}
 	if !isInDefault {
 		t.Errorf("ID should be fields with default")
-	}
-
-	productWithNamedPrimaryKey, err := schema.Parse(&ProductWithNamedPrimaryKey{}, &sync.Map{}, schema.NamingStrategy{})
-	if err != nil {
-		t.Fatalf("failed to parse product struct with composite primary key, got error %v", err)
-	}
-
-	isInDefault = false
-	for _, field := range productWithNamedPrimaryKey.FieldsWithDefaultDBValue {
-		if field.Name == "ProductID" {
-			isInDefault = true
-			break
-		}
-	}
-	if !isInDefault {
-		t.Errorf("ProductID should be fields with default")
 	}
 }

--- a/tests/primary_key_uuid_test.go
+++ b/tests/primary_key_uuid_test.go
@@ -1,0 +1,54 @@
+package tests_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm/schema"
+)
+
+func TestStringPrimaryKeyDefault(t *testing.T) {
+	type Product struct {
+		ID   uuid.UUID
+		Code string
+		Name string
+	}
+	type ProductWithNamedPrimaryKey struct {
+		ProductID uuid.UUID `gorm:"primaryKey"`
+		Code      string
+		Name      string
+	}
+
+	product, err := schema.Parse(&Product{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("failed to parse product struct with composite primary key, got error %v", err)
+	}
+
+	isInDefault := false
+	for _, field := range product.FieldsWithDefaultDBValue {
+		if field.Name == "ID" {
+			isInDefault = true
+			break
+		}
+	}
+	if !isInDefault {
+		t.Errorf("ID should be fields with default")
+	}
+
+	productWithNamedPrimaryKey, err := schema.Parse(&ProductWithNamedPrimaryKey{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("failed to parse product struct with composite primary key, got error %v", err)
+	}
+
+	isInDefault = false
+	for _, field := range productWithNamedPrimaryKey.FieldsWithDefaultDBValue {
+		if field.Name == "ProductID" {
+			isInDefault = true
+			break
+		}
+	}
+	if !isInDefault {
+		t.Errorf("ProductID should be fields with default")
+	}
+}

--- a/tests/upsert_test.go
+++ b/tests/upsert_test.go
@@ -62,7 +62,7 @@ func TestUpsert(t *testing.T) {
 		}
 
 		r := DB.Session(&gorm.Session{DryRun: true}).Clauses(clause.OnConflict{UpdateAll: true}).Create(&RestrictedLanguage{Code: "upsert_code", Name: "upsert_name", Lang: "upsert_lang"})
-		if !regexp.MustCompile(`INTO .restricted_languages. .*\(.code.,.name.,.lang.,\) .* (SET|UPDATE) .name.=.*.name.\W*$`).MatchString(r.Statement.SQL.String()) {
+		if !regexp.MustCompile(`INTO .restricted_languages. .*\(.code.,.name.,.lang.\) .* (SET|UPDATE) .name.=.*.name.\W*$`).MatchString(r.Statement.SQL.String()) {
 			t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 		}
 	}

--- a/tests/upsert_test.go
+++ b/tests/upsert_test.go
@@ -1,7 +1,6 @@
 package tests_test
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -63,7 +62,6 @@ func TestUpsert(t *testing.T) {
 		}
 
 		r := DB.Session(&gorm.Session{DryRun: true}).Clauses(clause.OnConflict{UpdateAll: true}).Create(&RestrictedLanguage{Code: "upsert_code", Name: "upsert_name", Lang: "upsert_lang"})
-		fmt.Println(r.Statement.SQL.String())
 		if !regexp.MustCompile(`INTO .restricted_languages. .*\(.name.,.lang.,.code.\) .* (SET|UPDATE) .name.=.*.name. RETURNING .code.\W*$`).MatchString(r.Statement.SQL.String()) {
 			t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 		}

--- a/tests/upsert_test.go
+++ b/tests/upsert_test.go
@@ -62,7 +62,7 @@ func TestUpsert(t *testing.T) {
 		}
 
 		r := DB.Session(&gorm.Session{DryRun: true}).Clauses(clause.OnConflict{UpdateAll: true}).Create(&RestrictedLanguage{Code: "upsert_code", Name: "upsert_name", Lang: "upsert_lang"})
-		if !regexp.MustCompile(`INTO .restricted_languages. .*\(.name.,.lang.,.code.\) .* (SET|UPDATE) .name.=.*.name. RETURNING .code.\W*$`).MatchString(r.Statement.SQL.String()) {
+		if !regexp.MustCompile(`INTO .restricted_languages. .*\(.code.,.name.,.lang.,\) .* (SET|UPDATE) .name.=.*.name.\W*$`).MatchString(r.Statement.SQL.String()) {
 			t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 		}
 	}

--- a/tests/upsert_test.go
+++ b/tests/upsert_test.go
@@ -1,6 +1,7 @@
 package tests_test
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -62,7 +63,8 @@ func TestUpsert(t *testing.T) {
 		}
 
 		r := DB.Session(&gorm.Session{DryRun: true}).Clauses(clause.OnConflict{UpdateAll: true}).Create(&RestrictedLanguage{Code: "upsert_code", Name: "upsert_name", Lang: "upsert_lang"})
-		if !regexp.MustCompile(`INTO .restricted_languages. .*\(.code.,.name.,.lang.\) .* (SET|UPDATE) .name.=.*.name.\W*$`).MatchString(r.Statement.SQL.String()) {
+		fmt.Println(r.Statement.SQL.String())
+		if !regexp.MustCompile(`INTO .restricted_languages. .*\(.name.,.lang.,.code.\) .* (SET|UPDATE) .name.=.*.name. RETURNING .code.\W*$`).MatchString(r.Statement.SQL.String()) {
 			t.Errorf("Table with escape character, got %v", r.Statement.SQL.String())
 		}
 	}


### PR DESCRIPTION
# Default string primary keys

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
#### Issue https://github.com/go-gorm/gorm/issues/6192

About a year ago there was a [commit](https://github.com/go-gorm/gorm/commit/d834dd60b715422dc2a900fb2744f9c278a9830f#diff-eafe62eae191e88faad4c223c4de9af268c175ee68695872e175b814d7c5baa5) "removing unnecessary code".

This change did not remove unnecessary code, but broke inserting into table that use strings as primary keys.

Now instead of relying in the default of the database it would insert a zero value instead, storing empty strings for varchars/text, storing 00000000-0000-0000-0000-000000000000 for UUIDs, etc.

### User Case Description

Take the following model

```go
type User struct {
  ID uuid.UUID
  Name string
}
```
With a table of the following shape
```sql
CREATE TABLE "users" (
    "id" UUID DEFAULT gen_random_uuid() PRIMARY KEY,
    "name" VARCHAR NOT NULL
);
```
If you tried to do 
```go
user :=  User{Name: "Martin Munilla"}
db.Save(user)
```
You would get the following sql executed
```sql
INSERT INTO "users" ("id", "name") VALUES ('00000000-0000-0000-0000-000000000000', 'Martin Munilla')
```
Instead of
```sql
INSERT INTO "users" ("name") VALUES ('Martin Munilla')
```
Thus not allowing the database to execute the default clause
