### PR TITLE
use map look-up for indexes

### DIFF
--- a/schema/index.go
+++ b/schema/index.go
@@ -76,11 +76,12 @@ func (schema *Schema) ParseIndexes() map[string]Index {
 func (schema *Schema) LookIndex(name string) *Index {
 	if schema != nil {
 		indexes := schema.ParseIndexes()
-		for _, index := range indexes {
-			if index.Name == name {
-				return &index
-			}
 
+		if index, found := indexes[name]; found {
+			return &index
+		}
+
+		for _, index := range indexes {
 			for _, field := range index.Fields {
 				if field.Name == name {
 					return &index
@@ -111,10 +112,7 @@ func parseFieldIndexes(field *Field) (indexes []Index, err error) {
 					idx = len(tag)
 				}
 
-				if idx != -1 {
-					name = tag[0:idx]
-				}
-
+				name = tag[0:idx]
 				if name == "" {
 					subName := field.Name
 					const key = "COMPOSITE"

--- a/schema/index_test.go
+++ b/schema/index_test.go
@@ -21,6 +21,9 @@ type UserIndex struct {
 	Name7        string `gorm:"index:type"`
 	Name8        string `gorm:"index:,length:10;index:,collate:utf8"`
 
+	CompName1 string `gorm:"index:,unique,composite:idx_compname_1,option:NULLS NOT DISTINCT;not null"`
+	CompName2 string `gorm:"index:,composite:idx_compname_1"`
+
 	// Composite Index: Flattened structure.
 	Data0A string `gorm:"index:,composite:comp_id0"`
 	Data0B string `gorm:"index:,composite:comp_id0"`
@@ -154,6 +157,15 @@ func TestParseIndex(t *testing.T) {
 				Field: &schema.Field{Name: "Data2B"},
 			}},
 		},
+		"idx_user_indices_idx_compname_1": {
+			Class:  "UNIQUE",
+			Name:   "idx_user_indices_idx_compname_1",
+			Option: "NULLS NOT DISTINCT",
+			Fields: []schema.IndexOption{
+				{Field: &schema.Field{Name: "CompName1", NotNull: true}},
+				{Field: &schema.Field{Name: "CompName2"}},
+			},
+		},
 	}
 
 	CheckIndices(t, results, user.ParseIndexes())
@@ -253,7 +265,7 @@ func CheckIndices(t *testing.T, expected, actual map[string]schema.Index) {
 			}
 			for i, ef := range ei.Fields {
 				af := ai.Fields[i]
-				tests.AssertObjEqual(t, af, ef, "Name", "Unique", "UniqueIndex", "Expression", "Sort", "Collate", "Length")
+				tests.AssertObjEqual(t, af, ef, "Name", "Unique", "UniqueIndex", "Expression", "Sort", "Collate", "Length", "NotNull")
 			}
 		})
 		delete(actual, k)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ X] Do only one thing
- [ X] Non breaking API changes
- [ X] Tested

### What did this pull request do?

Changing the implementation of `schema.LookIndex` to use map's two-value assignment tests for the existence of a key when looking for an index before switching to field lookup for performance.

### User Case Description

The existing implementation of `Schema.LookIndex` uses linear search (in the best case) instead of using map test using const-time before falling back to a linear scan.
The new implementation has a performance advantage for cases with many indexes.