### PR TITLE
Fix for 7403 - a race condition bug.

### DIFF
--- a/callbacks/create.go
+++ b/callbacks/create.go
@@ -86,6 +86,10 @@ func Create(config *Config) func(db *gorm.DB) {
 			)
 			if db.AddError(err) == nil {
 				defer func() {
+					// Make sure it's processed and errors are taken into account.
+					if !rows.Next() {
+						db.AddError(rows.Err())
+					}
 					db.AddError(rows.Close())
 				}()
 				gorm.Scan(rows, db, mode)

--- a/callbacks/delete.go
+++ b/callbacks/delete.go
@@ -166,6 +166,10 @@ func Delete(config *Config) func(db *gorm.DB) {
 
 			if rows, err := db.Statement.ConnPool.QueryContext(db.Statement.Context, db.Statement.SQL.String(), db.Statement.Vars...); db.AddError(err) == nil {
 				gorm.Scan(rows, db, mode)
+				// Make sure it's processed and errors are taken into account.
+				if !rows.Next() {
+					db.AddError(rows.Err())
+				}
 				db.AddError(rows.Close())
 			}
 		}

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -22,6 +22,10 @@ func Query(db *gorm.DB) {
 				return
 			}
 			defer func() {
+				// Make sure it's processed and errors are taken into account.
+				if !rows.Next() {
+					db.AddError(rows.Err())
+				}
 				db.AddError(rows.Close())
 			}()
 			gorm.Scan(rows, db, 0)

--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -91,6 +91,10 @@ func Update(config *Config) func(db *gorm.DB) {
 					db.Statement.Dest = db.Statement.ReflectValue.Addr().Interface()
 					gorm.Scan(rows, db, mode)
 					db.Statement.Dest = dest
+					// Make sure it's processed and errors are taken into account.
+					if !rows.Next() {
+						db.AddError(rows.Err())
+					}
 					db.AddError(rows.Close())
 				}
 			} else {

--- a/scan.go
+++ b/scan.go
@@ -350,10 +350,6 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 		}
 	}
 
-	if err := rows.Err(); err != nil && err != db.Error {
-		db.AddError(err)
-	}
-
 	if db.RowsAffected == 0 && db.Statement.RaiseErrorOnNotFound && db.Error == nil {
 		db.AddError(ErrRecordNotFound)
 	}


### PR DESCRIPTION
Fix for the bug described here: https://github.com/go-gorm/gorm/issues/7403

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

The fix removes the global call to "rows.Err()" from the generic Scan method, as it's something that should be done by the caller when the caller knows that the method can be called in a safe way (the rows instance is explicitly or implicitly closed).
By calling the method after making sure that the `rows` instance is closed, the code protects the call against the race condition described in the issue.

The fixed `Scan()` method is also called internally, so I also made sure that potential errors won't be missed there, by calling the `Err()` method after making sure that the `rows` instance is closed. It's 100% safe, because the `Next()` method called there ensures that the instance is closed and releases the potential read lock which may be left by `Scan()` method.

I didn't add a dedicated test case, because the bug causes a race condition which is not easy to reproduce. If there was a way to mock the whole rows instance then it could be probably checked. All existing test cases passed.