### PR TITLE
fix: table not change (#6913)

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -490,7 +490,7 @@ func (stmt *Statement) Parse(value interface{}) (err error) {
 }
 
 func (stmt *Statement) ParseWithSpecialTableName(value interface{}, specialTableName string) (err error) {
-	if stmt.Schema, err = schema.ParseWithSpecialTableName(value, stmt.DB.cacheStore, stmt.DB.NamingStrategy, specialTableName); err == nil && stmt.Table == "" {
+	if stmt.Schema, err = schema.ParseWithSpecialTableName(value, stmt.DB.cacheStore, stmt.DB.NamingStrategy, specialTableName); err == nil {
 		if tables := strings.Split(stmt.Schema.Table, "."); len(tables) == 2 {
 			stmt.TableExpr = &clause.Expr{SQL: stmt.Quote(stmt.Schema.Table)}
 			stmt.Table = tables[1]


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
__Update Condition for Table Selection:__ This change allows `ParseWithSpecialTableName` to re-evaluate and update the table name based on the value passed, not just when the table name is initially empty.

### User Case Description
When you use embedded structures, you might write queries like this
```go
type StatisticBase struct {
    Date          time.Time
    Amount, Count int
}

type IncomeStatistic struct {
    StatisticBase
    Tas    int
    UserId uint
}

type ExpendStatistic struct {
    StatisticBase
    UserId uint
}

type Total struct{ Amount, Count int }

type Statistic struct{ Income, Expend Total }

func queryStatistic(db *gorm.DB, start, end time.Time) (result Statistic, err error) {
    query := db.Where("date BETWEEN ? AND ?", start, end)
    query = query.Select("SUM(amount) as Amount,SUM(count) as Count")
    err = query.Model(&IncomeStatistic{}).Scan(&result.Income).Error
    if err != nil {
        return
    }
    err = query.Model(&ExpendStatistic{}).Scan(&result.Expend).Error
    return
}
```
But the table for the second query did not change.

```mysql
SELECT SUM(amount) as Amount,SUM(count) as Count FROM `income_statistic` WHERE date BETWEEN '2024-11-03 09:38:53.615' AND '2024-11-08 09:38:53.615';
SELECT SUM(amount) as Amount,SUM(count) as Count FROM `income_statistic` WHERE date BETWEEN '2024-11-03 09:38:53.615' AND '2024-11-08 09:38:53.615';
```
Since the table is only updated when empty, this is what the "pull request" wants to change, which will give the user more flexibility to manipulate the data as needed.
