### PR TITLE
fix: auto migrate tries to delete non-existent unique constraint

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -762,7 +762,8 @@ func (m Migrator) DropConstraint(value interface{}, name string) error {
 		if constraint != nil {
 			name = constraint.GetName()
 		}
-		return m.DB.Exec("ALTER TABLE ? DROP CONSTRAINT ?", clause.Table{Name: table}, clause.Column{Name: name}).Error
+		// using IF EXISTS here as we are "guessing" the constraint name
+		return m.DB.Exec("ALTER TABLE ? DROP CONSTRAINT IF EXISTS ?", clause.Table{Name: table}, clause.Column{Name: name}).Error
 	})
 }
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
This change simply updates the migrator to use `IF EXISTS` when trying to drop constraint.  The reason for this is based on issue #7100 .  With the PR #6640 the naming for unique constraints was changed.  Previously the migrator was creating unique indexes with a naming prefix of `idx_`.  When #6640 went it, the name changed to be `uni_`.  But if your previous upgrade created the constraint with a name of `idx_` the migrator would see you had a constraint and try to delete it.  But it was using the updated naming pattern in this statement.  So that would result in a command like `ALTER TABLE "compliance_integrations" DROP CONSTRAINT "uni_compliance_integrations_clusterid"`.  Since the name of the constraint is `idx_compliance_integrations_clusterid` the call to `DROP CONSTRAINT` fails.  The point of this change is to simply make it a no-op if the constraint doesn't exist.  That will prevent failure.  The old constraint may linger in these cases but that is not the scope of this change.  The scope of this change is to have a migrator that does not cause unnecessary failures for users.

### User Case Description

<!-- Your use case -->
