### PR TITLE
feat: add SyncSchema as alias for AutoMigrate()

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -24,6 +24,11 @@ func (db *DB) AutoMigrate(dst ...interface{}) error {
 	return db.Migrator().AutoMigrate(dst...)
 }
 
+// SyncSchema is an alias for AutoMigrate
+func (db *DB) SyncSchema(dst ...interface{}) error {
+	return db.AutoMigrate(dst...)
+}
+
 // ViewOption view option
 type ViewOption struct {
 	Replace     bool   // If true, exec `CREATE`. If false, exec `CREATE OR REPLACE`


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?

This PR is based on issue https://github.com/go-gorm/gorm/issues/7048.
GORM users will be able to perform automatic migration of database schemas using either AutoMigrate or SyncSchema.


### User Case Description

```go
gorm.AutoMigrate(&model.User{})
gorm.AutoMigrate(&model.Character{})
gorm.AutoMigrate(&model.UserCharacter{})

//or
gorm.SyncSchema(&model.User{})
gorm.SyncSchema(&model.Character{})
gorm.SyncSchema(&model.UserCharacter{})

```