### PR TITLE
fix replace associations with custom pk

### DIFF
--- a/utils/tests/models.go
+++ b/utils/tests/models.go
@@ -102,3 +102,14 @@ type Child struct {
 	ParentID *uint
 	Parent   *Parent
 }
+
+type Owner struct {
+	gorm.Model
+	Name       string     `gorm:"index"`
+	CreditCard CreditCard `gorm:"foreignKey:OwnerName;references:name"`
+}
+
+type CreditCard struct {
+	Number   string
+	UserName string `gorm:"primaryKey;unique;size:255"`
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
This PR fixes the Replace association issue with incorrect ON DUPLICATE KEY UPDATE statement.
The example of such issue: https://github.com/go-gorm/playground/pull/745


### User Case Description

<!-- Your use case -->
