### PR TITLE
Fix association replace non-addressable panic

### DIFF
--- a/association.go
+++ b/association.go
@@ -384,11 +384,6 @@ func (association *Association) saveAssociation(clear bool, values ...interface{
 	)
 
 	appendToRelations := func(source, rv reflect.Value, clear bool) {
-		if !rv.CanAddr() {
-			association.Error = ErrInvalidValue
-			return
-		}
-
 		switch association.Relationship.Type {
 		case schema.HasOne, schema.BelongsTo:
 			switch rv.Kind() {
@@ -401,6 +396,10 @@ func (association *Association) saveAssociation(clear bool, values ...interface{
 					}
 				}
 			case reflect.Struct:
+				if !rv.CanAddr() {
+					association.Error = ErrInvalidValue
+					return
+				}
 				association.Error = association.Relationship.Field.Set(association.DB.Statement.Context, source, rv.Addr().Interface())
 
 				if association.Relationship.Field.FieldType.Kind() == reflect.Struct {
@@ -438,6 +437,10 @@ func (association *Association) saveAssociation(clear bool, values ...interface{
 					appendToFieldValues(reflect.Indirect(rv.Index(i)).Addr())
 				}
 			case reflect.Struct:
+				if !rv.CanAddr() {
+					association.Error = ErrInvalidValue
+					return
+				}
 				appendToFieldValues(rv.Addr())
 			}
 

--- a/tests/associations_has_many_test.go
+++ b/tests/associations_has_many_test.go
@@ -554,3 +554,15 @@ func TestHasManyAssociationUnscoped(t *testing.T) {
 		t.Errorf("expected %d contents, got %d", 0, len(contents))
 	}
 }
+
+func TestHasManyAssociationReplaceWithNonValidValue(t *testing.T) {
+	user := User{Name: "jinzhu", Languages: []Language{{Name: "EN"}}}
+
+	if err := DB.Create(&user).Error; err != nil {
+		t.Fatalf("errors happened when create: %v", err)
+	}
+
+	if err := DB.Model(&user).Association("Languages").Replace(Language{Name: "DE"}, Language{Name: "FR"}); err == nil {
+		t.Error("expected association error to be not nil")
+	}
+}

--- a/tests/associations_has_one_test.go
+++ b/tests/associations_has_one_test.go
@@ -255,3 +255,15 @@ func TestPolymorphicHasOneAssociationForSlice(t *testing.T) {
 	DB.Model(&pets).Association("Toy").Clear()
 	AssertAssociationCount(t, pets, "Toy", 0, "After Clear")
 }
+
+func TestHasOneAssociationReplaceWithNonValidValue(t *testing.T) {
+	user := User{Name: "jinzhu", Account: Account{Number: "1"}}
+
+	if err := DB.Create(&user).Error; err != nil {
+		t.Fatalf("errors happened when create: %v", err)
+	}
+
+	if err := DB.Model(&user).Association("Languages").Replace(Account{Number: "2"}); err == nil {
+		t.Error("expected association error to be not nil")
+	}
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

While replacing associations using an example from the docs panic occurs.

```
db.Model(&user).Association("Languages").Replace(Language{Name: "DE"}, languageEN)
```
![image](https://github.com/go-gorm/gorm/assets/32732298/94837ec3-d8e1-4cc0-8e34-ffb8e325a786)


This PR fixes this issue by asserting if the value addressable and checking for the association error later.

### User Case Description

Here is the PR for the playground example: https://github.com/go-gorm/playground/pull/734
This is not the obvious case, but the code should not panic in the case but handle the invalid value gracefully
