### PR TITLE
fix: AfterQuery using safer right trim while clearing from clause's j…

### DIFF
--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -288,7 +288,7 @@ func AfterQuery(db *gorm.DB) {
 	// clear the joins after query because preload need it
 	if v, ok := db.Statement.Clauses["FROM"].Expression.(clause.From); ok {
 		fromClause := db.Statement.Clauses["FROM"]
-		fromClause.Expression = clause.From{Tables: v.Tables, Joins: v.Joins[:len(v.Joins)-len(db.Statement.Joins)]} // keep the original From Joins
+		fromClause.Expression = clause.From{Tables: v.Tables, Joins: utils.RTrimSlice(v.Joins, len(db.Statement.Joins))} // keep the original From Joins
 		db.Statement.Clauses["FROM"] = fromClause
 	}
 	if db.Error == nil && db.Statement.Schema != nil && !db.Statement.SkipHooks && db.Statement.Schema.AfterFind && db.RowsAffected > 0 {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -166,3 +166,14 @@ func SplitNestedRelationName(name string) []string {
 func JoinNestedRelationNames(relationNames []string) string {
 	return strings.Join(relationNames, nestedRelationSplit)
 }
+
+// RTrimSlice Right trims the given slice by given length
+func RTrimSlice[T any](v []T, trimLen int) []T {
+	if trimLen >= len(v) { // trimLen greater than slice len means fully sliced
+		return v[:0]
+	}
+	if trimLen < 0 { // negative trimLen is ignored
+		return v[:]
+	}
+	return v[:len(v)-trimLen]
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -138,3 +138,64 @@ func TestToString(t *testing.T) {
 		})
 	}
 }
+
+func TestRTrimSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []int
+		trimLen  int
+		expected []int
+	}{
+		{
+			name:     "Trim two elements from end",
+			input:    []int{1, 2, 3, 4, 5},
+			trimLen:  2,
+			expected: []int{1, 2, 3},
+		},
+		{
+			name:     "Trim entire slice",
+			input:    []int{1, 2, 3},
+			trimLen:  3,
+			expected: []int{},
+		},
+		{
+			name:     "Trim length greater than slice length",
+			input:    []int{1, 2, 3},
+			trimLen:  5,
+			expected: []int{},
+		},
+		{
+			name:     "Zero trim length",
+			input:    []int{1, 2, 3},
+			trimLen:  0,
+			expected: []int{1, 2, 3},
+		},
+		{
+			name:     "Trim one element from end",
+			input:    []int{1, 2, 3},
+			trimLen:  1,
+			expected: []int{1, 2},
+		},
+		{
+			name:     "Empty slice",
+			input:    []int{},
+			trimLen:  2,
+			expected: []int{},
+		},
+		{
+			name:     "Negative trim length (should be treated as zero)",
+			input:    []int{1, 2, 3},
+			trimLen:  -1,
+			expected: []int{1, 2, 3},
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			result := RTrimSlice(testcase.input, testcase.trimLen)
+			if !AssertEqual(result, testcase.expected) {
+				t.Errorf("RTrimSlice(%v, %d) = %v; want %v", testcase.input, testcase.trimLen, result, testcase.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Summary:**
As a fix to https://github.com/go-gorm/gorm/issues/7025 , clearing of `db.Statement.Clauses["FROM"]` was in introduced in https://github.com/go-gorm/gorm/pull/7027

At https://github.com/go-gorm/gorm/blob/master/callbacks/query.go#L291 , it can cause a panic if `db.Statement.Clauses["FROM"].Joins` slice is being sliced using negative upper bound index
i.e. when `len(db.Statement.Joins) > len(v.Joins)`. Please observe below the case reproduced in current source code

**Steps to reproduce:**

![image](https://github.com/user-attachments/assets/931f8c18-fa67-46ce-8ac6-dc26ef40c387)


In the case above, wrong column name `pets.names` (instead of pets.name) is passed as query.
When **Count()** is called after `Find()` on the the same `gorm.DB` instance with a wrong query, it calls `AfterQuery` twice which in turn tries to trim the slice twice which now is empty after first trim. Hence instead of obtaining actual SQL error, it causes a panic due to index out of bound error.


**Checklist:**
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

**What did this pull request do?:**
This Pull Request:
Safely trims the `db.Statement.Clauses["FROM"].Joins`
Unit test for newly added functions for Safe right trimming of slice


**User Case:**
In one of my our projects, we are using gorm (just fantastic) as ORM support for Postgres. After upgrading gorm version from `v1.9.16 -> v1.25.11`, we identified panic in API due to broken migration which changes a column name causing the query to be wrong.

Of course this is a minor fix requirement but much needed to prevent API server error and handle SQL error gracefully.