### PR TITLE
Generate unique savepoint names for nested transactions

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -29,8 +29,8 @@ require (
 	github.com/microsoft/go-mssqldb v1.7.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	golang.org/x/crypto v0.24.0 // indirect
-	golang.org/x/text v0.16.0 // indirect
+	golang.org/x/crypto v0.26.0 // indirect
+	golang.org/x/text v0.17.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This test changes `SAVEPOINT` names from relying on the memory address of the callback (which can cause unexpected issues with partial rollbacks), to using a random integer.

The integer is generated using `maphash.Hash`, which is used as that internally relies on `runtime.fastrand`, which is the most performant way to get a random integer.

I've ensured the test fails without my code changes, and passes with them applied.

### Use Case Description

Covered in https://github.com/go-gorm/gorm/issues/7173