### PR TITLE
Add parse methods with central log instance

### DIFF
--- a/association.go
+++ b/association.go
@@ -22,7 +22,7 @@ func (db *DB) Association(column string) *Association {
 	association := &Association{DB: db}
 	table := db.Statement.Table
 
-	if err := db.Statement.Parse(db.Statement.Model); err == nil {
+	if err := db.Statement.ParseWithLogger(db.Statement.Model, db.Logger); err == nil {
 		db.Statement.Table = table
 		association.Relationship = db.Statement.Schema.Relationships.Relations[column]
 

--- a/callbacks.go
+++ b/callbacks.go
@@ -102,7 +102,7 @@ func (p *processor) Execute(db *DB) *DB {
 
 	// parse model values
 	if stmt.Model != nil {
-		if err := stmt.Parse(stmt.Model); err != nil && (!errors.Is(err, schema.ErrUnsupportedDataType) || (stmt.Table == "" && stmt.TableExpr == nil && stmt.SQL.Len() == 0)) {
+		if err := stmt.ParseWithLogger(stmt.Model, p.db.Logger); err != nil && (!errors.Is(err, schema.ErrUnsupportedDataType) || (stmt.Table == "" && stmt.TableExpr == nil && stmt.SQL.Len() == 0)) {
 			if errors.Is(err, schema.ErrUnsupportedDataType) && stmt.Table == "" && stmt.TableExpr == nil {
 				db.AddError(fmt.Errorf("%w: Table not set, please set it like: db.Model(&user) or db.Table(\"users\")", err))
 			} else {

--- a/callbacks/preload.go
+++ b/callbacks/preload.go
@@ -173,7 +173,7 @@ func preloadDB(db *gorm.DB, reflectValue reflect.Value, dest interface{}) *gorm.
 		return true
 	})
 
-	if err := tx.Statement.Parse(dest); err != nil {
+	if err := tx.Statement.ParseWithLogger(dest, db.Logger); err != nil {
 		tx.AddError(err)
 		return tx
 	}

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -86,7 +86,7 @@ func BuildQuerySQL(db *gorm.DB) {
 			if queryFields {
 				stmt := gorm.Statement{DB: db}
 				// smaller struct
-				if err := stmt.Parse(db.Statement.Dest); err == nil && (db.QueryFields || stmt.Schema.ModelType != db.Statement.Schema.ModelType) {
+				if err := stmt.ParseWithLogger(db.Statement.Dest, db.Logger); err == nil && (db.QueryFields || stmt.Schema.ModelType != db.Statement.Schema.ModelType) {
 					clauseSelect.Columns = make([]clause.Column, len(stmt.Schema.DBNames))
 
 					for idx, dbName := range stmt.Schema.DBNames {

--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -250,7 +250,7 @@ func ConvertToAssignments(stmt *gorm.Statement) (set clause.Set) {
 		if !updatingValue.CanAddr() || stmt.Dest != stmt.Model {
 			// different schema
 			updatingStmt := &gorm.Statement{DB: stmt.DB}
-			if err := updatingStmt.Parse(stmt.Dest); err == nil {
+			if err := updatingStmt.ParseWithLogger(stmt.Dest, stmt.Logger); err == nil {
 				updatingSchema = updatingStmt.Schema
 				isDiffSchema = true
 			}

--- a/gorm.go
+++ b/gorm.go
@@ -444,13 +444,13 @@ func (db *DB) SetupJoinTable(model interface{}, field string, joinTable interfac
 		modelSchema, joinSchema *schema.Schema
 	)
 
-	err := stmt.Parse(model)
+	err := stmt.ParseWithLogger(model, db.Logger)
 	if err != nil {
 		return err
 	}
 	modelSchema = stmt.Schema
 
-	err = stmt.Parse(joinTable)
+	err = stmt.ParseWithLogger(joinTable, db.Logger)
 	if err != nil {
 		return err
 	}

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -67,7 +67,7 @@ func (m Migrator) RunWithValue(value interface{}, fc func(*gorm.Statement) error
 
 	if table, ok := value.(string); ok {
 		stmt.Table = table
-	} else if err := stmt.ParseWithSpecialTableName(value, stmt.Table); err != nil {
+	} else if err := stmt.ParseWithSpecialTableNameWithLogger(value, stmt.Table, m.DB.Logger); err != nil {
 		return err
 	}
 
@@ -348,7 +348,7 @@ func (m Migrator) RenameTable(oldName, newName interface{}) error {
 		oldTable = clause.Table{Name: v}
 	} else {
 		stmt := &gorm.Statement{DB: m.DB}
-		if err := stmt.Parse(oldName); err == nil {
+		if err := stmt.ParseWithLogger(oldName, m.DB.Logger); err == nil {
 			oldTable = m.CurrentTable(stmt)
 		} else {
 			return err
@@ -359,7 +359,7 @@ func (m Migrator) RenameTable(oldName, newName interface{}) error {
 		newTable = clause.Table{Name: v}
 	} else {
 		stmt := &gorm.Statement{DB: m.DB}
-		if err := stmt.Parse(newName); err == nil {
+		if err := stmt.ParseWithLogger(newName, m.DB.Logger); err == nil {
 			newTable = m.CurrentTable(stmt)
 		} else {
 			return err
@@ -918,7 +918,7 @@ func (m Migrator) ReorderModels(values []interface{}, autoAdd bool) (results []i
 		}
 		beDependedOn := map[*schema.Schema]bool{}
 		// support for special table name
-		if err := dep.ParseWithSpecialTableName(value, m.DB.Statement.Table); err != nil {
+		if err := dep.ParseWithSpecialTableNameWithLogger(value, m.DB.Statement.Table, m.Config.DB.Logger); err != nil {
 			m.DB.Logger.Error(context.Background(), "failed to parse value %#v, got error %v", value, err)
 		}
 		if _, ok := parsedSchemas[dep.Statement.Schema]; ok {

--- a/statement.go
+++ b/statement.go
@@ -486,11 +486,19 @@ func (stmt *Statement) Build(clauses ...string) {
 }
 
 func (stmt *Statement) Parse(value interface{}) (err error) {
-	return stmt.ParseWithSpecialTableName(value, "")
+	return stmt.ParseWithSpecialTableNameWithLogger(value, "", logger.Default)
+}
+
+func (stmt *Statement) ParseWithLogger(value interface{}, log logger.Interface) (err error) {
+	return stmt.ParseWithSpecialTableNameWithLogger(value, "", log)
 }
 
 func (stmt *Statement) ParseWithSpecialTableName(value interface{}, specialTableName string) (err error) {
-	if stmt.Schema, err = schema.ParseWithSpecialTableName(value, stmt.DB.cacheStore, stmt.DB.NamingStrategy, specialTableName); err == nil && stmt.Table == "" {
+	return stmt.ParseWithSpecialTableNameWithLogger(value, specialTableName, logger.Default)
+}
+
+func (stmt *Statement) ParseWithSpecialTableNameWithLogger(value interface{}, specialTableName string, log logger.Interface) (err error) {
+	if stmt.Schema, err = schema.ParseWithSpecialTableNameWithLogger(value, stmt.DB.cacheStore, stmt.DB.NamingStrategy, specialTableName, log); err == nil && stmt.Table == "" {
 		if tables := strings.Split(stmt.Schema.Table, "."); len(tables) == 2 {
 			stmt.TableExpr = &clause.Expr{SQL: stmt.Quote(stmt.Schema.Table)}
 			stmt.Table = tables[1]


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested (works as far as i can tell)

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
Added additional methods that include a logger as parameter, so internal methods can pass a the logger from the config though.

### User Case Description
When i use gorm, i get logs like this:
```
2024/08/06 20:08:59 /project/internal/http_server/http.go:34
[error] invalid field found for struct wishes/internal/model.Wish's field Owner: define a valid foreign key for relations or implement the Valuer/Scanner interface
```

Currently, i need to do something like this.
```golang
import "io/gorm/logger"
var g *gorm.DB
logger.Default = g.Logger
```
To get gorm to use the central logger (this is the same (unrelated) error, but in the format i specified for my logs):
```
19:32:47 ERR ../../go/pkg/mod/gorm.io/gorm@v1.25.11/schema/schema.go:334 > invalid field found for struct wishes/internal/model.Wish's field Owner: define a valid foreign key for relations or implement the Valuer/Scanner interface type=gorm
```
<!-- Your use case -->
