### PR TITLE
fix: AfterQuery clear Statement.Joins causes the query to fail

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -100,9 +100,10 @@ func BuildQuerySQL(db *gorm.DB) {
 		fromClause := clause.From{}
 		if v, ok := db.Statement.Clauses["FROM"].Expression.(clause.From); ok {
 			fromClause = v
+			fromClause.Joins = fromClause.Joins[:0]
 		}
 
-		if len(db.Statement.Joins) != 0 || len(fromClause.Joins) != 0 {
+		if len(db.Statement.Joins) != 0 {
 			if len(db.Statement.Selects) == 0 && len(db.Statement.Omits) == 0 && db.Statement.Schema != nil {
 				clauseSelect.Columns = make([]clause.Column, len(db.Statement.Schema.DBNames))
 				for idx, dbName := range db.Statement.Schema.DBNames {
@@ -285,8 +286,6 @@ func Preload(db *gorm.DB) {
 }
 
 func AfterQuery(db *gorm.DB) {
-	// clear the joins after query because preload need it
-	db.Statement.Joins = nil
 	if db.Error == nil && db.Statement.Schema != nil && !db.Statement.SkipHooks && db.Statement.Schema.AfterFind && db.RowsAffected > 0 {
 		callMethod(db, func(value interface{}, tx *gorm.DB) bool {
 			if i, ok := value.(AfterFindInterface); ok {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [√] Do only one thing
- [√] Non breaking API changes
- [√ ] Tested

### What did this pull request do?
fix  https://github.com/go-gorm/gorm/issues/7025

There are two options. The first is to choose to clear the Joins in the fromClause each time and regenerate them for every query, which would be somewhat less performant. The second option involves adding cached fields within the fromClause's Joins, allowing subsequent queries to utilize these caches. In this case, the first option has been selected.
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

```go
type User struct {
	gorm.Model
	Account Account
}

type Account struct {
	gorm.Model
	UserID sql.NullInt64
	Number string

	Companies []Company
	Pet       Pet
}

type Company struct {
	ID        int
	AccountID int32
	Name      string
}

type Pet struct {
	gorm.Model

	AccountID *uint
	Name      string
}

func main() {
	user := User{
		Account:Account{
			Number: "123456",
			Companies: []Company{
				{Name: "Corp1"}, {Name: "Corp2"},
			},
			Pet: Pet{
				Name: "Pet1",
			},
		},
	}
	DB.AutoMigrate(&User{}, &Account{}, &Pet{}, &Company{})
	DB.Create(&user)
	fmt.Println("-------------------------------------------------------")
	var count int64
	var result User
	DB = DB.Model(&User{}).
		Joins("Account").
		Joins("Account.Pet").
		Preload("Account.Companies")

	if err := DB.Count(&count).Error; err != nil {
		log.Errorf("Failed, got error: %v", err)
	}

	if err := DB.First(&result, user.ID).Error; err != nil {
		log.Errorf("Failed, got error: %v", err)
	}

	if len(result.Account.Companies) != 2 {
		log.Errorf("Failed, got %v", len(result.Account.Companies))
	}

	if result.Account.Pet.Name != "Pet1" {
		log.Errorf("Failed, got '%v'", result.Account.Pet.Name)
	}
	log.Info(count)
	spew.Dump(result)
}

```
