### PR TITLE
refactor: improve logging for unimplemented ErrorTranslator in TranlateError config enabled

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -189,6 +189,12 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 				_ = db.Close()
 			}
 		}
+
+		if config.TranslateError {
+			if _, ok := db.Dialector.(ErrorTranslator); !ok {
+				config.Logger.Warn(context.Background(), "The TranslateError option is enabled, but the Dialector %s does not implement ErrorTranslator.", db.Dialector.Name())
+			}
+		}
 	}
 
 	if config.PrepareStmt {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested
  - test if the dummyDialector has no `Translate()`, occur warning log. (in `TestDialectorWithErrorTranslatorSupport()`)

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
If the user's config conficts with db driver's dialector implementation, a warning log will be generate to heldy identify the issue.
### User Case Description

<!-- Your use case -->
I enable `TranslateError` config as true, but my MySQL DB driver (version:1.4.7) doesn't implement `Transalte()` method.
Therefore, I had trouble identifying this situation. I think log information is necessary.