### PR TITLE
Add public BuildCondition method for associations

### DIFF
--- a/association.go
+++ b/association.go
@@ -41,6 +41,16 @@ func (db *DB) Association(column string) *Association {
 	return association
 }
 
+func (association *Association) BuildCondition() *DB {
+	if association.Error != nil {
+		tx := association.DB
+		tx.Error = association.Error
+		return tx
+	}
+
+	return association.buildCondition()
+}
+
 func (association *Association) Unscoped() *Association {
 	return &Association{
 		DB:           association.DB,


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR proposes to add a public variant of the `buildCondition()` method, as it would allow dynamic query creation, for cases when the user would like do additional filtering, ordering or limiting before calling `Find()` or `Count()` on the transaction statement.

### User Case Description

I'm creating a connector between GORM and GraphQL, where associated fields on a model are returned as the result of a pagination function, which allows the user to apply ORDER, LIMIT and WHERE conditions before returning a page of associated records.

As the association struct does not allow for setting these before calling the `Find()` and `Count()` methods, having access to this private `buildCondition()` method is the next best way to be able to construct this query.
