### PR TITLE
fix: update incorrect default name when parse dest model field.

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -125,7 +125,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		Readable:               true,
 		PrimaryKey:             utils.CheckTruth(tagSetting["PRIMARYKEY"], tagSetting["PRIMARY_KEY"]),
 		AutoIncrement:          utils.CheckTruth(tagSetting["AUTOINCREMENT"]),
-		HasDefaultValue:        utils.CheckTruth(tagSetting["AUTOINCREMENT"]),
+		HasDefaultValue:        utils.CheckTruth(tagSetting["DEFAULT"]),
 		NotNull:                utils.CheckTruth(tagSetting["NOT NULL"], tagSetting["NOTNULL"]),
 		Unique:                 utils.CheckTruth(tagSetting["UNIQUE"]),
 		Comment:                tagSetting["COMMENT"],


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

it correctly update Field.HasDefaultValue field value when using Schema.ParseField method to init the field.

### User Case Description

<!-- Your use case -->
