### PR TITLE
fix: prevent interface type array from causing runtime errors

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -122,7 +122,7 @@ func (p *processor) Execute(db *DB) *DB {
 			stmt.ReflectValue = stmt.ReflectValue.Elem()
 		}
 		if (stmt.ReflectValue.Kind() == reflect.Slice || stmt.ReflectValue.Kind() == reflect.Array) &&
-			(stmt.ReflectValue.Len() > 0 || stmt.ReflectValue.Index(0).Kind() == reflect.Interface) {
+			(stmt.ReflectValue.Len() > 0 && stmt.ReflectValue.Index(0).Kind() == reflect.Interface) {
 			len := stmt.ReflectValue.Len()
 			firstElem := stmt.ReflectValue.Index(0)
 			for firstElem.Kind() == reflect.Interface || firstElem.Kind() == reflect.Ptr {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -131,7 +131,7 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 	modelType := reflect.Indirect(value).Type()
 
 	if modelType.Kind() == reflect.Interface {
-		modelType = reflect.Indirect(reflect.ValueOf(dest)).Elem().Type()
+		modelType = reflect.Indirect(value).Elem().Type()
 	}
 
 	for modelType.Kind() == reflect.Slice || modelType.Kind() == reflect.Array || modelType.Kind() == reflect.Ptr {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -138,6 +138,15 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 		modelType = modelType.Elem()
 	}
 
+	if modelType.Kind() == reflect.Interface {
+		if value.Len() > 0 {
+			modelType = reflect.Indirect(value.Index(0)).Elem().Type()
+		}
+		if modelType.Kind() == reflect.Ptr {
+			modelType = modelType.Elem()
+		}
+	}
+
 	if modelType.Kind() != reflect.Struct {
 		if modelType.PkgPath() == "" {
 			return nil, fmt.Errorf("%w: %+v", ErrUnsupportedDataType, dest)

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -791,3 +791,65 @@ func TestCreateFromMapWithTable(t *testing.T) {
 		t.Errorf("failed to create data from map with table, @id != id")
 	}
 }
+
+func TestCreateWithInterfaceType(t *testing.T) {
+	user := *GetUser("create", Config{})
+	type UserInterface interface{}
+	var userInterface UserInterface = &user
+
+	if results := DB.Create(userInterface); results.Error != nil {
+		t.Fatalf("errors happened when create: %v", results.Error)
+	} else if results.RowsAffected != 1 {
+		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)
+	}
+
+	if user.ID == 0 {
+		t.Errorf("user's primary key should has value after create, got : %v", user.ID)
+	}
+
+	if user.CreatedAt.IsZero() {
+		t.Errorf("user's created at should be not zero")
+	}
+
+	if user.UpdatedAt.IsZero() {
+		t.Errorf("user's updated at should be not zero")
+	}
+
+	var newUser User
+	if err := DB.Where("id = ?", user.ID).First(&newUser).Error; err != nil {
+		t.Fatalf("errors happened when query: %v", err)
+	} else {
+		CheckUser(t, newUser, user)
+	}
+}
+
+func TestCreateWithInterfaceArrayType(t *testing.T) {
+	user := *GetUser("create", Config{})
+	type UserInterface interface{}
+	var userInterface UserInterface = &user
+
+	if results := DB.Create([]UserInterface{userInterface}); results.Error != nil {
+		t.Fatalf("errors happened when create: %v", results.Error)
+	} else if results.RowsAffected != 1 {
+		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)
+	}
+
+	if user.ID == 0 {
+		t.Errorf("user's primary key should has value after create, got : %v", user.ID)
+	}
+
+	if user.CreatedAt.IsZero() {
+		t.Errorf("user's created at should be not zero")
+	}
+
+	if user.UpdatedAt.IsZero() {
+		t.Errorf("user's updated at should be not zero")
+	}
+
+	var newUser User
+	if err := DB.Where("id = ?", user.ID).First(&newUser).Error; err != nil {
+		t.Fatalf("errors happened when query: %v", err)
+	} else {
+		CheckUser(t, newUser, user)
+	}
+}

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -823,33 +823,14 @@ func TestCreateWithInterfaceType(t *testing.T) {
 	}
 }
 
-// func TestCreateWithInterfaceArrayType(t *testing.T) {
-// 	user := *GetUser("create", Config{})
-// 	type UserInterface interface{}
-// 	var userInterface UserInterface = &user
+func TestCreateWithInterfaceArrayType(t *testing.T) {
+	user := *GetUser("create", Config{})
+	type UserInterface interface{}
+	var userInterface UserInterface = &user
 
-// 	if results := DB.Create([]UserInterface{userInterface}); results.Error != nil {
-// 		t.Fatalf("errors happened when create: %v", results.Error)
-// 	} else if results.RowsAffected != 1 {
-// 		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)
-// 	}
-
-// 	if user.ID == 0 {
-// 		t.Errorf("user's primary key should has value after create, got : %v", user.ID)
-// 	}
-
-// 	if user.CreatedAt.IsZero() {
-// 		t.Errorf("user's created at should be not zero")
-// 	}
-
-// 	if user.UpdatedAt.IsZero() {
-// 		t.Errorf("user's updated at should be not zero")
-// 	}
-
-// 	var newUser User
-// 	if err := DB.Where("id = ?", user.ID).First(&newUser).Error; err != nil {
-// 		t.Fatalf("errors happened when query: %v", err)
-// 	} else {
-// 		CheckUser(t, newUser, user)
-// 	}
-// }
+	if results := DB.Create([]UserInterface{userInterface}); results.Error != nil {
+		t.Fatalf("errors happened when create: %v", results.Error)
+	} else if results.RowsAffected != 1 {
+		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)
+	}
+}

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -823,33 +823,33 @@ func TestCreateWithInterfaceType(t *testing.T) {
 	}
 }
 
