### PR TITLE
add DB level propagation for the Unscoped flag

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -50,6 +50,8 @@ type Config struct {
 	CreateBatchSize int
 	// TranslateError enabling error translation
 	TranslateError bool
+	// PropagateUnscoped propagate Unscoped to every other nested statement
+	PropagateUnscoped bool
 
 	// ClauseBuilders clause builder
 	ClauseBuilders map[string]clause.ClauseBuilder
@@ -408,6 +410,9 @@ func (db *DB) getInstance() *DB {
 				Clauses:   map[string]clause.Clause{},
 				Vars:      make([]interface{}, 0, 8),
 				SkipHooks: db.Statement.SkipHooks,
+			}
+			if db.Config.PropagateUnscoped {
+				tx.Statement.Unscoped = db.Statement.Unscoped
 			}
 		} else {
 			// with clone statement

--- a/gorm.go
+++ b/gorm.go
@@ -112,6 +112,7 @@ type Session struct {
 	DisableNestedTransaction bool
 	AllowGlobalUpdate        bool
 	FullSaveAssociations     bool
+	PropagateUnscoped        bool
 	QueryFields              bool
 	Context                  context.Context
 	Logger                   logger.Interface
@@ -241,6 +242,10 @@ func (db *DB) Session(config *Session) *DB {
 
 	if config.FullSaveAssociations {
 		txConfig.FullSaveAssociations = true
+	}
+
+	if config.PropagateUnscoped {
+		txConfig.PropagateUnscoped = true
 	}
 
 	if config.Context != nil || config.PrepareStmt || config.SkipHooks {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR adds `PropagateUnscoped` to `DB`'s `Config`. Its purpose is to allow propagation of the parent `Statement`'s `Unscoped` flag to nested statements. 

#### Should this become the default behavior?

Is there any scenario where `getInstance()` where we don't want this flag to propagate? For the record, all tests pass if we just persist the `Unscoped` state when `clone == 1`. 

I just didn't want to introduce what may be a breaking change in more complex production environments for which gorm's tests don't offer coverage therefore this is a disabled by default flag.

Regardless, this kind of change should not be introduced without a flag to panic control it.

### User Case Description

When one wants to create advanced hooks which leverage not just the usual Before/After but also `StatementModifier` hooks while reusing the `Unscoped` state of the parent statement, it can be expected that the flag propagates to all child hooks.

One can, and that's what we find ourselves doing more often than not, is to store the original tx/stmt's `Unscoped` state and adding repeated extra lines of code where one wants to keep the state after a nested `Delete` or `Model` calls done inside hooks - arguably, in every possibly nested hook.

Since for some, or even all, use cases, one just wants to have `Unscoped` propagated to all nested statements, this is a way cleaner and non intrusive solution to address such challenge.