### PR TITLE
fix: ensure ErrRecordNotFound is triggered on find queries

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -414,12 +414,13 @@ func (db *DB) getInstance() *DB {
 		if db.clone == 1 {
 			// clone with new statement
 			tx.Statement = &Statement{
-				DB:        tx,
-				ConnPool:  db.Statement.ConnPool,
-				Context:   db.Statement.Context,
-				Clauses:   map[string]clause.Clause{},
-				Vars:      make([]interface{}, 0, 8),
-				SkipHooks: db.Statement.SkipHooks,
+				DB:                   tx,
+				ConnPool:             db.Statement.ConnPool,
+				Context:              db.Statement.Context,
+				Clauses:              map[string]clause.Clause{},
+				Vars:                 make([]interface{}, 0, 8),
+				SkipHooks:            db.Statement.SkipHooks,
+				RaiseErrorOnNotFound: db.Statement.RaiseErrorOnNotFound,
 			}
 			if db.Config.PropagateUnscoped {
 				tx.Statement.Unscoped = db.Statement.Unscoped


### PR DESCRIPTION
This commit ensures that ErrRecordNotFound is properly triggered when using find queries with the RaiseErrorOnNotFound flag enabled, without the need for using `WithContext`.

fix issues #7354
