### PR TITLE
fix(limit): set default limit to math.MaxInt when only offset is provided

### DIFF
--- a/clause/limit.go
+++ b/clause/limit.go
@@ -1,18 +1,28 @@
 package clause
 
-// Limit limit clause
+import (
+	"math"
+)
+
+// Limit represents a limit clause
 type Limit struct {
 	Limit  *int
 	Offset int
 }
 
-// Name where clause name
+// Name returns the name of the clause ("LIMIT")
 func (limit Limit) Name() string {
 	return "LIMIT"
 }
 
-// Build build where clause
+// Build constructs the LIMIT clause
 func (limit Limit) Build(builder Builder) {
+	// If only offset is defined and limit is nil, set limit to math.MaxInt
+	if limit.Limit == nil && limit.Offset > 0 {
+		maxInt := math.MaxInt
+		limit.Limit = &maxInt
+	}
+
 	if limit.Limit != nil && *limit.Limit >= 0 {
 		builder.WriteString("LIMIT ")
 		builder.AddVar(builder, *limit.Limit)
@@ -26,7 +36,7 @@ func (limit Limit) Build(builder Builder) {
 	}
 }
 
-// MergeClause merge order by clauses
+// MergeClause merges two limit clauses
 func (limit Limit) MergeClause(clause *Clause) {
 	clause.Name = ""
 

--- a/clause/limit_test.go
+++ b/clause/limit_test.go
@@ -13,68 +13,119 @@ func TestLimit(t *testing.T) {
 	limit10 := 10
 	limit50 := 50
 	limitNeg10 := -10
+
 	results := []struct {
 		Clauses []clause.Interface
 		Result  string
 		Vars    []interface{}
 	}{
+		// case #0 - limit10 offset20
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{
-				Limit:  &limit10,
-				Offset: 20,
-			}},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				clause.Limit{Limit: &limit10, Offset: 20},
+			},
 			"SELECT * FROM `users` LIMIT ? OFFSET ?",
 			[]interface{}{limit10, 20},
 		},
+		// case #1 - limit0
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Limit: &limit0}},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				clause.Limit{Limit: &limit0},
+			},
 			"SELECT * FROM `users` LIMIT ?",
 			[]interface{}{limit0},
 		},
+		// case #2 - limit0 offset0 => offset0 is effectively ignored
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Limit: &limit0}, clause.Limit{Offset: 0}},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				clause.Limit{Limit: &limit0}, clause.Limit{Offset: 0},
+			},
 			"SELECT * FROM `users` LIMIT ?",
 			[]interface{}{limit0},
 		},
+		// case #3 - only offset=20
+		// MySQL demands limit if offset>0 => math.MaxInt
 		{
-			// Updated test case: only Offset is given, so now we expect math.MaxInt as LIMIT
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Offset: 20}},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				clause.Limit{Offset: 20},
+			},
 			"SELECT * FROM `users` LIMIT ? OFFSET ?",
 			[]interface{}{math.MaxInt, 20},
 		},
+		// case #4 - multiple offsets (20 -> 30)
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Offset: 20}, clause.Limit{Offset: 30}},
-			"SELECT * FROM `users` OFFSET ?",
-			[]interface{}{30},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				clause.Limit{Offset: 20}, clause.Limit{Offset: 30},
+			},
+			"SELECT * FROM `users` LIMIT ? OFFSET ?",
+			[]interface{}{math.MaxInt, 30},
 		},
+		// case #5 - merge offset20 with limit10
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Offset: 20}, clause.Limit{Limit: &limit10}},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				clause.Limit{Offset: 20}, clause.Limit{Limit: &limit10},
+			},
 			"SELECT * FROM `users` LIMIT ? OFFSET ?",
 			[]interface{}{limit10, 20},
 		},
+		// case #6 - merge offset20->30 with limit10
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Limit: &limit10, Offset: 20}, clause.Limit{Offset: 30}},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				clause.Limit{Limit: &limit10, Offset: 20},
+				clause.Limit{Offset: 30},
+			},
 			"SELECT * FROM `users` LIMIT ? OFFSET ?",
 			[]interface{}{limit10, 30},
 		},
