### PR TITLE
Allow session config naming override

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -118,6 +118,7 @@ type Session struct {
 	Logger                   logger.Interface
 	NowFunc                  func() time.Time
 	CreateBatchSize          int
+	NamingStrategy           *schema.NamingStrategy
 }
 
 // Open initialize db session based on dialector
@@ -290,6 +291,10 @@ func (db *DB) Session(config *Session) *DB {
 
 	if config.DisableNestedTransaction {
 		txConfig.DisableNestedTransaction = true
+	}
+
+	if config.NamingStrategy != nil {
+		txConfig.NamingStrategy = config.NamingStrategy
 	}
 
 	if !config.NewDB {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Allows naming strategy to change on the fly. This is helpful when you may want to dynamically alter the naming strategy for individual struct without changing the behavior everywhere.

### User Case Description

Change naming strategy for individual structs/db transactions/sessions.
