### PR TITLE
fix: AfterQuery using safer right trim to clear FROM clause's joins

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -288,7 +288,7 @@ func AfterQuery(db *gorm.DB) {
 	// clear the joins after query because preload need it
 	if v, ok := db.Statement.Clauses["FROM"].Expression.(clause.From); ok {
 		fromClause := db.Statement.Clauses["FROM"]
-		fromClause.Expression = clause.From{Tables: v.Tables, Joins: v.Joins[:len(v.Joins)-len(db.Statement.Joins)]} // keep the original From Joins
+		fromClause.Expression = clause.From{Tables: v.Tables, Joins: utils.RTrimSlice(v.Joins, len(v.Joins)-len(db.Statement.Joins))} // keep the original From Joins
 		db.Statement.Clauses["FROM"] = fromClause
 	}
 	if db.Error == nil && db.Statement.Schema != nil && !db.Statement.SkipHooks && db.Statement.Schema.AfterFind && db.RowsAffected > 0 {

--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -476,19 +476,3 @@ func TestJoinsPreload_Issue7013_NoEntries(t *testing.T) {
 
 	AssertEqual(t, len(entries), 0)
 }
-
-func TestJoinWithWrongColumnName_MultipleAfterQueryCalls(t *testing.T) {
-	type result struct {
-		gorm.Model
-		Name string
-		Pets []*Pet `gorm:"foreignKey:UserID"`
-	}
-	user := *GetUser("joins_with_select", Config{Pets: 2})
-	DB.Save(&user)
-	var results []result
-	var total int64
-	assert.NotPanics(t, func() {
-		err := DB.Table("users").Select("users.id, pets.id as pet_id, pets.name").Joins("left join pets on pets.user_id = users.id").Where("users.name = ? and pets.names = ?", "joins_with_select", "joins_with_select_pet_2").Preload("Pets").Find(&results).Limit(-1).Offset(-1).Count(&total).Error
-		assert.ErrorContains(t, err, "no such column: pets.names")
-	})
-}

--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -476,3 +476,19 @@ func TestJoinsPreload_Issue7013_NoEntries(t *testing.T) {
 
 	AssertEqual(t, len(entries), 0)
 }
+
+func TestJoinWithWrongColumnName_MultipleAfterQueryCalls(t *testing.T) {
+	type result struct {
+		gorm.Model
+		Name string
+		Pets []*Pet `gorm:"foreignKey:UserID"`
+	}
+	user := *GetUser("joins_with_select", Config{Pets: 2})
+	DB.Save(&user)
+	var results []result
+	var total int64
+	assert.NotPanics(t, func() {
+		err := DB.Table("users").Select("users.id, pets.id as pet_id, pets.name").Joins("left join pets on pets.user_id = users.id").Where("users.name = ? and pets.names = ?", "joins_with_select", "joins_with_select_pet_2").Preload("Pets").Find(&results).Limit(-1).Offset(-1).Count(&total).Error
+		assert.ErrorContains(t, err, "no such column: pets.names")
+	})
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -166,3 +166,26 @@ func SplitNestedRelationName(name string) []string {
 func JoinNestedRelationNames(relationNames []string) string {
 	return strings.Join(relationNames, nestedRelationSplit)
 }
+
+// MaxInt returns maximum of two integers
+func MaxInt(n1, n2 int) int {
+	if n1 > n2 {
+		return n1
+	}
+	return n2
+}
+
+// MinInt returns minimum of two integers
+func MinInt(n1, n2 int) int {
+	if n1 < n2 {
+		return n1
+	}
+	return n2
+}
+
+// RTrimSlice Right trims the give slice by given length
+func RTrimSlice[T any](v []T, trimLen int) []T {
+	rPtr := MaxInt(trimLen, 0)  // should not be negative
+	rPtr = MinInt(len(v), rPtr) // should not be greater than length
+	return v[:rPtr]
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -138,3 +138,78 @@ func TestToString(t *testing.T) {
 		})
 	}
 }
+
+func TestMaxInt(t *testing.T) {
+
+	type testVal struct {
+		n1, n2 int
+	}
+
+	integerSet := []int{100, 10, 0, -10, -100} // test set in desc order
+	samples := []testVal{}
+
+	for _, i := range integerSet {
+		for _, j := range integerSet {
+			samples = append(samples, testVal{n1: i, n2: j})
+		}
+	}
+
+	for _, sample := range samples {
+		t.Run("", func(t *testing.T) {
+			result := MaxInt(sample.n1, sample.n2)
+			if !(result >= sample.n1 && result >= sample.n2) {
+				t.Fatalf("For n1=%d and n2=%d, result is %d;", sample.n1, sample.n2, result)
+			}
+		})
+	}
+}
+
+func TestMinInt(t *testing.T) {
+
+	type testVal struct {
+		n1, n2 int
+	}
+
+	integerSet := []int{100, 10, 0, -10, -100} // test set in desc order
+	samples := []testVal{}
+
+	for _, i := range integerSet {
+		for _, j := range integerSet {
+			samples = append(samples, testVal{n1: i, n2: j})
+		}
+	}
+
+	for _, sample := range samples {
+		t.Run("", func(t *testing.T) {
+			result := MinInt(sample.n1, sample.n2)
+			if !(result <= sample.n1 && result <= sample.n2) {
+				t.Fatalf("For n1=%d and n2=%d, result is %d;", sample.n1, sample.n2, result)
+			}
+		})
+	}
+}
+
+func TestRTrimSlice(t *testing.T) {
+	samples := []struct {
+		input    []int
+		trimLen  int
+		expected []int
+	}{
+		{[]int{1, 2, 3, 4, 5}, 3, []int{1, 2, 3}},
+		{[]int{1, 2, 3, 4, 5}, 0, []int{}},
+		{[]int{1, 2, 3, 4, 5}, 5, []int{1, 2, 3, 4, 5}},
+		{[]int{1, 2, 3, 4, 5}, 10, []int{1, 2, 3, 4, 5}}, // trimLen greater than slice length
+		{[]int{1, 2, 3, 4, 5}, -1, []int{}},              // negative trimLen
+		{[]int{}, 3, []int{}},                            // empty slice
+		{[]int{1, 2, 3}, 1, []int{1}},                    // trim to a single element
+	}
+
+	for _, sample := range samples {
+		t.Run("", func(t *testing.T) {
+			result := RTrimSlice(sample.input, sample.trimLen)
+			if !AssertEqual(result, sample.expected) {
+				t.Errorf("Triming %v by length %d gives %v but want %v", sample.input, sample.trimLen, result, sample.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As a fix to [this issue](https://github.com/go-gorm/gorm/issues/7025) , clearing of db.Statement.Clauses["FROM"] was in introduced in [this pull-request](https://github.com/go-gorm/gorm/pull/7027)

At https://github.com/go-gorm/gorm/blob/master/callbacks/query.go#L291 , it can cause a panic if `db.Statement.Clauses["FROM"].Joins` slice is being sliced using negative upper bound index. Please observe below the case reproduced in current source code

![image](https://github.com/user-attachments/assets/21ed1613-d1cf-483d-a34e-cb44f7df323c)

In the case above, wrong column name `pets.names` (instead of pets.name) is passed as query.
When `Count()` is called after `Find()` on the the same `gorm.DB` instance with a wrong query, it calls AfterQuery twice which in turn tries to trim the slice twice which now is empty after first trim. Hence instead of obtaining actual SQL error, it causes a panic due to index out of bound error.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This Pull Request:

- Safely trims the `db.Statement.Clauses["FROM"].Joins`
- Unit test for newly added functions for Safe right trimming of slice
- Unit Test for wrong query case

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

User Case:

In one of my our projects, we are using gorm (just fantastic) as ORM support for Postgres. After upgrading gorm version from `v1.9.16` -> `v1.25.11`, we identified panic in API due to broken migration which changes a column name causing the query to be wrong.

Of course this is a minor fix requirement but much needed to prevent API server error and handle SQL error gracefully.

<!-- Your use case -->
