### PR TITLE
fix deprecated reflect.PtrTo reflect.PointerTo usage

### DIFF
--- a/callbacks/associations.go
+++ b/callbacks/associations.go
@@ -47,7 +47,7 @@ func SaveBeforeAssociations(create bool) func(db *gorm.DB) {
 					)
 
 					if !isPtr {
-						fieldType = reflect.PtrTo(fieldType)
+						fieldType = reflect.PointerTo(fieldType)
 					}
 
 					elems := reflect.MakeSlice(reflect.SliceOf(fieldType), 0, 10)
@@ -126,7 +126,7 @@ func SaveAfterAssociations(create bool) func(db *gorm.DB) {
 					)
 
 					if !isPtr {
-						fieldType = reflect.PtrTo(fieldType)
+						fieldType = reflect.PointerTo(fieldType)
 					}
 
 					elems := reflect.MakeSlice(reflect.SliceOf(fieldType), 0, 10)
@@ -195,7 +195,7 @@ func SaveAfterAssociations(create bool) func(db *gorm.DB) {
 				fieldType := rel.Field.IndirectFieldType.Elem()
 				isPtr := fieldType.Kind() == reflect.Ptr
 				if !isPtr {
-					fieldType = reflect.PtrTo(fieldType)
+					fieldType = reflect.PointerTo(fieldType)
 				}
 				elems := reflect.MakeSlice(reflect.SliceOf(fieldType), 0, 10)
 				identityMap := map[string]bool{}
@@ -268,11 +268,11 @@ func SaveAfterAssociations(create bool) func(db *gorm.DB) {
 				fieldType := rel.Field.IndirectFieldType.Elem()
 				isPtr := fieldType.Kind() == reflect.Ptr
 				if !isPtr {
-					fieldType = reflect.PtrTo(fieldType)
+					fieldType = reflect.PointerTo(fieldType)
 				}
 				elems := reflect.MakeSlice(reflect.SliceOf(fieldType), 0, 10)
 				distinctElems := reflect.MakeSlice(reflect.SliceOf(fieldType), 0, 10)
-				joins := reflect.MakeSlice(reflect.SliceOf(reflect.PtrTo(rel.JoinTable.ModelType)), 0, 10)
+				joins := reflect.MakeSlice(reflect.SliceOf(reflect.PointerTo(rel.JoinTable.ModelType)), 0, 10)
 				objs := []reflect.Value{}
 
 				appendToJoins := func(obj reflect.Value, elem reflect.Value) {

--- a/scan.go
+++ b/scan.go
@@ -15,7 +15,7 @@ func prepareValues(values []interface{}, db *DB, columnTypes []*sql.ColumnType, 
 	if db.Statement.Schema != nil {
 		for idx, name := range columns {
 			if field := db.Statement.Schema.LookUpField(name); field != nil {
-				values[idx] = reflect.New(reflect.PtrTo(field.FieldType)).Interface()
+				values[idx] = reflect.New(reflect.PointerTo(field.FieldType)).Interface()
 				continue
 			}
 			values[idx] = new(interface{})
@@ -23,7 +23,7 @@ func prepareValues(values []interface{}, db *DB, columnTypes []*sql.ColumnType, 
 	} else if len(columnTypes) > 0 {
 		for idx, columnType := range columnTypes {
 			if columnType.ScanType() != nil {
-				values[idx] = reflect.New(reflect.PtrTo(columnType.ScanType())).Interface()
+				values[idx] = reflect.New(reflect.PointerTo(columnType.ScanType())).Interface()
 			} else {
 				values[idx] = new(interface{})
 			}

--- a/schema/field.go
+++ b/schema/field.go
@@ -996,6 +996,6 @@ func (field *Field) setupNewValuePool() {
 	}
 
 	if field.NewValuePool == nil {
-		field.NewValuePool = poolInitializer(reflect.PtrTo(field.IndirectFieldType))
+		field.NewValuePool = poolInitializer(reflect.PointerTo(field.IndirectFieldType))
 	}
 }

--- a/schema/utils.go
+++ b/schema/utils.go
@@ -71,7 +71,7 @@ func appendSettingFromTag(tag reflect.StructTag, value string) reflect.StructTag
 // GetRelationsValues get relations's values from a reflect value
 func GetRelationsValues(ctx context.Context, reflectValue reflect.Value, rels []*Relationship) (reflectResults reflect.Value) {
 	for _, rel := range rels {
-		reflectResults = reflect.MakeSlice(reflect.SliceOf(reflect.PtrTo(rel.FieldSchema.ModelType)), 0, 1)
+		reflectResults = reflect.MakeSlice(reflect.SliceOf(reflect.PointerTo(rel.FieldSchema.ModelType)), 0, 1)
 
 		appendToResults := func(value reflect.Value) {
 			if _, isZero := rel.Field.ValueOf(ctx, value); !isZero {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non-breaking API changes
- [x] Tested

### What did this pull request do?
Fixed deprecated usage of `reflect.PtrTo` and replaced it with `reflect.PointerTo` for slice creation.

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
This fix addresses a deprecation warning related to `reflect.PtrTo`, ensuring compatibility with the latest Go versions. The change prevents potential issues with reflect-based model handling and improves maintainability.