### PR TITLE
Add new error for "Violation Check Constraint"

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -49,4 +49,6 @@ var (
 	ErrDuplicatedKey = errors.New("duplicated key not allowed")
 	// ErrForeignKeyViolated occurs when there is a foreign key constraint violation
 	ErrForeignKeyViolated = errors.New("violates foreign key constraint")
+	// ErrCheckConstraintViolated occurs when there is a check constraint violation
+	ErrCheckConstraintViolated = errors.New("violates check constraint")
 )


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add new error for "Check Constraint Violation"

### User Case Description

I added a check constraint in my table in PostgreSQL such as: 
`CONSTRAINT path_check CHECK (path ~ '^/[a-zA-Z0-9\-]+$')`

When an error occurs when I try to add a new row to the table, I want to be sure that it is a rule violation error or another type of error.
```go
if errors.Is(result.Error, gorm.ErrCheckConstraintViolated) {
  // handle check constraint violation error
}
```

Pull request for [go-gorm/postgres](https://github.com/go-gorm/postgres): https://github.com/go-gorm/postgres/pull/271