### PR TITLE
Handle postgres array

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -20,6 +20,10 @@ type Dialector interface {
 	Explain(sql string, vars ...interface{}) string
 }
 
+type ArrayValueHandler interface {
+	HandleArray(field *schema.Field) error
+}
+
 // Plugin GORM plugin interface
 type Plugin interface {
 	Name() string

--- a/schema/field.go
+++ b/schema/field.go
@@ -47,6 +47,7 @@ const (
 	String DataType = "string"
 	Time   DataType = "time"
 	Bytes  DataType = "bytes"
+	Array  DataType = "array"
 )
 
 const DefaultAutoIncrementIncrement int64 = 1
@@ -282,6 +283,10 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 	case reflect.Array, reflect.Slice:
 		if reflect.Indirect(fieldValue).Type().Elem() == ByteReflectType && field.DataType == "" {
 			field.DataType = Bytes
+		} else {
+			elemType := reflect.Indirect(fieldValue).Type().Elem()
+			field.DataType = Array
+			field.TagSettings["ELEM_TYPE"] = elemType.Kind().String()
 		}
 	}
 
@@ -976,6 +981,10 @@ func (field *Field) setupValuerAndSetter() {
 			}
 			return
 		}
+	}
+
+	if field.DataType != "" && field.FieldType.Kind() == reflect.Slice && field.FieldType.Elem().Kind() != reflect.Uint8 {
+		field.TagSettings["ARRAY_FIELD"] = "true"
 	}
 }
 

--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -48,6 +48,7 @@ func init() {
 
 func OpenTestConnection(cfg *gorm.Config) (db *gorm.DB, err error) {
 	dbDSN := os.Getenv("GORM_DSN")
+	enableArrayHandler := os.Getenv("GORM_ENABLE_ARRAY_HANDLER")
 	switch os.Getenv("GORM_DIALECT") {
 	case "mysql":
 		log.Println("testing mysql...")
@@ -63,6 +64,7 @@ func OpenTestConnection(cfg *gorm.Config) (db *gorm.DB, err error) {
 		db, err = gorm.Open(postgres.New(postgres.Config{
 			DSN:                  dbDSN,
 			PreferSimpleProtocol: true,
+			EnableArrayHandler:   enableArrayHandler == "true",
 		}), cfg)
 	case "sqlserver":
 		// go install github.com/microsoft/go-sqlcmd/cmd/sqlcmd@latest


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

Basically, this is the continuation of the changes on postgres driver part: https://github.com/go-gorm/postgres/pull/296

Hi @jinzhu and team, please review when you have a moment. Any feedbacks are welcome. Thanks!

### What did this pull request do?
Handle postgres array types

### User Case Description
Currently, when we we have column with array type in postgres database, we need to use or create custom type in our go program so that our program (with gorm) can map the type from/to database.

For example, we can't do this by default, because gorm will throw something like `unsupported data type: &[]`

```
type Country string

type Player struct {
	...
	Country               []Country `gorm:"type:text[]"`
}
```

we need to create custom type, for instance: 

```
type CountryArray []Country

func (a *CountryArray) Scan(src interface{}) error {
	var asBytes []byte
	switch v := src.(type) {
	case []byte:
		asBytes = v
	case string:
		asBytes = []byte(v)
	default:
		return errors.New("Scan source was not []bytes or string")
	}

	str := string(asBytes)
	parsed := strings.Trim(str, "{}")
	split := strings.Split(parsed, ",")

	*a = make(CountryArray, 0)
	for _, s := range split {
		if s == "" {
			continue
		}
		day, err := value_object.NewDayOfWeekFromString(s)
		if err != nil {
			return err
		}
		*a = append(*a, *day)
	}

	return nil
}

func (a CountryArray) Value() (driver.Value, error) {
	strArr := make([]string, len(a))
	for i, day := range a {
		strArr[i] = day.String()
	}
	return "{" + strings.Join(strArr, ",") + "}", nil
}
```

Then, use it in the model
```
type Country string

type Player struct {
	...
	Country               CountryArray `gorm:"type:text[]"`
}
```

---

By this PR, we can just implement like this, without having to use/create custom type for each array column
```
type Country string

type Player struct {
	...
	Country               []Country `gorm:"type:text[]"`
}
```
to achieve this, we just need to enable it via config
```
postgres.Config{
	...,
	EnableArrayHandler:   true,
}
```

### Compatibility and Tests

The logic of array handling is placed specifically on postgres driver so that gorm core remains clean, extensible, and database-agnostic. Since a new gorm core test case depends on new changes on postgres driver (which is new config attribute), we need to make sure that changes on postgres driver must be merged before changes on gorm core. However, it is fine if they are not merged simulatenously since this is backward compatible

<details><summary>Tests</summary>
New gorm core using new postgres driver
<img width="800" alt="Screenshot 2025-01-01 at 16 00 46" src="https://github.com/user-attachments/assets/473cfcc7-c18e-48a8-891c-ed8ed14ea28d" />

Existing gorm core using new postgres driver
<img width="929" alt="Screenshot 2025-01-01 at 16 04 26" src="https://github.com/user-attachments/assets/fdf470dd-b8e6-4c3e-a64f-594a5296022b" />

</details> 

