### PR TITLE
feat: add Only

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -51,4 +51,6 @@ var (
 	ErrForeignKeyViolated = errors.New("violates foreign key constraint")
 	// ErrCheckConstraintViolated occurs when there is a check constraint violation
 	ErrCheckConstraintViolated = errors.New("violates check constraint")
+	// ErrMultipleRecordsFound occurs when more than one record found with Only
+	ErrMultipleRecordsFound = errors.New("multiple records found")
 )

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -181,7 +181,10 @@ func (db *DB) Only(dest interface{}, conds ...interface{}) (tx *DB) {
 	}
 
 	if count > 1 {
-		findTx.AddError(ErrMultipleRecordsFound)
+		err := findTx.AddError(ErrMultipleRecordsFound)
+		if err != nil {
+			return nil
+		}
 	}
 
 	return findTx

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -181,7 +181,7 @@ func (db *DB) Only(dest interface{}, conds ...interface{}) (tx *DB) {
 	}
 
 	if count > 1 {
-		findTx.AddError(fmt.Errorf("expected exactly one record, but found %d", count))
+		findTx.AddError(ErrMultipleRecordsFound)
 	}
 
 	return findTx


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Introduces a new `Only` query method (see issue #7411). This method retrieves exactly one record ordered by primary key and returns an error if zero or multiple records match.

### User Case Description
GORM previously lacked a built‑in `Only` operation, forcing users to manually combine `First` and `Count` to enforce uniqueness. Many other ORMs provide this feature natively. <!-- Your use case -->
