### PR TITLE
fix: prevent interface type array from causing runtime errors

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -19,10 +19,7 @@ func (db *DB) Create(value interface{}) (tx *DB) {
 	if db.CreateBatchSize > 0 {
 		return db.CreateInBatches(value, db.CreateBatchSize)
 	}
-
-	tx = db.getInstance()
-	tx.Statement.Dest = value
-	return tx.callbacks.Create().Execute(tx)
+	return db.create(value)
 }
 
 // CreateInBatches inserts value in batches of batchSize
@@ -63,11 +60,14 @@ func (db *DB) CreateInBatches(value interface{}, batchSize int) (tx *DB) {
 
 		tx.RowsAffected = rowsAffected
 	default:
-		tx = db.getInstance()
-		tx.Statement.Dest = value
-		tx = tx.callbacks.Create().Execute(tx)
+		db.create(value)
 	}
 	return
+}
+func (db *DB) create(value interface{}) (tx *DB) {
+	tx = db.getInstance()
+	tx.Statement.Dest = value
+	return tx.callbacks.Create().Execute(tx)
 }
 
 // Save updates value in database. If value doesn't contain a matching primary key, value is inserted.

--- a/scan.go
+++ b/scan.go
@@ -202,6 +202,9 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 		switch reflectValueType.Kind() {
 		case reflect.Array, reflect.Slice:
 			reflectValueType = reflectValueType.Elem()
+			if reflectValueType.Kind() == reflect.Interface && reflectValue.Len() > 0 {
+				reflectValueType = reflect.Indirect(reflectValue.Index(0)).Elem().Type()
+			}
 		}
 		isPtr := reflectValueType.Kind() == reflect.Ptr
 		if isPtr {
@@ -318,7 +321,9 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 				} else {
 					elem = reflect.New(reflectValueType)
 				}
