### PR TITLE
fix: int type variable defaultMaxSize overflows in 32-bit environment

### DIFF
--- a/internal/stmt_store/stmt_store.go
+++ b/internal/stmt_store/stmt_store.go
@@ -3,6 +3,7 @@ package stmt_store
 import (
 	"context"
 	"database/sql"
+	"math"
 	"sync"
 	"time"
 
@@ -73,7 +74,7 @@ type Store interface {
 // the cache can theoretically store as many elements as possible.
 // (1 << 63) - 1 is the maximum value that an int64 type can represent.
 const (
-	defaultMaxSize = (1 << 63) - 1
+	defaultMaxSize = math.MaxInt
 	// defaultTTL defines the default time-to-live (TTL) for each cache entry.
 	// When the TTL for cache entries is not specified, each cache entry will expire after 24 hours.
 	defaultTTL = time.Hour * 24


### PR DESCRIPTION
Refs: #7435

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Fix int type variable `defaultMaxSize` overflows in 32-bit environment.

```shell
GOARCH=386 go test -timeout 20m -v ./...
  shell: /usr/bin/bash -e {0}
# gorm.io/gorm/internal/stmt_store
Error: 
../../../go/pkg/mod/gorm.io/gorm@v1.26.0/internal/stmt_store/stmt_store.go:99:10: 
cannot use defaultMaxSize (untyped int constant 9223372036854775807) as int value in assignment (overflows)
```

### User Case Description

<!-- Your use case -->
