### PR TITLE
fix(scan): update Scan function to reset structs to zero values for each scan

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -331,6 +331,9 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 			}
 		case reflect.Struct, reflect.Ptr:
 			if initialized || rows.Next() {
+				if mode == ScanInitialized && reflectValue.Kind() == reflect.Struct {
+					db.Statement.ReflectValue.Set(reflect.Zero(reflectValue.Type()))
+				}
 				db.scanIntoStruct(rows, reflectValue, values, fields, joinFields)
 			}
 		default:


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Accidentally closed #6938 so this is the same PR just with the final implemented solution
Addresses #6819
Adding a condition to reset the values of a struct when a scan is initialized to handle nil values from the database

### User Case Description
It fixes the example from the docs where you initialize the var once:
```golang
    var datasetRow T
    for rows.Next() {
        err := db.ScanRows(rows, &datasetRow)
```