### PR TITLE
fix: prevent interface type array from causing runtime errors

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -121,6 +121,27 @@ func (p *processor) Execute(db *DB) *DB {
 
 			stmt.ReflectValue = stmt.ReflectValue.Elem()
 		}
+		if (stmt.ReflectValue.Kind() == reflect.Slice || stmt.ReflectValue.Kind() == reflect.Array) &&
+			(stmt.ReflectValue.Len() > 0 || stmt.ReflectValue.Index(0).Kind() == reflect.Interface) {
+			len := stmt.ReflectValue.Len()
+			firstElem := stmt.ReflectValue.Index(0)
+			for firstElem.Kind() == reflect.Interface || firstElem.Kind() == reflect.Ptr {
+				firstElem = firstElem.Elem()
+			}
+			elemType := firstElem.Type()
+			sliceType := reflect.SliceOf(elemType)
+			structArrayReflectValue := reflect.MakeSlice(sliceType, 0, len)
+
+			for i := 0; i < len; i++ {
+				elem := stmt.ReflectValue.Index(i)
+				for elem.Kind() == reflect.Interface || elem.Kind() == reflect.Ptr {
+					elem = elem.Elem()
+				}
+				structArrayReflectValue = reflect.Append(structArrayReflectValue, elem)
+			}
+			stmt.ReflectValue = structArrayReflectValue
+			fmt.Println(stmt.ReflectValue.Type())
+		}
 		if !stmt.ReflectValue.IsValid() {
 			db.AddError(ErrInvalidValue)
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -138,6 +138,14 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 		modelType = modelType.Elem()
 	}
 
+	if modelType.Kind() == reflect.Interface {
+		if value.Len() > 0 {
+			modelType = reflect.Indirect(value.Index(0)).Elem().Type()
+		}
+		if modelType.Kind() == reflect.Ptr {
+			modelType = modelType.Elem()
+		}
+	}
 	if modelType.Kind() != reflect.Struct {
 		if modelType.PkgPath() == "" {
 			return nil, fmt.Errorf("%w: %+v", ErrUnsupportedDataType, dest)

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -791,3 +791,15 @@ func TestCreateFromMapWithTable(t *testing.T) {
 		t.Errorf("failed to create data from map with table, @id != id")
 	}
 }
+
+func TestCreateWithInterfaceArrayType(t *testing.T) {
+	user := *GetUser("create", Config{})
+	type UserInterface interface{}
+	var userInterface UserInterface = &user
+
+	if results := DB.Create([]UserInterface{userInterface}); results.Error != nil {
+		t.Fatalf("errors happened when create: %v", results.Error)
+	} else if results.RowsAffected != 1 {
+		t.Fatalf("rows affected expects: %v, got %v", 1, results.RowsAffected)
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [v] Tested

### What did this pull request do?
fix: prevent interface type array from causing runtime errors
It has been modified to find out the value when it is an interface array.
### User Case Description
```go
type UserInterface interface {
	GetName() string
}

db.Table("users").Create([]UserInterface{UserToUserInterface(&userData)})
```
In this case, create is allowed.