-func TestCreateWithInterfaceArrayType(t *testing.T) {
-	user := *GetUser("create", Config{})
-	type UserInterface interface{}
-	var userInterface UserInterface = &user
+// func TestCreateWithInterfaceArrayType(t *testing.T) {
+// 	user := *GetUser("create", Config{})
+// 	type UserInterface interface{}
+// 	var userInterface UserInterface = &user
 
-	if results := DB.Create([]UserInterface{userInterface}); results.Error != nil {
-		t.Fatalf("errors happened when create: %v", results.Error)
-	} else if results.RowsAffected != 1 {
-		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)
-	}
+// 	if results := DB.Create([]UserInterface{userInterface}); results.Error != nil {
+// 		t.Fatalf("errors happened when create: %v", results.Error)
+// 	} else if results.RowsAffected != 1 {
+// 		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)
+// 	}
 
-	if user.ID == 0 {
-		t.Errorf("user's primary key should has value after create, got : %v", user.ID)
-	}
+// 	if user.ID == 0 {
+// 		t.Errorf("user's primary key should has value after create, got : %v", user.ID)
+// 	}
 
-	if user.CreatedAt.IsZero() {
-		t.Errorf("user's created at should be not zero")
-	}
+// 	if user.CreatedAt.IsZero() {
+// 		t.Errorf("user's created at should be not zero")
+// 	}
 
-	if user.UpdatedAt.IsZero() {
-		t.Errorf("user's updated at should be not zero")
-	}
+// 	if user.UpdatedAt.IsZero() {
+// 		t.Errorf("user's updated at should be not zero")
+// 	}
 
-	var newUser User
-	if err := DB.Where("id = ?", user.ID).First(&newUser).Error; err != nil {
-		t.Fatalf("errors happened when query: %v", err)
-	} else {
-		CheckUser(t, newUser, user)
-	}
-}
+// 	var newUser User
+// 	if err := DB.Where("id = ?", user.ID).First(&newUser).Error; err != nil {
+// 		t.Fatalf("errors happened when query: %v", err)
+// 	} else {
+// 		CheckUser(t, newUser, user)
+// 	}
+// }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?

fix: prevent interface type array from causing runtime errors
It has been modified to find out the value when it is an interface array.

### User Case Description
``` go
type UserInterface interface {
	GetName() string
}

db.Table("users").Create([]UserInterface{UserToUserInterface(&userData)})
```
In this case, create is allowed.
<!-- Your use case -->
