### PR TITLE
Faster utils.FileWithLineNum

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -33,8 +33,8 @@ func sourceDir(file string) string {
 // FileWithLineNum return the file name and line number of the current file
 func FileWithLineNum() string {
 	pcs := [13]uintptr{}
-	// the second caller usually from gorm internal, so start from 2
-	len := runtime.Callers(2, pcs[:])
+	// the third caller usually from gorm internal
+	len := runtime.Callers(3, pcs[:])
 	frames := runtime.CallersFrames(pcs[:len])
 	for i := 0; i < len; i++ {
 		// second return value is "more", not "ok"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -32,12 +32,16 @@ func sourceDir(file string) string {
 
 // FileWithLineNum return the file name and line number of the current file
 func FileWithLineNum() string {
-	// the second caller usually from gorm internal, so set i start from 2
-	for i := 2; i < 15; i++ {
-		_, file, line, ok := runtime.Caller(i)
-		if ok && (!strings.HasPrefix(file, gormSourceDir) || strings.HasSuffix(file, "_test.go")) &&
-			!strings.HasSuffix(file, ".gen.go") {
-			return file + ":" + strconv.FormatInt(int64(line), 10)
+	pcs := [13]uintptr{}
+	// the second caller usually from gorm internal, so start from 2
+	len := runtime.Callers(2, pcs[:])
+	frames := runtime.CallersFrames(pcs[:len])
+	for i := 0; i < len; i++ {
+		// second return value is "more", not "ok"
+		frame, _ := frames.Next()
+		if (!strings.HasPrefix(frame.File, gormSourceDir) ||
+			strings.HasSuffix(frame.File, "_test.go")) && !strings.HasSuffix(frame.File, ".gen.go") {
+			return string(strconv.AppendInt(append([]byte(frame.File), ':'), int64(frame.Line), 10))
 		}
 	}
 


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested (may be untestable for ci)

### What did this pull request do?

Faster `utils.FileWithLineNum`. Avoid call `runtime.Caller` multi times.

Trace log performace gained a little.