+		// case #7 - negative offset => offset=0 => "SELECT * FROM `users` LIMIT 10"
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Limit: &limit10, Offset: 20}, clause.Limit{Offset: 30}, clause.Limit{Offset: -10}},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				clause.Limit{Limit: &limit10, Offset: 20},
+				clause.Limit{Offset: 30},
+				clause.Limit{Offset: -10},
+			},
 			"SELECT * FROM `users` LIMIT ?",
 			[]interface{}{limit10},
 		},
+		// case #8 - negative limit => treat as nil => offset=30 => => "LIMIT ? OFFSET ?"
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Limit: &limit10, Offset: 20}, clause.Limit{Offset: 30}, clause.Limit{Limit: &limitNeg10}},
-			"SELECT * FROM `users` OFFSET ?",
-			[]interface{}{30},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				// Start with limit10 offset20
+				clause.Limit{Limit: &limit10, Offset: 20},
+				// Then change offset to 30
+				clause.Limit{Offset: 30},
+				// Then set limit to negative => remove limit => offset>0 => limit=math.MaxInt
+				clause.Limit{Limit: &limitNeg10},
+			},
+			"SELECT * FROM `users` LIMIT ? OFFSET ?",
+			[]interface{}{math.MaxInt, 30},
 		},
+		// case #9 - changing limit from 10 -> 50, offset=30
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Limit: &limit10, Offset: 20}, clause.Limit{Offset: 30}, clause.Limit{Limit: &limit50}},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				clause.Limit{Limit: &limit10, Offset: 20},
+				clause.Limit{Offset: 30},
+				clause.Limit{Limit: &limit50},
+			},
 			"SELECT * FROM `users` LIMIT ? OFFSET ?",
 			[]interface{}{limit50, 30},
 		},
-		// New test example: if only Offset is defined, Limit should become math.MaxInt
+		// case #10 - only offset=100 => "LIMIT ? OFFSET ?", math.MaxInt, 100
 		{
-			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Offset: 100}},
+			[]clause.Interface{
+				clause.Select{}, clause.From{},
+				clause.Limit{Offset: 100},
+			},
 			"SELECT * FROM `users` LIMIT ? OFFSET ?",
 			[]interface{}{math.MaxInt, 100},
 		},

--- a/clause/limit_test.go
+++ b/clause/limit_test.go
@@ -2,6 +2,7 @@ package clause_test
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"gorm.io/gorm/clause"
@@ -36,9 +37,10 @@ func TestLimit(t *testing.T) {
 			[]interface{}{limit0},
 		},
 		{
+			// Updated test case: only Offset is given, so now we expect math.MaxInt as LIMIT
 			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Offset: 20}},
-			"SELECT * FROM `users` OFFSET ?",
-			[]interface{}{20},
+			"SELECT * FROM `users` LIMIT ? OFFSET ?",
+			[]interface{}{math.MaxInt, 20},
 		},
 		{
 			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Offset: 20}, clause.Limit{Offset: 30}},
@@ -69,6 +71,12 @@ func TestLimit(t *testing.T) {
 			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Limit: &limit10, Offset: 20}, clause.Limit{Offset: 30}, clause.Limit{Limit: &limit50}},
 			"SELECT * FROM `users` LIMIT ? OFFSET ?",
 			[]interface{}{limit50, 30},
+		},
+		// New test example: if only Offset is defined, Limit should become math.MaxInt
+		{
+			[]clause.Interface{clause.Select{}, clause.From{}, clause.Limit{Offset: 100}},
+			"SELECT * FROM `users` LIMIT ? OFFSET ?",
+			[]interface{}{math.MaxInt, 100},
 		},
 	}
 


### PR DESCRIPTION
## Description
This PR fixes an issue where MySQL requires both LIMIT and OFFSET to be provided when using OFFSET. When only OFFSET is specified, the LIMIT is now automatically set to math.MaxInt.

## Changes
- Updated Limit clause to use math.MaxInt when only offset is provided
- Updated existing tests to reflect new behavior
- Added new test cases to verify the behavior

## Related Issue
Fixes #7302

## Testing
- Added new test case for verifying behavior when only offset is provided
- All existing tests pass
- Manually tested with MySQL