### PR TITLE
Fix `AutoMigrate`, alterColumn The previous modifications were ignored

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -549,9 +549,9 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 			case schema.Bool:
 				v1, _ := strconv.ParseBool(dv)
 				v2, _ := strconv.ParseBool(field.DefaultValue)
-				alterColumn = v1 != v2
+				alterColumn = alterColumn || (v1 != v2)
 			default:
-				alterColumn = dv != field.DefaultValue
+				alterColumn = alterColumn || (dv != field.DefaultValue)
 			}
 		}
 	}


### PR DESCRIPTION
The `AutoMigrate` function, when a field in struct has a 'default' value, modifying the 'size' value is invalid

```
type Object struct {
	ID   uint
	Name string `gorm:"column:name;default:'';size:16"`
}

->

type Object struct {
	ID   uint
	Name string `gorm:"column:name;default:'';size:16"` // update size 16 -> 100，the size in the database is still 16
}
```
