### PR TITLE
feat: `BeforeUpdate` hook supports update using struct field value

### DIFF
--- a/tests/hooks_test.go
+++ b/tests/hooks_test.go
@@ -649,4 +649,7 @@ func TestBeforeUpdateWithStructColumn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("find struct failed: %v", err)
 	}
+	if su.Version != 2 {
+		t.Errorf("find version failed: %v", su.Version)
+	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
In the `BeforeUpdate` hook function, if the structure field value is updated and the field has the `gorm:"column:field_name"` set, the field is updated in SQL

### User Case Description
- Code:
```go
type User struct {
	ID      int64 `gorm:"column:id;primary_key"`
	Version int64 `gorm:"column:version"`
	UserID  int64 `gorm:"column:user_id"`
}

// BeforeUpdate gorm hook
func (u *User) BeforeUpdate(*gorm.DB) error {
	u.Version = time.Now().Unix()
	return nil
}

func Update() error {
	return DB().Model(&User{}).Where("id = ?", 1).Update("user_id", 312123).Error
}
```
- Expected Output:
```sql
UPDATE `user` SET `version`=1724247677,`user_id`=312123 WHERE id = 1
```
<!-- Your use case -->
