### PR TITLE
Fix join in delete

### DIFF
--- a/callbacks/delete.go
+++ b/callbacks/delete.go
@@ -126,7 +126,19 @@ func Delete(config *Config) func(db *gorm.DB) {
 
 		if db.Statement.SQL.Len() == 0 {
 			db.Statement.SQL.Grow(100)
-			db.Statement.AddClauseIfNotExists(clause.Delete{})
+
+			deleteClause := clause.Delete{}
+
+			HandleJoins(
+				db,
+				func(db *gorm.DB) {
+					deleteClause.Modifier = db.Statement.Table
+				},
+				func(db *gorm.DB, tableAliasName string, join gorm.Join, relation *schema.Relationship) {
+				},
+			)
+
+			db.Statement.AddClauseIfNotExists(deleteClause)
 
 			if db.Statement.Schema != nil {
 				_, queryValues := schema.GetIdentityFieldValuesMap(db.Statement.Context, db.Statement.ReflectValue, db.Statement.Schema.PrimaryFields)

--- a/callbacks/delete.go
+++ b/callbacks/delete.go
@@ -134,7 +134,7 @@ func Delete(config *Config) func(db *gorm.DB) {
 				func(db *gorm.DB) {
 					deleteClause.Modifier = db.Statement.Table
 				},
-				func(db *gorm.DB, tableAliasName string, join gorm.Join, relation *schema.Relationship) {
+				func(db *gorm.DB, tableAliasName string, idx int, relation *schema.Relationship) {
 				},
 			)
 

--- a/callbacks/delete.go
+++ b/callbacks/delete.go
@@ -132,7 +132,7 @@ func Delete(config *Config) func(db *gorm.DB) {
 			HandleJoins(
 				db,
 				func(db *gorm.DB) {
-					deleteClause.Modifier = db.Statement.Table
+					deleteClause.Table = db.Statement.Table
 				},
 				func(db *gorm.DB, tableAliasName string, idx int, relation *schema.Relationship) {
 				},

--- a/callbacks/join.go
+++ b/callbacks/join.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func HandleJoins(db *gorm.DB, prejoinCallback func(db *gorm.DB), perFieldNameCallback func(db *gorm.DB, tableAliasName string, join gorm.Join, relation *schema.Relationship)) {
+func HandleJoins(db *gorm.DB, prejoinCallback func(db *gorm.DB), perFieldNameCallback func(db *gorm.DB, tableAliasName string, idx int, relation *schema.Relationship)) {
 	// inline joins
 	fromClause := clause.From{}
 	if v, ok := db.Statement.Clauses["FROM"].Expression.(clause.From); ok {
@@ -19,7 +19,7 @@ func HandleJoins(db *gorm.DB, prejoinCallback func(db *gorm.DB), perFieldNameCal
 		prejoinCallback(db)
 
 		specifiedRelationsName := make(map[string]interface{})
-		for _, join := range db.Statement.Joins {
+		for idx, join := range db.Statement.Joins {
 			if db.Statement.Schema != nil {
 				var isRelations bool // is relations or raw sql
 				var relations []*schema.Relationship
@@ -59,7 +59,7 @@ func HandleJoins(db *gorm.DB, prejoinCallback func(db *gorm.DB), perFieldNameCal
 							tableAliasName = utils.NestedRelationName(parentTableName, tableAliasName)
 						}
 
-						perFieldNameCallback(db, tableAliasName, join, relation)
+						perFieldNameCallback(db, tableAliasName, idx, relation)
 
 						exprs := make([]clause.Expression, len(relation.References))
 						for idx, ref := range relation.References {

--- a/callbacks/join.go
+++ b/callbacks/join.go
@@ -1,0 +1,154 @@
+package callbacks
+
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
+	"gorm.io/gorm/utils"
+	"strings"
+)
+
+func HandleJoins(db *gorm.DB, prejoinCallback func(db *gorm.DB), perFieldNameCallback func(db *gorm.DB, tableAliasName string, join gorm.Join, relation *schema.Relationship)) {
+	// inline joins
+	fromClause := clause.From{}
+	if v, ok := db.Statement.Clauses["FROM"].Expression.(clause.From); ok {
+		fromClause = v
+	}
+
+	if len(db.Statement.Joins) != 0 || len(fromClause.Joins) != 0 {
+		prejoinCallback(db)
+
+		specifiedRelationsName := make(map[string]interface{})
+		for _, join := range db.Statement.Joins {
+			if db.Statement.Schema != nil {
+				var isRelations bool // is relations or raw sql
+				var relations []*schema.Relationship
+				relation, ok := db.Statement.Schema.Relationships.Relations[join.Name]
+				if ok {
+					isRelations = true
+					relations = append(relations, relation)
+				} else {
+					// handle nested join like "Manager.Company"
+					nestedJoinNames := strings.Split(join.Name, ".")
+					if len(nestedJoinNames) > 1 {
+						isNestedJoin := true
+						gussNestedRelations := make([]*schema.Relationship, 0, len(nestedJoinNames))
+						currentRelations := db.Statement.Schema.Relationships.Relations
+						for _, relname := range nestedJoinNames {
+							// incomplete match, only treated as raw sql
+							if relation, ok = currentRelations[relname]; ok {
+								gussNestedRelations = append(gussNestedRelations, relation)
+								currentRelations = relation.FieldSchema.Relationships.Relations
+							} else {
+								isNestedJoin = false
+								break
+							}
+						}
+
+						if isNestedJoin {
+							isRelations = true
+							relations = gussNestedRelations
+						}
+					}
+				}
+
+				if isRelations {
+					genJoinClause := func(joinType clause.JoinType, parentTableName string, relation *schema.Relationship) clause.Join {
+						tableAliasName := relation.Name
+						if parentTableName != clause.CurrentTable {
+							tableAliasName = utils.NestedRelationName(parentTableName, tableAliasName)
+						}
+
+						perFieldNameCallback(db, tableAliasName, join, relation)
+
+						exprs := make([]clause.Expression, len(relation.References))
+						for idx, ref := range relation.References {
+							if ref.OwnPrimaryKey {
+								exprs[idx] = clause.Eq{
+									Column: clause.Column{Table: parentTableName, Name: ref.PrimaryKey.DBName},
+									Value:  clause.Column{Table: tableAliasName, Name: ref.ForeignKey.DBName},
+								}
+							} else {
+								if ref.PrimaryValue == "" {
+									exprs[idx] = clause.Eq{
+										Column: clause.Column{Table: parentTableName, Name: ref.ForeignKey.DBName},
+										Value:  clause.Column{Table: tableAliasName, Name: ref.PrimaryKey.DBName},
+									}
+								} else {
+									exprs[idx] = clause.Eq{
+										Column: clause.Column{Table: tableAliasName, Name: ref.ForeignKey.DBName},
+										Value:  ref.PrimaryValue,
+									}
+								}
+							}
+						}
+
+						{
+							onStmt := gorm.Statement{Table: tableAliasName, DB: db, Clauses: map[string]clause.Clause{}}
+							for _, c := range relation.FieldSchema.QueryClauses {
+								onStmt.AddClause(c)
+							}
+
+							if join.On != nil {
+								onStmt.AddClause(join.On)
+							}
+
+							if cs, ok := onStmt.Clauses["WHERE"]; ok {
+								if where, ok := cs.Expression.(clause.Where); ok {
+									where.Build(&onStmt)
+
+									if onSQL := onStmt.SQL.String(); onSQL != "" {
+										vars := onStmt.Vars
+										for idx, v := range vars {
+											bindvar := strings.Builder{}
+											onStmt.Vars = vars[0 : idx+1]
+											db.Dialector.BindVarTo(&bindvar, &onStmt, v)
+											onSQL = strings.Replace(onSQL, bindvar.String(), "?", 1)
+										}
+
+										exprs = append(exprs, clause.Expr{SQL: onSQL, Vars: vars})
+									}
+								}
+							}
+						}
+
+						return clause.Join{
+							Type:  joinType,
+							Table: clause.Table{Name: relation.FieldSchema.Table, Alias: tableAliasName},
+							ON:    clause.Where{Exprs: exprs},
+						}
+					}
+
+					parentTableName := clause.CurrentTable
+					for _, rel := range relations {
+						// joins table alias like "Manager, Company, Manager__Company"
+						nestedAlias := utils.NestedRelationName(parentTableName, rel.Name)
+						if _, ok := specifiedRelationsName[nestedAlias]; !ok {
+							fromClause.Joins = append(fromClause.Joins, genJoinClause(join.JoinType, parentTableName, rel))
+							specifiedRelationsName[nestedAlias] = nil
+						}
+
+						if parentTableName != clause.CurrentTable {
+							parentTableName = utils.NestedRelationName(parentTableName, rel.Name)
+						} else {
+							parentTableName = rel.Name
+						}
+					}
+				} else {
+					fromClause.Joins = append(fromClause.Joins, clause.Join{
+						Expression: clause.NamedExpr{SQL: join.Name, Vars: join.Conds},
+					})
+				}
+			} else {
+				fromClause.Joins = append(fromClause.Joins, clause.Join{
+					Expression: clause.NamedExpr{SQL: join.Name, Vars: join.Conds},
+				})
+			}
+		}
+
+		db.Statement.AddClause(fromClause)
+	} else {
+		db.Statement.AddClauseIfNotExists(clause.From{})
+	}
+
+}

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -104,10 +104,10 @@ func BuildQuerySQL(db *gorm.DB) {
 					}
 				}
 			},
-			func(db *gorm.DB, tableAliasName string, join gorm.Join, relation *schema.Relationship) {
+			func(db *gorm.DB, tableAliasName string, idx int, relation *schema.Relationship) {
 				columnStmt := gorm.Statement{
 					Table: tableAliasName, DB: db, Schema: relation.FieldSchema,
-					Selects: join.Selects, Omits: join.Omits,
+					Selects: db.Statement.Joins[idx].Selects, Omits: db.Statement.Joins[idx].Omits,
 				}
 
 				selectColumns, restricted := columnStmt.SelectAndOmitColumns(false, false)

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -2,13 +2,11 @@ package callbacks
 
 import (
 	"fmt"
-	"reflect"
-	"strings"
-
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
 	"gorm.io/gorm/utils"
+	"reflect"
 )
 
 func Query(db *gorm.DB) {
@@ -96,166 +94,34 @@ func BuildQuerySQL(db *gorm.DB) {
 			}
 		}
 
-		// inline joins
-		fromClause := clause.From{}
-		if v, ok := db.Statement.Clauses["FROM"].Expression.(clause.From); ok {
-			fromClause = v
-		}
-
-		if len(db.Statement.Joins) != 0 || len(fromClause.Joins) != 0 {
-			if len(db.Statement.Selects) == 0 && len(db.Statement.Omits) == 0 && db.Statement.Schema != nil {
-				clauseSelect.Columns = make([]clause.Column, len(db.Statement.Schema.DBNames))
-				for idx, dbName := range db.Statement.Schema.DBNames {
-					clauseSelect.Columns[idx] = clause.Column{Table: db.Statement.Table, Name: dbName}
-				}
-			}
-
-			specifiedRelationsName := make(map[string]interface{})
-			for _, join := range db.Statement.Joins {
-				if db.Statement.Schema != nil {
-					var isRelations bool // is relations or raw sql
-					var relations []*schema.Relationship
-					relation, ok := db.Statement.Schema.Relationships.Relations[join.Name]
-					if ok {
-						isRelations = true
-						relations = append(relations, relation)
-					} else {
-						// handle nested join like "Manager.Company"
-						nestedJoinNames := strings.Split(join.Name, ".")
-						if len(nestedJoinNames) > 1 {
-							isNestedJoin := true
-							gussNestedRelations := make([]*schema.Relationship, 0, len(nestedJoinNames))
-							currentRelations := db.Statement.Schema.Relationships.Relations
-							for _, relname := range nestedJoinNames {
-								// incomplete match, only treated as raw sql
-								if relation, ok = currentRelations[relname]; ok {
-									gussNestedRelations = append(gussNestedRelations, relation)
-									currentRelations = relation.FieldSchema.Relationships.Relations
-								} else {
-									isNestedJoin = false
-									break
-								}
-							}
-
-							if isNestedJoin {
-								isRelations = true
-								relations = gussNestedRelations
-							}
-						}
+		HandleJoins(
+			db,
+			func(db *gorm.DB) {
+				if len(db.Statement.Selects) == 0 && len(db.Statement.Omits) == 0 && db.Statement.Schema != nil {
+					clauseSelect.Columns = make([]clause.Column, len(db.Statement.Schema.DBNames))
+					for idx, dbName := range db.Statement.Schema.DBNames {
+						clauseSelect.Columns[idx] = clause.Column{Table: db.Statement.Table, Name: dbName}
 					}
+				}
+			},
+			func(db *gorm.DB, tableAliasName string, join gorm.Join, relation *schema.Relationship) {
+				columnStmt := gorm.Statement{
+					Table: tableAliasName, DB: db, Schema: relation.FieldSchema,
+					Selects: join.Selects, Omits: join.Omits,
+				}
 
-					if isRelations {
-						genJoinClause := func(joinType clause.JoinType, parentTableName string, relation *schema.Relationship) clause.Join {
-							tableAliasName := relation.Name
-							if parentTableName != clause.CurrentTable {
-								tableAliasName = utils.NestedRelationName(parentTableName, tableAliasName)
-							}
-
-							columnStmt := gorm.Statement{
-								Table: tableAliasName, DB: db, Schema: relation.FieldSchema,
-								Selects: join.Selects, Omits: join.Omits,
-							}
-
-							selectColumns, restricted := columnStmt.SelectAndOmitColumns(false, false)
-							for _, s := range relation.FieldSchema.DBNames {
-								if v, ok := selectColumns[s]; (ok && v) || (!ok && !restricted) {
-									clauseSelect.Columns = append(clauseSelect.Columns, clause.Column{
-										Table: tableAliasName,
-										Name:  s,
-										Alias: utils.NestedRelationName(tableAliasName, s),
-									})
-								}
-							}
-
-							exprs := make([]clause.Expression, len(relation.References))
-							for idx, ref := range relation.References {
-								if ref.OwnPrimaryKey {
-									exprs[idx] = clause.Eq{
-										Column: clause.Column{Table: parentTableName, Name: ref.PrimaryKey.DBName},
-										Value:  clause.Column{Table: tableAliasName, Name: ref.ForeignKey.DBName},
-									}
-								} else {
-									if ref.PrimaryValue == "" {
-										exprs[idx] = clause.Eq{
-											Column: clause.Column{Table: parentTableName, Name: ref.ForeignKey.DBName},
-											Value:  clause.Column{Table: tableAliasName, Name: ref.PrimaryKey.DBName},
-										}
-									} else {
-										exprs[idx] = clause.Eq{
-											Column: clause.Column{Table: tableAliasName, Name: ref.ForeignKey.DBName},
-											Value:  ref.PrimaryValue,
-										}
-									}
-								}
-							}
-
-							{
-								onStmt := gorm.Statement{Table: tableAliasName, DB: db, Clauses: map[string]clause.Clause{}}
-								for _, c := range relation.FieldSchema.QueryClauses {
-									onStmt.AddClause(c)
-								}
-
-								if join.On != nil {
-									onStmt.AddClause(join.On)
-								}
-
-								if cs, ok := onStmt.Clauses["WHERE"]; ok {
-									if where, ok := cs.Expression.(clause.Where); ok {
-										where.Build(&onStmt)
-
-										if onSQL := onStmt.SQL.String(); onSQL != "" {
-											vars := onStmt.Vars
-											for idx, v := range vars {
-												bindvar := strings.Builder{}
-												onStmt.Vars = vars[0 : idx+1]
-												db.Dialector.BindVarTo(&bindvar, &onStmt, v)
-												onSQL = strings.Replace(onSQL, bindvar.String(), "?", 1)
-											}
-
-											exprs = append(exprs, clause.Expr{SQL: onSQL, Vars: vars})
-										}
-									}
-								}
-							}
-
-							return clause.Join{
-								Type:  joinType,
-								Table: clause.Table{Name: relation.FieldSchema.Table, Alias: tableAliasName},
-								ON:    clause.Where{Exprs: exprs},
-							}
-						}
-
-						parentTableName := clause.CurrentTable
-						for _, rel := range relations {
-							// joins table alias like "Manager, Company, Manager__Company"
-							nestedAlias := utils.NestedRelationName(parentTableName, rel.Name)
-							if _, ok := specifiedRelationsName[nestedAlias]; !ok {
-								fromClause.Joins = append(fromClause.Joins, genJoinClause(join.JoinType, parentTableName, rel))
-								specifiedRelationsName[nestedAlias] = nil
-							}
-
-							if parentTableName != clause.CurrentTable {
-								parentTableName = utils.NestedRelationName(parentTableName, rel.Name)
-							} else {
-								parentTableName = rel.Name
-							}
-						}
-					} else {
-						fromClause.Joins = append(fromClause.Joins, clause.Join{
-							Expression: clause.NamedExpr{SQL: join.Name, Vars: join.Conds},
+				selectColumns, restricted := columnStmt.SelectAndOmitColumns(false, false)
+				for _, s := range relation.FieldSchema.DBNames {
+					if v, ok := selectColumns[s]; (ok && v) || (!ok && !restricted) {
+						clauseSelect.Columns = append(clauseSelect.Columns, clause.Column{
+							Table: tableAliasName,
+							Name:  s,
+							Alias: utils.NestedRelationName(tableAliasName, s),
 						})
 					}
-				} else {
-					fromClause.Joins = append(fromClause.Joins, clause.Join{
-						Expression: clause.NamedExpr{SQL: join.Name, Vars: join.Conds},
-					})
 				}
-			}
-
-			db.Statement.AddClause(fromClause)
-		} else {
-			db.Statement.AddClauseIfNotExists(clause.From{})
-		}
+			},
+		)
 
 		db.Statement.AddClauseIfNotExists(clauseSelect)
 

--- a/chainable_api.go
+++ b/chainable_api.go
@@ -260,7 +260,7 @@ func joins(db *DB, joinType clause.JoinType, query string, args ...interface{}) 
 
 	if len(args) == 1 {
 		if db, ok := args[0].(*DB); ok {
-			j := join{
+			j := Join{
 				Name: query, Conds: args, Selects: db.Statement.Selects,
 				Omits: db.Statement.Omits, JoinType: joinType,
 			}
@@ -272,7 +272,7 @@ func joins(db *DB, joinType clause.JoinType, query string, args ...interface{}) 
 		}
 	}
 
-	tx.Statement.Joins = append(tx.Statement.Joins, join{Name: query, Conds: args, JoinType: joinType})
+	tx.Statement.Joins = append(tx.Statement.Joins, Join{Name: query, Conds: args, JoinType: joinType})
 	return
 }
 
@@ -448,9 +448,10 @@ func (db *DB) Assign(attrs ...interface{}) (tx *DB) {
 // Unscoped allows queries to include records marked as deleted,
 // overriding the soft deletion behavior.
 // Example:
-//    var users []User
-//    db.Unscoped().Find(&users)
-//    // Retrieves all users, including deleted ones.
+//
+//	var users []User
+//	db.Unscoped().Find(&users)
+//	// Retrieves all users, including deleted ones.
 func (db *DB) Unscoped() (tx *DB) {
 	tx = db.getInstance()
 	tx.Statement.Unscoped = true

--- a/chainable_api.go
+++ b/chainable_api.go
@@ -260,7 +260,7 @@ func joins(db *DB, joinType clause.JoinType, query string, args ...interface{}) 
 
 	if len(args) == 1 {
 		if db, ok := args[0].(*DB); ok {
-			j := Join{
+			j := join{
 				Name: query, Conds: args, Selects: db.Statement.Selects,
 				Omits: db.Statement.Omits, JoinType: joinType,
 			}
@@ -272,7 +272,7 @@ func joins(db *DB, joinType clause.JoinType, query string, args ...interface{}) 
 		}
 	}
 
-	tx.Statement.Joins = append(tx.Statement.Joins, Join{Name: query, Conds: args, JoinType: joinType})
+	tx.Statement.Joins = append(tx.Statement.Joins, join{Name: query, Conds: args, JoinType: joinType})
 	return
 }
 

--- a/clause/delete.go
+++ b/clause/delete.go
@@ -13,7 +13,7 @@ func (d Delete) Build(builder Builder) {
 
 	if d.Modifier != "" {
 		builder.WriteByte(' ')
-		builder.WriteString(d.Modifier)
+		builder.WriteQuoted(d.Modifier)
 	}
 }
 

--- a/clause/delete.go
+++ b/clause/delete.go
@@ -2,6 +2,7 @@ package clause
 
 type Delete struct {
 	Modifier string
+	Table    string
 }
 
 func (d Delete) Name() string {
@@ -13,7 +14,11 @@ func (d Delete) Build(builder Builder) {
 
 	if d.Modifier != "" {
 		builder.WriteByte(' ')
-		builder.WriteQuoted(d.Modifier)
+		builder.WriteString(d.Modifier)
+	}
+	if d.Table != "" {
+		builder.WriteByte(' ')
+		builder.WriteQuoted(d.Table)
 	}
 }
 

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+gorm.io/gorm v1.25.11 h1:/Wfyg1B/je1hnDx3sMkX+gAlxrlZpn6X0BXRlwXlvHg=
+gorm.io/gorm v1.25.11/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=

--- a/statement.go
+++ b/statement.go
@@ -33,7 +33,7 @@ type Statement struct {
 	Selects              []string          // selected columns
 	Omits                []string          // omit columns
 	ColumnMapping        map[string]string // map columns
-	Joins                []Join
+	Joins                []join
 	Preloads             map[string][]interface{}
 	Settings             sync.Map
 	ConnPool             ConnPool
@@ -49,7 +49,7 @@ type Statement struct {
 	scopes               []func(*DB) *DB
 }
 
-type Join struct {
+type join struct {
 	Name     string
 	Conds    []interface{}
 	On       *clause.Where
@@ -538,7 +538,7 @@ func (stmt *Statement) clone() *Statement {
 	}
 
 	if len(stmt.Joins) > 0 {
-		newStmt.Joins = make([]Join, len(stmt.Joins))
+		newStmt.Joins = make([]join, len(stmt.Joins))
 		copy(newStmt.Joins, stmt.Joins)
 	}
 

--- a/statement.go
+++ b/statement.go
@@ -33,7 +33,7 @@ type Statement struct {
 	Selects              []string          // selected columns
 	Omits                []string          // omit columns
 	ColumnMapping        map[string]string // map columns
-	Joins                []join
+	Joins                []Join
 	Preloads             map[string][]interface{}
 	Settings             sync.Map
 	ConnPool             ConnPool
@@ -49,7 +49,7 @@ type Statement struct {
 	scopes               []func(*DB) *DB
 }
 
-type join struct {
+type Join struct {
 	Name     string
 	Conds    []interface{}
 	On       *clause.Where
@@ -538,7 +538,7 @@ func (stmt *Statement) clone() *Statement {
 	}
 
 	if len(stmt.Joins) > 0 {
-		newStmt.Joins = make([]join, len(stmt.Joins))
+		newStmt.Joins = make([]Join, len(stmt.Joins))
 		copy(newStmt.Joins, stmt.Joins)
 	}
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -11,7 +11,7 @@ require (
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/driver/sqlite v1.5.6
 	gorm.io/driver/sqlserver v1.5.3
-	gorm.io/gorm v1.25.10
+	gorm.io/gorm v1.25.11
 )
 
 require (


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

In MySQL, delete supports inner joins (but not left joins).
This PR does two things to make it possible for us to use `InnerJoin` to build a clause into our delete SQL statements.
1. Abstract the join logic from `query.go` into `join.go` to allow it to be re-used in delete (now) and possibly in update (in future work).
2. Use the join logic in delete, and add table name after the `DELETE ` keyword.

The problems with this PR:
1. It does not check if the join is an `InnerJoins` or a `Joins` - so this will build `DELETE t FROM t LEFT JOIN r WHERE ...;` statements if it is passed a normal left join - when this is invalid SQL. The logic should be upgraded to silently discard the join, or emit an error that says `"You cannot left join in a delete statement. Maybe you meant to inner join instead?"`.
2. Tries to make the least amount of changes possible. This is why the introduced `HandleJoins` function takes two callback arguments - to make it very faithful to what initially happened in `query.go` and ensure no regressions.
3. It does not introduce a test. I tried it out and it works, but it should introduce a test.

I'm reluctant to solve those three problems until a contributor goes through the logic and verifies that the work done is meaningful. If that's the case, we can have a discussion about the organization of the code, and error handling / silent discarding of clause for left joins, and once the logic is finalized, I'll introduce tests for it.

### User Case Description

```
// Delete a ModelB based on the value of a column in TableA
db.InnerJoins("TableA").Where("TableA.columnA in ?", values).Delete(&ModelB { ID: someID });
```