### PR TITLE
Fixed "*DB.Raw()" bug where single or double quotes containing '@' were incorrectly identified as named variables

### DIFF
--- a/clause/expression.go
+++ b/clause/expression.go
@@ -88,6 +88,7 @@ func (expr NamedExpr) Build(builder Builder) {
 		inName           bool
 		afterParenthesis bool
 		namedMap         = make(map[string]interface{}, len(expr.Vars))
+		quotationMarks   byte
 	)
 
 	for _, v := range expr.Vars {
@@ -124,6 +125,14 @@ func (expr NamedExpr) Build(builder Builder) {
 	name := make([]byte, 0, 10)
 
 	for _, v := range []byte(expr.SQL) {
+		if quotationMarks == v && (v == '"' || v == '\'') {
+			quotationMarks = 0
+		} else if quotationMarks == 0 && (v == '"' || v == '\'') {
+			quotationMarks = v
+		} else if quotationMarks == '"' || quotationMarks == '\'' {
+			builder.WriteByte(v)
+			continue
+		}
 		if v == '@' && !inName {
 			inName = true
 			name = name[:0]

--- a/tests/raw_test.go
+++ b/tests/raw_test.go
@@ -1,0 +1,110 @@
+package tests_test
+
+import (
+	. "gorm.io/gorm/utils/tests"
+	"testing"
+)
+
+func TestRawSelect(t *testing.T) {
+	users := []User{
+		*GetUser("raw1", Config{}),
+		*GetUser("raw2", Config{}),
+		*GetUser("raw3", Config{}),
+		*GetUser("@name", Config{}),
+		*GetUser("@age", Config{}),
+	}
+
+	if err := DB.Create(&users).Error; err != nil {
+		t.Fatalf("errors happened when create users: %v", err)
+	}
+	tests := []struct {
+		TestName string
+		Sql      string
+		args     map[string]interface{}
+		Expect   []User
+		errFlag  bool
+	}{
+		{
+			"raw_test1",
+			`select * from users where name like @name and age = 18`,
+			map[string]interface{}{
+				"name": "raw1",
+			},
+			[]User{
+				users[0],
+			},
+			false,
+		},
+		{
+			"raw_test2",
+			`select * from users where name like @name and age = 18`,
+			map[string]interface{}{
+				"name": "@name",
+			},
+			[]User{
+				users[3],
+			},
+			false,
+		},
+		{
+			"raw_test3",
+			`select * from users where name like @name and age = 18`,
+			map[string]interface{}{
+				"name": "@age",
+			},
+			[]User{
+				users[4],
+			},
+			false,
+		},
+		{
+			"raw_test4",
+			`select * from users where name like "@name" and age = 18`,
+			map[string]interface{}{
+				"name": "raw1",
+			},
+			[]User{
+				users[3],
+			},
+			false,
+		},
+		{
+			"raw_test5",
+			`select * from users where name like "@name" and age = 18`,
+			map[string]interface{}{
+				"name": "@raw",
+			},
+			[]User{
+				users[3],
+			},
+			false,
+		},
+		{
+			"raw_test6",
+			`select * from users where name like "@name" and age = 18`,
+			map[string]interface{}{
+				"name": "@age",
+			},
+			[]User{
+				users[3],
+			},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			var results []User
+			if err := DB.Raw(test.Sql, test.args).Scan(&results).Error; err != nil && !test.errFlag {
+				t.Errorf("errors %s: %v", test.TestName, err)
+			} else {
+				if len(results) != len(test.Expect) {
+					t.Errorf("errors %s: %v", test.TestName, err)
+				} else {
+					for i := 0; i < len(results); i++ {
+						CheckUser(t, results[i], test.Expect[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/tests/raw_test.go
+++ b/tests/raw_test.go
@@ -55,7 +55,7 @@ func TestRawSelect(t *testing.T) {
 		},
 		{
 			"raw_test4",
-			`select * from users where name like "raw3" and age = @age`,
+			`select * from users where name like 'raw3' and age = @age`,
 			map[string]interface{}{
 				"age": 18,
 			},
@@ -65,7 +65,7 @@ func TestRawSelect(t *testing.T) {
 		},
 		{
 			"raw_test5",
-			`select * from users where name like "@name" and age = @age`,
+			`select * from users where name like '@name' and age = @age`,
 			map[string]interface{}{
 				"age": 18,
 			},
@@ -75,7 +75,7 @@ func TestRawSelect(t *testing.T) {
 		},
 		{
 			"raw_test6",
-			`select * from users where name like "@age" and age = @age`,
+			`select * from users where name like '@age' and age = @age`,
 			map[string]interface{}{
 				"age": 18,
 			},

--- a/tests/raw_test.go
+++ b/tests/raw_test.go
@@ -55,19 +55,19 @@ func TestRawSelect(t *testing.T) {
 		},
 		{
 			"raw_test4",
-			`select * from users where name like "@name" and age = 18`,
+			`select * from users where name like "raw3" and age = @age`,
 			map[string]interface{}{
-				"name": "raw1",
+				"age": 18,
 			},
 			[]User{
-				users[3],
+				users[2],
 			},
 		},
 		{
 			"raw_test5",
-			`select * from users where name like "@name" and age = 18`,
+			`select * from users where name like "@name" and age = @age`,
 			map[string]interface{}{
-				"name": "@raw",
+				"age": 18,
 			},
 			[]User{
 				users[3],
@@ -75,12 +75,12 @@ func TestRawSelect(t *testing.T) {
 		},
 		{
 			"raw_test6",
-			`select * from users where name like "@name" and age = 18`,
+			`select * from users where name like "@age" and age = @age`,
 			map[string]interface{}{
-				"name": "@age",
+				"age": 18,
 			},
 			[]User{
-				users[3],
+				users[4],
 			},
 		},
 	}

--- a/tests/raw_test.go
+++ b/tests/raw_test.go
@@ -22,7 +22,6 @@ func TestRawSelect(t *testing.T) {
 		Sql      string
 		args     map[string]interface{}
 		Expect   []User
-		errFlag  bool
 	}{
 		{
 			"raw_test1",
@@ -33,7 +32,6 @@ func TestRawSelect(t *testing.T) {
 			[]User{
 				users[0],
 			},
-			false,
 		},
 		{
 			"raw_test2",
@@ -44,7 +42,6 @@ func TestRawSelect(t *testing.T) {
 			[]User{
 				users[3],
 			},
-			false,
 		},
 		{
 			"raw_test3",
@@ -55,7 +52,6 @@ func TestRawSelect(t *testing.T) {
 			[]User{
 				users[4],
 			},
-			false,
 		},
 		{
 			"raw_test4",
@@ -66,7 +62,6 @@ func TestRawSelect(t *testing.T) {
 			[]User{
 				users[3],
 			},
-			false,
 		},
 		{
 			"raw_test5",
@@ -77,7 +72,6 @@ func TestRawSelect(t *testing.T) {
 			[]User{
 				users[3],
 			},
-			false,
 		},
 		{
 			"raw_test6",
@@ -88,13 +82,12 @@ func TestRawSelect(t *testing.T) {
 			[]User{
 				users[3],
 			},
-			false,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.TestName, func(t *testing.T) {
 			var results []User
-			if err := DB.Raw(test.Sql, test.args).Scan(&results).Error; err != nil && !test.errFlag {
+			if err := DB.Raw(test.Sql, test.args).Scan(&results).Error; err != nil {
 				t.Errorf("errors %s: %v", test.TestName, err)
 			} else {
 				if len(results) != len(test.Expect) {


### PR DESCRIPTION
- [*] Do only one thing
- [*] Non breaking API changes
- [*] Tested

### What did this pull request do?

Fixed "*DB.Raw()"  has a bug where single or double quotes containing '@' are incorrectly recognized as named variables.
When I call the Raw method, if the SQL contains a quote wrapped ` @ `, then this ` @ ` will not be treated as part of the string, but as a named parameter. I have increased the judgment of quotation marks to ensure that the content inside the quotation marks will not be recognized as distinctive symbols.

### User Case Description
Values
``` go
values := map[string]interface{}{
	"email": `%qq.com`,
}
```
Origin
``` sql
select * from users where email like @email and name = "@email"
```
Result
``` shell
D:/go/src/runtime/proc.go:271 sql: expected 1 arguments, got 2
[21.008ms] [rows:-] select * from users where email like '%qq.com' and name = "'%qq.com'"
```

#### After repair

Result
``` shell
D:/go/src/runtime/proc.go:271
[29.642ms] [rows:0] select * from users where email like '%qq.com' and name = "@email"
```
