### PR TITLE
perf: use strings.Cut to replace strings.SplitN

### DIFF
--- a/callbacks/preload.go
+++ b/callbacks/preload.go
@@ -103,11 +103,11 @@ func preloadEntryPoint(db *gorm.DB, joins []string, relationships *schema.Relati
 				joined = true
 				continue
 			}
-			joinNames := strings.SplitN(join, ".", 2)
-			if len(joinNames) == 2 {
-				if _, ok := relationships.Relations[joinNames[0]]; ok && name == joinNames[0] {
+			join0, join1, cut := strings.Cut(join, ".")
+			if cut {
+				if _, ok := relationships.Relations[join0]; ok && name == join0 {
 					joined = true
-					nestedJoins = append(nestedJoins, joinNames[1])
+					nestedJoins = append(nestedJoins, join1)
 				}
 			}
 		}


### PR DESCRIPTION
Replaced strings.SplitN with strings.Cut to reduce allocations and improve performance.  
Below is my local test code.  
join_test.go  
```go
package gorm

import (
	"strings"
	"testing"
)

func original(join string) (join0, join1 string, cut bool) {
	joins := strings.SplitN(join, ".", 2)
	if len(joins) == 2 {
		return joins[0], joins[1], true
	}
	return "", "", false
}

func optimized(join string) (join0, join1 string, cut bool) {
	join0, join1, cut = strings.Cut(join, ".")
	if cut {
		return join0, join1, cut
	}
	return "", "", false
}

func Benchmark_join(b *testing.B) {
	join := "a.b"

	b.Run("original", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			original(join)
		}
	})

	b.Run("optimized", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			optimized(join)
		}
	})
}
```

benchmark output
```text
goos: darwin
goarch: amd64
pkg: testgolang/gorm
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
Benchmark_join
Benchmark_join/original
Benchmark_join/original-8         	27360766	        40.37 ns/op	      32 B/op	       1 allocs/op
Benchmark_join/optimized
Benchmark_join/optimized-8        	158664487	         7.664 ns/op	       0 B/op	       0 allocs/op
PASS

Process finished with the exit code 0
```