### PR TITLE
perf: use strings.IndexByte to replace strings.Index

### DIFF
--- a/schema/index.go
+++ b/schema/index.go
@@ -105,7 +105,7 @@ func parseFieldIndexes(field *Field) (indexes []Index, err error) {
 				var (
 					name       string
 					tag        = strings.Join(v[1:], ":")
-					idx        = strings.Index(tag, ",")
+					idx        = strings.IndexByte(tag, ',')
 					tagSetting = strings.Join(strings.Split(tag, ",")[1:], ",")
 					settings   = ParseTagSetting(tagSetting, ",")
 					length, _  = strconv.Atoi(settings["LENGTH"])

--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -675,7 +675,7 @@ func (rel *Relationship) ParseConstraint() *Constraint {
 
 	var (
 		name     string
-		idx      = strings.Index(str, ",")
+		idx      = strings.IndexByte(str, ',')
 		settings = ParseTagSetting(str, ",")
 	)
 


### PR DESCRIPTION
`strings.IndexByte` offers better performance than `strings.Index`.