### PR TITLE
Fix: execute scopes before count

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -457,6 +457,10 @@ func (db *DB) Count(count *int64) (tx *DB) {
 		defer delete(tx.Statement.Clauses, "SELECT")
 	}
 
+	if len(tx.Statement.scopes) > 0 {
+		tx.Statement.executeScopes()
+	}
+
 	if len(tx.Statement.Selects) == 0 {
 		tx.Statement.AddClause(clause.Select{Expression: clause.Expr{SQL: "count(*)"}})
 	} else if !strings.HasPrefix(strings.TrimSpace(strings.ToLower(tx.Statement.Selects[0])), "count(") {


### PR DESCRIPTION
Resolves #7407

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [ ] ~Tested~

### What did this pull request do?

Executes scopes prior to `Count` functionality.

### User Case Description

Using selects within scopes prior to running `Count()`.
