### PR TITLE
feat: add BeforeFind hook

### DIFF
--- a/callbacks/callbacks.go
+++ b/callbacks/callbacks.go
@@ -48,6 +48,7 @@ func RegisterDefaultCallbacks(db *gorm.DB, config *Config) {
 	createCallback.Clauses = config.CreateClauses
 
 	queryCallback := db.Callback().Query()
+	queryCallback.Register("gorm:before_query", BeforeQuery)
 	queryCallback.Register("gorm:query", Query)
 	queryCallback.Register("gorm:preload", Preload)
 	queryCallback.Register("gorm:after_query", AfterQuery)

--- a/callbacks/interfaces.go
+++ b/callbacks/interfaces.go
@@ -34,6 +34,10 @@ type AfterDeleteInterface interface {
 	AfterDelete(*gorm.DB) error
 }
 
+type BeforeFindInterface interface {
+	BeforeFind(*gorm.DB) error
+}
+
 type AfterFindInterface interface {
 	AfterFind(*gorm.DB) error
 }

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -12,7 +12,7 @@ import (
 )
 
 func BeforeQuery(db *gorm.DB) {
-	if db.Error == nil && db.Statement.Schema != nil && !db.Statement.Statement.SkipHooks && db.Statement.Schema.BeforeFind {
+	if db.Error == nil && db.Statement.Schema != nil && !db.Statement.SkipHooks && db.Statement.Schema.BeforeFind {
 		callMethod(db, func(value interface{}, tx *gorm.DB) bool {
 			if i, ok := value.(BeforeFindInterface); ok {
 				db.AddError(i.BeforeFind(tx))

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -11,6 +11,18 @@ import (
 	"gorm.io/gorm/utils"
 )
 
+func BeforeQuery(db *gorm.DB) {
+	if db.Error == nil && db.Statement.Schema != nil && !db.Statement.Statement.SkipHooks && db.Statement.Schema.BeforeFind {
+		callMethod(db, func(value interface{}, tx *gorm.DB) bool {
+			if i, ok := value.(BeforeFindInterface); ok {
+				db.AddError(i.BeforeFind(tx))
+				return true
+			}
+			return false
+		})
+	}
+}
+
 func Query(db *gorm.DB) {
 	if db.Error == nil {
 		BuildQuerySQL(db)

--- a/schema/callbacks_test.go
+++ b/schema/callbacks_test.go
@@ -31,7 +31,7 @@ func TestCallback(t *testing.T) {
 		}
 	}
 
-	for _, str := range []string{"BeforeCreate", "BeforeUpdate", "AfterUpdate", "AfterSave", "BeforeDelete", "AfterDelete", "AfterFind"} {
+	for _, str := range []string{"BeforeCreate", "BeforeUpdate", "AfterUpdate", "AfterSave", "BeforeDelete", "AfterDelete", "BeforeFind", "AfterFind"} {
 		if reflect.Indirect(reflect.ValueOf(user)).FieldByName(str).Interface().(bool) {
 			t.Errorf("%v should be false", str)
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -24,6 +24,7 @@ const (
 	callbackTypeAfterSave    callbackType = "AfterSave"
 	callbackTypeBeforeDelete callbackType = "BeforeDelete"
 	callbackTypeAfterDelete  callbackType = "AfterDelete"
+	callbackTypeBeforeFind   callbackType = "BeforeFind"
 	callbackTypeAfterFind    callbackType = "AfterFind"
 )
 
@@ -52,7 +53,7 @@ type Schema struct {
 	BeforeUpdate, AfterUpdate bool
 	BeforeDelete, AfterDelete bool
 	BeforeSave, AfterSave     bool
-	AfterFind                 bool
+	BeforeFind, AfterFind     bool
 	err                       error
 	initialized               chan struct{}
 	namer                     Namer
@@ -308,7 +309,7 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 		callbackTypeBeforeUpdate, callbackTypeAfterUpdate,
 		callbackTypeBeforeSave, callbackTypeAfterSave,
 		callbackTypeBeforeDelete, callbackTypeAfterDelete,
-		callbackTypeAfterFind,
+		callbackTypeBeforeFind, callbackTypeAfterFind,
 	}
 	for _, cbName := range callbackTypes {
 		if methodValue := callBackToMethodValue(modelValue, cbName); methodValue.IsValid() {
@@ -396,6 +397,8 @@ func callBackToMethodValue(modelType reflect.Value, cbType callbackType) reflect
 		return modelType.MethodByName(string(callbackTypeBeforeDelete))
 	case callbackTypeAfterDelete:
 		return modelType.MethodByName(string(callbackTypeAfterDelete))
+	case callbackTypeBeforeFind:
+		return modelType.MethodByName(string(callbackTypeBeforeFind))
 	case callbackTypeAfterFind:
 		return modelType.MethodByName(string(callbackTypeAfterFind))
 	default:

--- a/tests/hooks_test.go
+++ b/tests/hooks_test.go
@@ -655,25 +655,28 @@ func (s *Product8) BeforeFind(tx *gorm.DB) error {
 	return nil
 }
 
-// Fails for postgres
-// ERROR: invalid input syntax for type bigint: "t" (SQLSTATE 22P02)
 func TestBeforeFindModifiesQuery(t *testing.T) {
 	DB.Migrator().DropTable(&Product8{})
 	DB.AutoMigrate(&Product8{})
 
-	products := []Product8{
-		{Code: "A", Price: 100},
-		{Code: "B", Price: 30},
+	p1 := Product8{Code: "A", Price: 30}
+	DB.Create(&p1)
+
+	var result Product8
+
+	DB.Find(&result)
+
+	if (result != Product8{}) {
+		t.Errorf("BeforeFind should filter results, got %v", result)
 	}
-	DB.Create(&products)
 
-	var results []Product8
+	p2 := Product8{Code: "B", Price: 100}
+	DB.Create(&p2)
 
-	// Without condition, hooks will be skipped
-	DB.Find(&results, true)
+	DB.Find(&result)
 
-	if len(results) != 1 || results[0].Code != "A" {
-		t.Errorf("BeforeFind should filter results, got %v", results)
+	if result.Code != "B" {
+		t.Errorf("BeforeFind should filter results, got %v", result)
 	}
 }
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Added BeforeFind hook capability to the queries. Closes #7357 

### User Case Description

From now on Find, First, Take and so on can have before hook.
It will be executed before executing query itself.

```go
type Product struct {
    Code string
    Price float64
}

func (s *Product) BeforeFind() error {
    // do something before query
}