### PR TITLE
Composite pk handling

### DIFF
--- a/clause/clause.go
+++ b/clause/clause.go
@@ -64,6 +64,7 @@ func (c Clause) Build(builder Builder) {
 
 const (
 	PrimaryKey   string = "~~~py~~~" // primary key
+	PrimaryKeys  string = "~~~ps~~~" // primary keys
 	CurrentTable string = "~~~ct~~~" // current table
 	Associations string = "~~~as~~~" // associations
 )

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -228,7 +228,7 @@ func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, bat
 
 		// Optimize for-break
 		resultsValue := reflect.Indirect(reflect.ValueOf(dest))
-		if result.Statement.Schema.PrioritizedPrimaryField == nil {
+		if result.Statement.Schema.PrioritizedPrimaryField == nil && result.Statement.Schema.PrimaryFields != nil && len(result.Statement.Schema.PrimaryFields) == 1 {
 			tx.AddError(ErrPrimaryKeyRequired)
 			break
 		}

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -118,7 +118,7 @@ func (db *DB) Save(value interface{}) (tx *DB) {
 // First finds the first record ordered by primary key, matching given conditions conds
 func (db *DB) First(dest interface{}, conds ...interface{}) (tx *DB) {
 	tx = db.Limit(1).Order(clause.OrderByColumn{
-		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey},
+		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKeys},
 	})
 	if len(conds) > 0 {
 		if exprs := tx.Statement.BuildCondition(conds[0], conds[1:]...); len(exprs) > 0 {
@@ -146,7 +146,7 @@ func (db *DB) Take(dest interface{}, conds ...interface{}) (tx *DB) {
 // Last finds the last record ordered by primary key, matching given conditions conds
 func (db *DB) Last(dest interface{}, conds ...interface{}) (tx *DB) {
 	tx = db.Limit(1).Order(clause.OrderByColumn{
-		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey},
+		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKeys},
 		Desc:   true,
 	})
 	if len(conds) > 0 {
@@ -173,9 +173,10 @@ func (db *DB) Find(dest interface{}, conds ...interface{}) (tx *DB) {
 
 // FindInBatches finds all records in batches of batchSize
 func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, batch int) error) *DB {
+	// Use PrimaryKeys to handle composite primary key situations
 	var (
 		tx = db.Order(clause.OrderByColumn{
-			Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey},
+			Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKeys},
 		}).Session(&Session{})
 		queryDB      = tx
 		rowsAffected int64
@@ -232,12 +233,71 @@ func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, bat
 			break
 		}
 
-		primaryValue, zero := result.Statement.Schema.PrioritizedPrimaryField.ValueOf(tx.Statement.Context, resultsValue.Index(resultsValue.Len()-1))
-		if zero {
-			tx.AddError(ErrPrimaryKeyRequired)
-			break
+		// The following will build a where clause like this:
+		// struct {
+		// col1    uint `gorm:"primaryKey;autoIncrement:false"`
+		// col2    uint `gorm:"primaryKey;autoIncrement:false"`
+		// col3    uint `gorm:"primaryKey;autoIncrement:false"`
+		// }
+		// last row returned was col1 = 2, col2 = 3, col3 = 5
+		// where clause will be generated as follows
+		// WHERE (col1 > 2 OR (col1 = 2 AND col2 > 3) OR (col1 = 2 AND col2 = 3 AND col3 > 5))
+		// Detect composite primary keys
+		if result.Statement.Schema.PrimaryFields != nil {
+			pkCount := len(result.Statement.Schema.PrimaryFields)
+
+			// Handle composite primary key Where clauses
+			if pkCount > 1 {
+				var f *schema.Field
+				var orClauses []clause.Expression
+				for i := 0; i < pkCount; i++ {
+					var andClauses []clause.Expression
+					// Build 1st column GT clause
+					if i == 0 {
+						f = result.Statement.Schema.PrimaryFields[i]
+						primaryValue, zero := f.ValueOf(tx.Statement.Context, resultsValue.Index(resultsValue.Len()-1))
+						if zero {
+							tx.AddError(ErrPrimaryKeyRequired)
+							break
+						}
+						orClauses = append(orClauses, clause.Gt{Column: clause.Column{Table: clause.CurrentTable, Name: f.DBName}, Value: primaryValue})
+					} else {
+						// Build AND clause and append to OR clauses
+						for j := 0; j <= i; j++ {
+							f = result.Statement.Schema.PrimaryFields[j]
+							primaryValue, zero := f.ValueOf(tx.Statement.Context, resultsValue.Index(resultsValue.Len()-1))
+							if zero {
+								tx.AddError(ErrPrimaryKeyRequired)
+								break
+							}
+							if j == i {
+								// Build current outer column GT clause
+								andClauses = append(andClauses, clause.Gt{Column: clause.Column{Table: clause.CurrentTable, Name: f.DBName}, Value: primaryValue})
+							} else {
+								// Build all other columns EQ clause
+								andClauses = append(andClauses, clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: f.DBName}, Value: primaryValue})
+							}
+						}
+						orClauses = append(orClauses, clause.And(andClauses...))
+					}
+				}
+				queryDB = tx.Clauses(clause.Or(orClauses...))
+			} else {
+				primaryValue, zero := result.Statement.Schema.PrimaryFields[0].ValueOf(tx.Statement.Context, resultsValue.Index(resultsValue.Len()-1))
+				if zero {
+					tx.AddError(ErrPrimaryKeyRequired)
+					break
+				}
+				queryDB = tx.Clauses(clause.Gt{Column: clause.Column{Table: clause.CurrentTable, Name: result.Statement.Schema.PrimaryFields[0].DBName}, Value: primaryValue})
+			}
+		} else {
+			primaryValue, zero := result.Statement.Schema.PrioritizedPrimaryField.ValueOf(tx.Statement.Context, resultsValue.Index(resultsValue.Len()-1))
+			if zero {
+				tx.AddError(ErrPrimaryKeyRequired)
+				break
+			}
+			queryDB = tx.Clauses(clause.Gt{Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey}, Value: primaryValue})
 		}
-		queryDB = tx.Clauses(clause.Gt{Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey}, Value: primaryValue})
 	}
 
 	tx.RowsAffected = rowsAffected
