### PR TITLE
fix: use reflect.Append when preloading nested associations instead of making a slice with fixed size

### DIFF
--- a/callbacks/preload.go
+++ b/callbacks/preload.go
@@ -125,13 +125,15 @@ func preloadEntryPoint(db *gorm.DB, joins []string, relationships *schema.Relati
 				case reflect.Slice, reflect.Array:
 					if rv.Len() > 0 {
 						reflectValue := rel.FieldSchema.MakeSlice().Elem()
-						reflectValue.SetLen(rv.Len())
 						for i := 0; i < rv.Len(); i++ {
 							frv := rel.Field.ReflectValueOf(db.Statement.Context, rv.Index(i))
 							if frv.Kind() != reflect.Ptr {
-								reflectValue.Index(i).Set(frv.Addr())
+								reflectValue = reflect.Append(reflectValue, frv.Addr())
 							} else {
-								reflectValue.Index(i).Set(frv)
+								if frv.IsNil() {
+									continue
+								}
+								reflectValue = reflect.Append(reflectValue, frv)
 							}
 						}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -67,9 +67,10 @@ func (schema Schema) String() string {
 }
 
 func (schema Schema) MakeSlice() reflect.Value {
-	slice := reflect.MakeSlice(reflect.SliceOf(reflect.PtrTo(schema.ModelType)), 0, 20)
+	slice := reflect.MakeSlice(reflect.SliceOf(reflect.PointerTo(schema.ModelType)), 0, 20)
 	results := reflect.New(slice.Type())
 	results.Elem().Set(slice)
+
 	return results
 }
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -11,7 +11,7 @@ require (
 	gorm.io/driver/postgres v1.5.7
 	gorm.io/driver/sqlite v1.5.5
 	gorm.io/driver/sqlserver v1.5.3
-	gorm.io/gorm v1.25.9
+	gorm.io/gorm v1.25.10
 )
 
 require (

--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -1,10 +1,12 @@
 package tests_test
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 	. "gorm.io/gorm/utils/tests"
 )
@@ -399,4 +401,76 @@ func TestNestedJoins(t *testing.T) {
 		}
 		CheckPet(t, *user.Manager.NamedPet, *users2[idx].Manager.NamedPet)
 	}
+}
+
+func TestJoinsPreload_Issue7013(t *testing.T) {
+	manager := &User{Name: "Manager"}
+	DB.Create(manager)
+
+	var userIDs []uint
+	for i := 0; i < 21; i++ {
+		user := &User{Name: fmt.Sprintf("User%d", i), ManagerID: &manager.ID}
+		DB.Create(user)
+		userIDs = append(userIDs, user.ID)
+	}
+
+	var entries []User
+	assert.NotPanics(t, func() {
+		assert.NoError(t,
+			DB.Debug().Preload("Manager.Team").
+				Joins("Manager.Company").
+				Find(&entries).Error)
+	})
+}
+
+func TestJoinsPreload_Issue7013_RelationEmpty(t *testing.T) {
+	type (
+		Furniture struct {
+			gorm.Model
+			OwnerID *uint
+		}
+
+		Owner struct {
+			gorm.Model
+			Furnitures []Furniture
+			CompanyID  *uint
+			Company    Company
+		}
+
+		Building struct {
+			gorm.Model
+			Name    string
+			OwnerID *uint
+			Owner   Owner
+		}
+	)
+
+	DB.Migrator().DropTable(&Building{}, &Owner{}, &Furniture{})
+	DB.Migrator().AutoMigrate(&Building{}, &Owner{}, &Furniture{})
+
+	home := &Building{Name: "relation_empty"}
+	DB.Create(home)
+
+	var entries []Building
+	assert.NotPanics(t, func() {
+		assert.NoError(t,
+			DB.Debug().Preload("Owner.Furnitures").
+				Joins("Owner.Company").
+				Find(&entries).Error)
+	})
+
+	AssertEqual(t, entries, []Building{{Model: home.Model, Name: "relation_empty", Owner: Owner{Company: Company{}}}})
+}
+
+func TestJoinsPreload_Issue7013_NoEntries(t *testing.T) {
+	var entries []User
+	assert.NotPanics(t, func() {
+		assert.NoError(t,
+			DB.Debug().Preload("Manager.Team").
+				Joins("Manager.Company").
+				Where("false").
+				Find(&entries).Error)
+	})
+
+	AssertEqual(t, len(entries), 0)
 }


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

attempt to fix issue https://github.com/go-gorm/gorm/issues/7013

### User Case Description

Joins Preload causes panic for a large (>20) number of items, see the issue.

@a631807682 I've tried this since I guess it's better to have a slice with the proper len and cap (if we know it when making the slice) instead of appending items to it. However I'm not very comfortable with the `preload` func and could not figure out which len and cap values to use for the other `schema.MakeSlice` calls. 

Also, can you tell me where I could add a test case for that? Something that would look like the playground test I guess. maybe `joins_test.go` ?
