### PR TITLE
Fix (#7002) Where Condition Build Issue

### DIFF
--- a/clause/where.go
+++ b/clause/where.go
@@ -5,8 +5,10 @@ import (
 )
 
 const (
-	AndWithSpace = " AND "
-	OrWithSpace  = " OR "
+	AndWithSpace       = " AND "
+	OrWithSpace        = " OR "
+	AndSymbolWithSpace = " && "
+	OrSymbolWithSpace  = " || "
 )
 
 // Where where clause
@@ -58,22 +60,26 @@ func buildExprs(exprs []Expression, builder Builder, joinCond string) {
 				if len(v.Exprs) == 1 {
 					if e, ok := v.Exprs[0].(Expr); ok {
 						sql := strings.ToUpper(e.SQL)
-						wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace)
+						wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace) ||
+							strings.Contains(sql, AndSymbolWithSpace) || strings.Contains(sql, OrSymbolWithSpace)
 					}
 				}
 			case AndConditions:
 				if len(v.Exprs) == 1 {
 					if e, ok := v.Exprs[0].(Expr); ok {
 						sql := strings.ToUpper(e.SQL)
-						wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace)
+						wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace) ||
+							strings.Contains(sql, AndSymbolWithSpace) || strings.Contains(sql, OrSymbolWithSpace)
 					}
 				}
 			case Expr:
 				sql := strings.ToUpper(v.SQL)
-				wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace)
+				wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace) ||
+					strings.Contains(sql, AndSymbolWithSpace) || strings.Contains(sql, OrSymbolWithSpace)
 			case NamedExpr:
 				sql := strings.ToUpper(v.SQL)
-				wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace)
+				wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace) ||
+					strings.Contains(sql, AndSymbolWithSpace) || strings.Contains(sql, OrSymbolWithSpace)
 			}
 		}
 

--- a/clause/where.go
+++ b/clause/where.go
@@ -197,7 +197,8 @@ func (not NotConditions) Build(builder Builder) {
 				e, wrapInParentheses := c.(Expr)
 				if wrapInParentheses {
 					sql := strings.ToUpper(e.SQL)
-					if wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace); wrapInParentheses {
+					if wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace) ||
+						strings.Contains(sql, AndSymbolWithSpace) || strings.Contains(sql, OrSymbolWithSpace); wrapInParentheses {
 						builder.WriteByte('(')
 					}
 				}
@@ -232,7 +233,8 @@ func (not NotConditions) Build(builder Builder) {
 			e, wrapInParentheses := c.(Expr)
 			if wrapInParentheses {
 				sql := strings.ToUpper(e.SQL)
-				if wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace); wrapInParentheses {
+				if wrapInParentheses = strings.Contains(sql, AndWithSpace) || strings.Contains(sql, OrWithSpace) ||
+					strings.Contains(sql, AndSymbolWithSpace) || strings.Contains(sql, OrSymbolWithSpace); wrapInParentheses {
 					builder.WriteByte('(')
 				}
 			}

--- a/clause/where_test.go
+++ b/clause/where_test.go
@@ -152,6 +152,28 @@ func TestWhere(t *testing.T) {
 			"SELECT * FROM `users` WHERE (`score` <= ? || `score` > ?) AND `score` > ?",
 			[]interface{}{100, 20, 0},
 		},
+		{
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Where{
+				Exprs: []clause.Expression{clause.Not(
+					clause.Expr{SQL: "`score` <= ? || `score` > ?",
+						Vars: []interface{}{100, 20}},
+				)},
+			}},
+			"SELECT * FROM `users` WHERE NOT (`score` <= ? || `score` > ?)",
+			[]interface{}{100, 20},
+		},
+		{
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Where{
+				Exprs: []clause.Expression{clause.Not(
+					clause.Expr{SQL: "`score` <= ? || `score` > ?",
+						Vars: []interface{}{100, 20}},
+					clause.Expr{SQL: "`score` > ?",
+						Vars: []interface{}{0}},
+				)},
+			}},
+			"SELECT * FROM `users` WHERE NOT ((`score` <= ? || `score` > ?) AND `score` > ?)",
+			[]interface{}{100, 20, 0},
+		},
 	}
 
 	for idx, result := range results {

--- a/clause/where_test.go
+++ b/clause/where_test.go
@@ -129,6 +129,29 @@ func TestWhere(t *testing.T) {
 			"SELECT * FROM `users` WHERE NOT ((`users`.`id` = ? AND `age` > ?) OR `score` < ?)",
 			[]interface{}{"1", 18, 100},
 		},
+		{
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Where{
+				Exprs: []clause.Expression{clause.Expr{
+					SQL:  "`score` <= ? || `score` > ?",
+					Vars: []interface{}{100, 20},
+				}},
+			}},
+			"SELECT * FROM `users` WHERE `score` <= ? || `score` > ?",
+			[]interface{}{100, 20},
+		},
+		{
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Where{
+				Exprs: []clause.Expression{clause.Expr{
+					SQL:  "`score` <= ? || `score` > ?",
+					Vars: []interface{}{100, 20},
+				}, clause.Expr{
+					SQL:  "`score` > ?",
+					Vars: []interface{}{0},
+				}},
+			}},
+			"SELECT * FROM `users` WHERE (`score` <= ? || `score` > ?) AND `score` > ?",
+			[]interface{}{100, 20, 0},
+		},
 	}
 
 	for idx, result := range results {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Add brackets wrap when sql expression contains `||`
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
* single `Expr` without brackets wrapped.(follow previous rules)
* multiple `Expr` and contains `||` will brackets wrapped.(new feature)

<!-- Your use case -->

### Playground Link
https://github.com/go-gorm/playground/pull/728

### Issue Link
https://github.com/go-gorm/gorm/issues/7002