@@ -307,7 +367,7 @@ func (db *DB) assignInterfacesToValue(values ...interface{}) {
 //	// user -> User{Name: "jinzhu", Age: 20, Email: "fake@fake.org"}
 func (db *DB) FirstOrInit(dest interface{}, conds ...interface{}) (tx *DB) {
 	queryTx := db.Limit(1).Order(clause.OrderByColumn{
-		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey},
+		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKeys},
 	})
 
 	if tx = queryTx.Find(dest, conds...); tx.RowsAffected == 0 {
@@ -347,7 +407,7 @@ func (db *DB) FirstOrInit(dest interface{}, conds ...interface{}) (tx *DB) {
 func (db *DB) FirstOrCreate(dest interface{}, conds ...interface{}) (tx *DB) {
 	tx = db.getInstance()
 	queryTx := db.Session(&Session{}).Limit(1).Order(clause.OrderByColumn{
-		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey},
+		Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKeys},
 	})
 
 	result := queryTx.Find(dest, conds...)

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -200,6 +200,7 @@ func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, bat
 		}
 	}
 
+find:
 	for {
 		result := queryDB.Limit(batchSize).Find(dest)
 		rowsAffected += result.RowsAffected
@@ -257,8 +258,8 @@ func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, bat
 						f = result.Statement.Schema.PrimaryFields[i]
 						primaryValue, zero := f.ValueOf(tx.Statement.Context, resultsValue.Index(resultsValue.Len()-1))
 						if zero {
-							tx.AddError(ErrPrimaryKeyRequired)
-							break
+							tx.AddError(ErrPrimaryKeyRequired) //nolint:typecheck,errcheck,gosec
+							break find
 						}
 						orClauses = append(orClauses, clause.Gt{Column: clause.Column{Table: clause.CurrentTable, Name: f.DBName}, Value: primaryValue})
 					} else {
@@ -267,8 +268,8 @@ func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, bat
 							f = result.Statement.Schema.PrimaryFields[j]
 							primaryValue, zero := f.ValueOf(tx.Statement.Context, resultsValue.Index(resultsValue.Len()-1))
 							if zero {
-								tx.AddError(ErrPrimaryKeyRequired)
-								break
+								tx.AddError(ErrPrimaryKeyRequired) //nolint:typecheck,errcheck,gosec
+								break find
 							}
 							if j == i {
 								// Build current outer column GT clause
@@ -285,7 +286,7 @@ func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, bat
 			} else {
 				primaryValue, zero := result.Statement.Schema.PrimaryFields[0].ValueOf(tx.Statement.Context, resultsValue.Index(resultsValue.Len()-1))
 				if zero {
-					tx.AddError(ErrPrimaryKeyRequired)
+					tx.AddError(ErrPrimaryKeyRequired) //nolint:typecheck,errcheck,gosec
 					break
 				}
 				queryDB = tx.Clauses(clause.Gt{Column: clause.Column{Table: clause.CurrentTable, Name: result.Statement.Schema.PrimaryFields[0].DBName}, Value: primaryValue})

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -294,7 +294,7 @@ find:
 		} else {
 			primaryValue, zero := result.Statement.Schema.PrioritizedPrimaryField.ValueOf(tx.Statement.Context, resultsValue.Index(resultsValue.Len()-1))
 			if zero {
-				tx.AddError(ErrPrimaryKeyRequired)
+				tx.AddError(ErrPrimaryKeyRequired) //nolint:typecheck,errcheck,gosec
 				break
 			}
 			queryDB = tx.Clauses(clause.Gt{Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey}, Value: primaryValue})

--- a/statement.go
+++ b/statement.go
@@ -144,19 +144,19 @@ func (stmt *Statement) QuoteTo(writer clause.Writer, field interface{}) {
 				} else {
 					write(v.Raw, v.Table)
 				}
-				writer.WriteByte('.')
+				writer.WriteByte('.') //nolint:typecheck,errcheck,gosec
 			}
 
 			if v.Name == clause.PrimaryKey {
 				switch {
 				case stmt.Schema == nil:
-					stmt.DB.AddError(ErrModelValueRequired) //nolint:typecheck,errcheck,gosec
+					stmt.DB.AddError(ErrModelValueRequired) //nolint:typecheck,errcheck,gosec,staticcheck
 				case stmt.Schema.PrioritizedPrimaryField != nil:
 					write(v.Raw, stmt.Schema.PrioritizedPrimaryField.DBName)
 				case len(stmt.Schema.DBNames) > 0:
 					write(v.Raw, stmt.Schema.DBNames[0])
 				default:
-					stmt.DB.AddError(ErrModelAccessibleFieldsRequired) //nolint:typecheck,errcheck,gosec
+					stmt.DB.AddError(ErrModelAccessibleFieldsRequired) //nolint:typecheck,errcheck,gosec,staticcheck
 				}
 			} else {
 				write(v.Raw, v.Name)

--- a/statement.go
+++ b/statement.go
@@ -112,7 +112,7 @@ func (stmt *Statement) QuoteTo(writer clause.Writer, field interface{}) {
 			} else if stmt.Schema.PrimaryFields != nil {
 				for idx, s := range stmt.Schema.PrimaryFieldDBNames {
 					if idx > 0 {
-						writer.WriteByte(',')
+						writer.WriteByte(',') //nolint:typecheck,errcheck,gosec
 					}
 					if v.Table != "" {
 						if v.Table == clause.CurrentTable {
@@ -120,7 +120,7 @@ func (stmt *Statement) QuoteTo(writer clause.Writer, field interface{}) {
 						} else {
 							write(v.Raw, v.Table)
 						}
-						writer.WriteByte('.')
+						writer.WriteByte('.') //nolint:typecheck,errcheck,gosec
 					}
 					write(v.Raw, s)
 				}
@@ -131,7 +131,7 @@ func (stmt *Statement) QuoteTo(writer clause.Writer, field interface{}) {
 					} else {
 						write(v.Raw, v.Table)
 					}
-					writer.WriteByte('.')
+					writer.WriteByte('.') //nolint:typecheck,errcheck,gosec
 				}
 				write(v.Raw, stmt.Schema.DBNames[0])
 			} else {
@@ -148,14 +148,15 @@ func (stmt *Statement) QuoteTo(writer clause.Writer, field interface{}) {
 			}
 
 			if v.Name == clause.PrimaryKey {
-				if stmt.Schema == nil {
-					stmt.DB.AddError(ErrModelValueRequired)
-				} else if stmt.Schema.PrioritizedPrimaryField != nil {
+				switch {
+				case stmt.Schema == nil:
+					stmt.DB.AddError(ErrModelValueRequired) //nolint:typecheck,errcheck,gosec
+				case stmt.Schema.PrioritizedPrimaryField != nil:
 					write(v.Raw, stmt.Schema.PrioritizedPrimaryField.DBName)
-				} else if len(stmt.Schema.DBNames) > 0 {
+				case len(stmt.Schema.DBNames) > 0:
 					write(v.Raw, stmt.Schema.DBNames[0])
-				} else {
-					stmt.DB.AddError(ErrModelAccessibleFieldsRequired) //nolint:typecheck,errcheck
+				default:
+					stmt.DB.AddError(ErrModelAccessibleFieldsRequired) //nolint:typecheck,errcheck,gosec
 				}
 			} else {
 				write(v.Raw, v.Name)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Ensure that Composite Primary Keys are handled correctly.
Fix issue https://github.com/go-gorm/playground/issues/800
Add new test for FindInBatch with Composite Primary key

### User Case Description

When using a struct with a composite primary key, all fields in the primary key should be used in the order by's to ensure that all databases will guarantee returning the same record(s) in the same order every time.
This is applicable to First, Last, FirstOrCreate, FirstOrInit and FindInBatch.

When getting subsequent batches in FindInBatch, the where clause has to take into account all parts of the composite primary key.

#### First, FirstOrCreate, FirstOrInit Use Case

1. create struct with multiple columns tagged with primaryKey
2. load struct with many rows of data, with the 1st column in the primary key repeated many times
3. issue a First/FirstOrCreate/FirstOrInit command

**Expected:**
The same record is always returned.
**Actual:**
At a random, usually under heavy load, the dbms may return a different 1st record, although it has the same value for the 1st column in the primary key.
**This Pull:**
Guaranteed to return the same record every time as all columns in the primary key are included in the order by statement.

#### Last Use Case

1. create struct with multiple columns tagged with primaryKey
2. load struct with many rows of data, with the 1st column in the primary key repeated many times
3. issue a Last command

**Expected:**
The same record is always returned.
**Actual:**
At a random, usually under heavy load, the dbms may return a different record, although it has the same 1st column in the primary key.
The record returned may not be the last record when taking all columns in the composite primary key into account, as the order by does not specify all the columns.
**This Pull:**
Guaranteed to return the same record every time as all columns in the primary key are included in the order by statement.

#### FindInBatch Use Case

1. create struct with multiple columns tagged with primaryKey
2. load struct with many rows of data, with the 1st column in the primary key repeated many times
3. issue a FindInBatch command with a batch smaller than the number of records
4. process the batches until all records consumed

**Expected:**
All the records are returned in batches
**Actual:**
A no primary key error is returned
**This Pull:**
1st issuance for FindInBatch has all columns in primary key in the order by.
Subsequent batches have where clause to ensure that the already consumed batches are excluded, and remaining records are returned up to the batch limit.

