### PR TITLE
ci: Add PostgreSQL 14 and 15 to GitHub Actions matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
   postgres:
     strategy:
       matrix:
-        dbversion: ['postgres:latest', 'postgres:15', 'postgres:14', 'postgres:13', 'postgres:12', 'postgres:11', 'postgres:10']
+        dbversion: ['postgres:latest', 'postgres:15', 'postgres:14', 'postgres:13']
         go: ['1.22', '1.21', '1.20']
         platform: [ubuntu-latest] # can not run in macOS and Windows
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
   postgres:
     strategy:
       matrix:
-        dbversion: ['postgres:latest', 'postgres:13', 'postgres:12', 'postgres:11', 'postgres:10']
+        dbversion: ['postgres:latest', 'postgres:15', 'postgres:14', 'postgres:13', 'postgres:12', 'postgres:11', 'postgres:10']
         go: ['1.22', '1.21', '1.20']
         platform: [ubuntu-latest] # can not run in macOS and Windows
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

This pull request updates the GitHub Actions workflow configuration to extend the test matrix for PostgreSQL versions. Specifically, it adds PostgreSQL 14 and PostgreSQL 15 to the list of database versions used in the CI tests. This change ensures that the project is tested against the latest PostgreSQL versions, improving compatibility and stability for users who are using or planning to use these newer versions.

### User Case Description

<!-- Your use case -->