-
+				if elem.Type().Kind() == reflect.Interface {
+					elem = elem.Elem()
+				}
 				db.scanIntoStruct(rows, elem, values, fields, joinFields)
 
 				if !update {

--- a/schema/field.go
+++ b/schema/field.go
@@ -462,7 +462,7 @@ func (field *Field) setupValuerAndSetter() {
 	default:
 		field.ValueOf = func(ctx context.Context, v reflect.Value) (interface{}, bool) {
 			v = reflect.Indirect(v)
-			if v.Kind() == reflect.Interface {
+			for v.Kind() == reflect.Interface {
 				v = reflect.Indirect(v)
 			}
 			for _, fieldIdx := range field.StructField.Index {

--- a/schema/field.go
+++ b/schema/field.go
@@ -462,6 +462,9 @@ func (field *Field) setupValuerAndSetter() {
 	default:
 		field.ValueOf = func(ctx context.Context, v reflect.Value) (interface{}, bool) {
 			v = reflect.Indirect(v)
+			if v.Kind() == reflect.Interface {
+				v = reflect.Indirect(v)
+			}
 			for _, fieldIdx := range field.StructField.Index {
 				if fieldIdx >= 0 {
 					v = v.Field(fieldIdx)

--- a/schema/field.go
+++ b/schema/field.go
@@ -462,7 +462,7 @@ func (field *Field) setupValuerAndSetter() {
 	default:
 		field.ValueOf = func(ctx context.Context, v reflect.Value) (interface{}, bool) {
 			v = reflect.Indirect(v)
-			for v.Kind() == reflect.Interface {
+			if v.Kind() == reflect.Interface {
 				v = reflect.Indirect(v)
 			}
 			for _, fieldIdx := range field.StructField.Index {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -136,8 +136,10 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 
 	for modelType.Kind() == reflect.Slice || modelType.Kind() == reflect.Array || modelType.Kind() == reflect.Ptr {
 		modelType = modelType.Elem()
+		if modelType.Kind() == reflect.Interface && value.Len() > 0 {
+			modelType = reflect.Indirect(value.Index(0)).Elem().Type()
+		}
 	}
-
 	if modelType.Kind() != reflect.Struct {
 		if modelType.PkgPath() == "" {
 			return nil, fmt.Errorf("%w: %+v", ErrUnsupportedDataType, dest)

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -791,3 +791,34 @@ func TestCreateFromMapWithTable(t *testing.T) {
 		t.Errorf("failed to create data from map with table, @id != id")
 	}
 }
+
+func TestCreateWithInterfaceType(t *testing.T) {
+	user := *GetUser("create", Config{})
+	type UserInterface interface{}
+	var userInterface UserInterface = &user
+	
+	if results := DB.Create(userInterface); results.Error != nil {
+		t.Fatalf("errors happened when create: %v", results.Error)
+	} else if results.RowsAffected != 1 {
+		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)
+	}
+
+	if user.ID == 0 {
+		t.Errorf("user's primary key should has value after create, got : %v", user.ID)
+	}
+
+	if user.CreatedAt.IsZero() {
+		t.Errorf("user's created at should be not zero")
+	}
+
+	if user.UpdatedAt.IsZero() {
+		t.Errorf("user's updated at should be not zero")
+	}
+
+	var newUser User
+	if err := DB.Where("id = ?", user.ID).First(&newUser).Error; err != nil {
+		t.Fatalf("errors happened when query: %v", err)
+	} else {
+		CheckUser(t, newUser, user)
+	}
+}

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -847,7 +847,7 @@ func TestCreateWithInterfaceArrayTypeWithTable(t *testing.T) {
 	}
 
 	var newUser User
-	if err := DB.Where("id = ?", user.ID).First(&newUser).Error; err != nil {
+	if err := DB.Table("users").Where("id = ?", user.ID).First(&newUser).Error; err != nil {
 		t.Fatalf("errors happened when query: %v", err)
 	} else {
 		CheckUser(t, newUser, user)

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -823,12 +823,12 @@ func TestCreateWithInterfaceType(t *testing.T) {
 	}
 }
 
-func TestCreateWithInterfaceArrayType(t *testing.T) {
+func TestCreateWithInterfaceArrayTypeWithTable(t *testing.T) {
 	user := *GetUser("create", Config{})
 	type UserInterface interface{}
 	var userInterface UserInterface = &user
 
-	if results := DB.Create([]UserInterface{userInterface}); results.Error != nil {
+	if results := DB.Table("users").Create([]UserInterface{userInterface}); results.Error != nil {
 		t.Fatalf("errors happened when create: %v", results.Error)
 	} else if results.RowsAffected != 1 {
 		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -796,8 +796,39 @@ func TestCreateWithInterfaceType(t *testing.T) {
 	user := *GetUser("create", Config{})
 	type UserInterface interface{}
 	var userInterface UserInterface = &user
-	
+
 	if results := DB.Create(userInterface); results.Error != nil {
+		t.Fatalf("errors happened when create: %v", results.Error)
+	} else if results.RowsAffected != 1 {
+		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)
+	}
+
+	if user.ID == 0 {
+		t.Errorf("user's primary key should has value after create, got : %v", user.ID)
+	}
+
+	if user.CreatedAt.IsZero() {
+		t.Errorf("user's created at should be not zero")
+	}
+
+	if user.UpdatedAt.IsZero() {
+		t.Errorf("user's updated at should be not zero")
+	}
+
+	var newUser User
+	if err := DB.Where("id = ?", user.ID).First(&newUser).Error; err != nil {
+		t.Fatalf("errors happened when query: %v", err)
+	} else {
+		CheckUser(t, newUser, user)
+	}
+}
+
+func TestCreateWithInterfaceArrayType(t *testing.T) {
+	user := *GetUser("create", Config{})
+	type UserInterface interface{}
+	var userInterface UserInterface = &user
+
+	if results := DB.Create([]UserInterface{userInterface}); results.Error != nil {
 		t.Fatalf("errors happened when create: %v", results.Error)
 	} else if results.RowsAffected != 1 {
 		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -826,7 +826,7 @@ func TestCreateWithInterfaceType(t *testing.T) {
 func TestCreateWithInterfaceArrayTypeWithTable(t *testing.T) {
 	user := *GetUser("create", Config{})
 	type UserInterface interface{}
-	var userInterface UserInterface = &user
+	var userInterface UserInterface = user
 
 	if results := DB.Table("users").Create([]UserInterface{userInterface}); results.Error != nil {
 		t.Fatalf("errors happened when create: %v", results.Error)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [v] Tested

### What did this pull request do?
fix: prevent interface type array from causing runtime errors
It has been modified to find out the value when it is an interface array.
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
``` go
type UserInterface interface {
	GetName() string
}

db.Table("users").Create([]UserInterface{UserToUserInterface(&userData)})
```
In this case, create is allowed.