### PR TITLE
fix: AfterQuery should clear FROM Clause's Joins rather than the Stat…

### DIFF
--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -184,20 +184,22 @@ func TestJoinCount(t *testing.T) {
 	DB.Create(&user)
 
 	query := DB.Model(&User{}).Joins("Company")
-	// Bug happens when .Count is called on a query.
-	// Removing the below two lines or downgrading to gorm v1.20.12 will make this test pass.
+
 	var total int64
 	query.Count(&total)
 
 	var result User
 
-	// Incorrectly generates a 'SELECT *' query which causes companies.id to overwrite users.id
 	if err := query.First(&result, user.ID).Error; err != nil {
 		t.Fatalf("Failed, got error: %v", err)
 	}
 
 	if result.ID != user.ID {
 		t.Fatalf("result's id, %d, doesn't match user's id, %d", result.ID, user.ID)
+	}
+	// should find company
+	if result.Company.ID != *user.CompanyID {
+		t.Fatalf("result's id, %d, doesn't match user's company id, %d", result.Company.ID, *user.CompanyID)
 	}
 }
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x]   Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
fix  https://github.com/go-gorm/gorm/issues/7025


<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

There are two options. The first is to choose to clear the Joins in the fromClause each time and regenerate them for every query, which would be somewhat less performant. The second option involves adding cached fields within the fromClause's Joins, allowing subsequent queries to utilize these caches. In this case, the first option has been selected.

Of course, there is still room for optimization here.