### PR TITLE
fix: strings.Title -> cases.Title bcs strings.Title library is deprecated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.18
 require (
 	github.com/jinzhu/inflection v1.0.0
 	github.com/jinzhu/now v1.1.5
+	golang.org/x/text v0.14.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/schema/naming.go
+++ b/schema/naming.go
@@ -8,6 +8,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/jinzhu/inflection"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Namer namer interface
@@ -121,7 +123,7 @@ var (
 func init() {
 	commonInitialismsForReplacer := make([]string, 0, len(commonInitialisms))
 	for _, initialism := range commonInitialisms {
-		commonInitialismsForReplacer = append(commonInitialismsForReplacer, initialism, strings.Title(strings.ToLower(initialism)))
+		commonInitialismsForReplacer = append(commonInitialismsForReplacer, initialism, cases.Title(language.Und).String(initialism))
 	}
 	commonInitialismsReplacer = strings.NewReplacer(commonInitialismsForReplacer...)
 }
@@ -186,9 +188,9 @@ func (ns NamingStrategy) toDBName(name string) string {
 }
 
 func (ns NamingStrategy) toSchemaName(name string) string {
-	result := strings.ReplaceAll(strings.Title(strings.ReplaceAll(name, "_", " ")), " ", "")
+	result := strings.ReplaceAll(cases.Title(language.Und, cases.NoLower).String(strings.ReplaceAll(name, "_", " ")), " ", "")
 	for _, initialism := range commonInitialisms {
-		result = regexp.MustCompile(strings.Title(strings.ToLower(initialism))+"([A-Z]|$|_)").ReplaceAllString(result, initialism+"$1")
+		result = regexp.MustCompile(cases.Title(language.Und, cases.NoLower).String(strings.ToLower(initialism))+"([A-Z]|$|_)").ReplaceAllString(result, initialism+"$1")
 	}
 	return result
 }

--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jinzhu/inflection"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+
 	"gorm.io/gorm/clause"
 )
 

--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/jinzhu/inflection"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"gorm.io/gorm/clause"
 )
 
@@ -301,9 +303,9 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 	}
 
 	for idx, ownField := range ownForeignFields {
-		joinFieldName := strings.Title(schema.Name) + ownField.Name
+		joinFieldName := cases.Title(language.Und, cases.NoLower).String(schema.Name) + ownField.Name
 		if len(joinForeignKeys) > idx {
-			joinFieldName = strings.Title(joinForeignKeys[idx])
+			joinFieldName = cases.Title(language.Und, cases.NoLower).String(joinForeignKeys[idx])
 		}
 
 		ownFieldsMap[joinFieldName] = ownField
@@ -318,7 +320,7 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 	}
 
 	for idx, relField := range refForeignFields {
-		joinFieldName := strings.Title(relation.FieldSchema.Name) + relField.Name
+		joinFieldName := cases.Title(language.Und, cases.NoLower).String(relation.FieldSchema.Name) + relField.Name
 
 		if _, ok := ownFieldsMap[joinFieldName]; ok {
 			if field.Name != relation.FieldSchema.Name {
@@ -329,7 +331,7 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 		}
 
 		if len(joinReferences) > idx {
-			joinFieldName = strings.Title(joinReferences[idx])
+			joinFieldName = cases.Title(language.Und, cases.NoLower).String(joinReferences[idx])
 		}
 
 		referFieldsMap[joinFieldName] = relField
@@ -347,7 +349,7 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 	}
 
 	joinTableFields = append(joinTableFields, reflect.StructField{
-		Name: strings.Title(schema.Name) + field.Name,
+		Name: cases.Title(language.Und, cases.NoLower).String(schema.Name) + field.Name,
 		Type: schema.ModelType,
 		Tag:  `gorm:"-"`,
 	})


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
change using library strings.Title to cases.Title because of strings. Title is deprecated for Go 1.18
below is a warnings when I run golangci-cli:
```
strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.
``` 

<!--
provide a general description of the code changes in your pull request
-->
I rewrite strings.Title -> cases.Title.
cases.TItle returns a Caser so it needed to parse to string because strings.Title returns string

cases.Title can be taken language, but I don't know which language supports for gorm so I tried to write `language.Und`.
this means you didn't decide which language.

### User Case Description

<!-- Your use case -->
