### PR TITLE
Support multiple expressions in OrderBy clause

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -306,9 +306,9 @@ func (db *DB) Having(query interface{}, args ...interface{}) (tx *DB) {
 //
 //	db.Order("name DESC")
 //	db.Order(clause.OrderByColumn{Column: clause.Column{Name: "name"}, Desc: true})
-//	db.Order(clause.OrderBy{Columns: []clause.OrderByColumn{
-//		{Column: clause.Column{Name: "name"}, Desc: true},
-//		{Column: clause.Column{Name: "age"}, Desc: true},
+//	db.Order(clause.OrderBy{Exprs: []clause.Expression{
+//		clause.OrderByColumn{Column: clause.Column{Name: "name"}, Desc: true},
+//		clause.OrderByColumn{Column: clause.Column{Name: "age"}, Desc: true},
 //	}})
 func (db *DB) Order(value interface{}) (tx *DB) {
 	tx = db.getInstance()

--- a/chainable_api.go
+++ b/chainable_api.go
@@ -318,12 +318,12 @@ func (db *DB) Order(value interface{}) (tx *DB) {
 		tx.Statement.AddClause(v)
 	case clause.OrderByColumn:
 		tx.Statement.AddClause(clause.OrderBy{
-			Columns: []clause.OrderByColumn{v},
+			Exprs: []clause.Expression{v},
 		})
 	case string:
 		if v != "" {
 			tx.Statement.AddClause(clause.OrderBy{
-				Columns: []clause.OrderByColumn{{
+				Exprs: []clause.Expression{clause.OrderByColumn{
 					Column: clause.Column{Name: v, Raw: true},
 				}},
 			})
@@ -448,9 +448,10 @@ func (db *DB) Assign(attrs ...interface{}) (tx *DB) {
 // Unscoped allows queries to include records marked as deleted,
 // overriding the soft deletion behavior.
 // Example:
-//    var users []User
-//    db.Unscoped().Find(&users)
-//    // Retrieves all users, including deleted ones.
+//
+//	var users []User
+//	db.Unscoped().Find(&users)
+//	// Retrieves all users, including deleted ones.
 func (db *DB) Unscoped() (tx *DB) {
 	tx = db.getInstance()
 	tx.Statement.Unscoped = true

--- a/clause/benchmarks_test.go
+++ b/clause/benchmarks_test.go
@@ -45,7 +45,7 @@ func BenchmarkComplexSelect(b *testing.B) {
 			}},
 			clause.GroupBy{Columns: []clause.Column{{Name: "role"}}, Having: []clause.Expression{clause.Eq{"role", "admin"}}},
 			clause.Limit{Limit: &limit10, Offset: 20},
-			clause.OrderBy{Columns: []clause.OrderByColumn{{Column: clause.PrimaryColumn, Desc: true}}},
+			clause.OrderBy{Exprs: []clause.Expression{clause.OrderByColumn{Column: clause.PrimaryColumn, Desc: true}}},
 		}
 
 		for _, clause := range clauses {

--- a/clause/order_by.go
+++ b/clause/order_by.go
@@ -17,6 +17,7 @@ type OrderBy struct {
 	Exprs []Expression
 }
 
+// Name where clause name
 func (orderBy OrderBy) Name() string {
 	return "ORDER BY"
 }

--- a/clause/order_by_test.go
+++ b/clause/order_by_test.go
@@ -15,16 +15,16 @@ func TestOrderBy(t *testing.T) {
 	}{
 		{
 			[]clause.Interface{clause.Select{}, clause.From{}, clause.OrderBy{
-				Columns: []clause.OrderByColumn{{Column: clause.PrimaryColumn, Desc: true}},
+				Exprs: []clause.Expression{clause.OrderByColumn{Column: clause.PrimaryColumn, Desc: true}},
 			}},
 			"SELECT * FROM `users` ORDER BY `users`.`id` DESC", nil,
 		},
 		{
 			[]clause.Interface{
 				clause.Select{}, clause.From{}, clause.OrderBy{
-					Columns: []clause.OrderByColumn{{Column: clause.PrimaryColumn, Desc: true}},
+					Exprs: []clause.Expression{clause.OrderByColumn{Column: clause.PrimaryColumn, Desc: true}},
 				}, clause.OrderBy{
-					Columns: []clause.OrderByColumn{{Column: clause.Column{Name: "name"}}},
+					Exprs: []clause.Expression{clause.OrderByColumn{Column: clause.Column{Name: "name"}}},
 				},
 			},
 			"SELECT * FROM `users` ORDER BY `users`.`id` DESC,`name`", nil,
@@ -32,9 +32,9 @@ func TestOrderBy(t *testing.T) {
 		{
 			[]clause.Interface{
 				clause.Select{}, clause.From{}, clause.OrderBy{
-					Columns: []clause.OrderByColumn{{Column: clause.PrimaryColumn, Desc: true}},
+					Exprs: []clause.Expression{clause.OrderByColumn{Column: clause.PrimaryColumn, Desc: true}},
 				}, clause.OrderBy{
-					Columns: []clause.OrderByColumn{{Column: clause.Column{Name: "name"}, Reorder: true}},
+					Exprs: []clause.Expression{clause.OrderByColumn{Column: clause.Column{Name: "name"}, Reorder: true}},
 				},
 			},
 			"SELECT * FROM `users` ORDER BY `name`", nil,
@@ -42,10 +42,22 @@ func TestOrderBy(t *testing.T) {
 		{
 			[]clause.Interface{
 				clause.Select{}, clause.From{}, clause.OrderBy{
-					Expression: clause.Expr{SQL: "FIELD(id, ?)", Vars: []interface{}{[]int{1, 2, 3}}, WithoutParentheses: true},
+					Exprs: []clause.Expression{clause.Expr{SQL: "FIELD(id, ?)", Vars: []interface{}{[]int{1, 2, 3}}, WithoutParentheses: true}},
 				},
 			},
 			"SELECT * FROM `users` ORDER BY FIELD(id, ?,?,?)",
+			[]interface{}{1, 2, 3},
+		},
+		{
+			[]clause.Interface{
+				clause.Select{}, clause.From{}, clause.OrderBy{
+					Exprs: []clause.Expression{
+						clause.Expr{SQL: "FIELD(id, ?)", Vars: []interface{}{[]int{1, 2, 3}}, WithoutParentheses: true},
+						clause.OrderByColumn{Column: clause.PrimaryColumn, Desc: true},
+					},
+				},
+			},
+			"SELECT * FROM `users` ORDER BY FIELD(id, ?,?,?),`users`.`id` DESC",
 			[]interface{}{1, 2, 3},
 		},
 	}

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -1025,7 +1025,7 @@ func TestOrder(t *testing.T) {
 	}
 
 	stmt := dryDB.Clauses(clause.OrderBy{
-		Expression: clause.Expr{SQL: "FIELD(id,?)", Vars: []interface{}{[]int{1, 2, 3}}, WithoutParentheses: true},
+		Exprs: []clause.Expression{clause.Expr{SQL: "FIELD(id,?)", Vars: []interface{}{[]int{1, 2, 3}}, WithoutParentheses: true}},
 	}).Find(&User{}).Statement
 
 	explainedSQL := dryDB.Dialector.Explain(stmt.SQL.String(), stmt.Vars...)
@@ -1050,7 +1050,7 @@ func TestOrderWithAllFields(t *testing.T) {
 	}
 
 	stmt := dryDB.Clauses(clause.OrderBy{
-		Expression: clause.Expr{SQL: "FIELD(id,?)", Vars: []interface{}{[]int{1, 2, 3}}, WithoutParentheses: true},
+		Exprs: []clause.Expression{clause.Expr{SQL: "FIELD(id,?)", Vars: []interface{}{[]int{1, 2, 3}}, WithoutParentheses: true}},
 	}).Find(&User{}).Statement
 
 	explainedSQL := dryDB.Dialector.Explain(stmt.SQL.String(), stmt.Vars...)

--- a/tests/sql_builder_test.go
+++ b/tests/sql_builder_test.go
@@ -449,7 +449,7 @@ func TestToSQL(t *testing.T) {
 	// UpdateColumns
 	sql = DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
 		return tx.Raw("SELECT * FROM users ?", clause.OrderBy{
-			Columns: []clause.OrderByColumn{{Column: clause.Column{Name: "id", Raw: true}, Desc: true}},
+			Exprs: []clause.Expression{clause.OrderByColumn{Column: clause.Column{Name: "id", Raw: true}, Desc: true}},
 		})
 	})
 	assertEqualSQL(t, `SELECT * FROM users ORDER BY id DESC`, sql)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [ ] Non breaking API changes
- [x] Tested

### What did this pull request do?

Currently, it's only possible to include one expression in an OrderBy clause. And there is no way to include both OrderBy expression and column name.
This PR changes the OrderBy clause to allow the usage of multiple expressions along with multiple column names.

### User Case Description

I want to order by an expression and multiple column names.
