### PR TITLE
fix: For time type, the time field will be automatically updated. Eve…

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -543,7 +543,7 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 		} else if currentDefaultNotNull || dvNotNull {
 			switch field.GORMDataType {
 			case schema.Time:
-				if !strings.EqualFold(strings.TrimSuffix(dv, "()"), strings.TrimSuffix(field.DefaultValue, "()")) {
+				if !strings.EqualFold(strings.Split(dv, "(")[0], strings.Split(field.DefaultValue, "(")[0]) {
 					alterColumn = true
 				}
 			case schema.Bool:


### PR DESCRIPTION

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

fix: For time type, the time field will be automatically updated. Even if the table structure is not changed, the table modification operation will be repeated.

fix:时间类型，自动更新时间字段会。表结构没改动，也会重复 执行改表操作。

### User Case Description

// Table Structure
// 表结构
`type CreateUpdateTimeAt struct {
	CreatedAt time.Time `gorm:"column:created_at;type:timestamp(3);default:CURRENT_TIMESTAMP(3);index:created_idx;;" json:"created_at"`              
	UpdatedAt time.Time `gorm:"column:updated_at;type:timestamp(3);default:CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3);" json:"updated_at"`
}`

// SQL to modify the table. Even if the table is not modified, it will be executed every time.
// 改表的SQL。表没改动，每次也会执行。
2024/12/12 16:15:50 /xxxx/service_context.go:46
`[118.788ms] [rows:0] ALTER TABLE `tenant_third_config` MODIFY COLUMN `updated_at` timestamp(3) DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) `
