### PR TITLE
fix: int type field size should is int32

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -328,13 +328,13 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 
 	if field.Size == 0 {
 		switch reflect.Indirect(fieldValue).Kind() {
-		case reflect.Int, reflect.Int64, reflect.Uint, reflect.Uint64, reflect.Float64:
+		case reflect.Int64, reflect.Uint64, reflect.Float64:
 			field.Size = 64
 		case reflect.Int8, reflect.Uint8:
 			field.Size = 8
 		case reflect.Int16, reflect.Uint16:
 			field.Size = 16
-		case reflect.Int32, reflect.Uint32, reflect.Float32:
+		case reflect.Int, reflect.Uint, reflect.Int32, reflect.Uint32, reflect.Float32:
 			field.Size = 32
 		}
 	}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
go type int,uint field size should is 32

### User Case Description
int type size is 32 in go . but field is 64.

