### PR TITLE
feat: Add optional case-insensitive matching for schema field lookup

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -270,7 +270,7 @@ func (db *DB) assignInterfacesToValue(values ...interface{}) {
 				db.assignInterfacesToValue(exprs)
 			}
 		default:
-			if s, err := schema.Parse(value, db.cacheStore, db.NamingStrategy); err == nil {
+			if s, err := schema.ParseWithCaseInsensitivity(value, db.cacheStore, db.NamingStrategy, db.CaseInsensitiveSchemaFields); err == nil {
 				reflectValue := reflect.Indirect(reflect.ValueOf(value))
 				switch reflectValue.Kind() {
 				case reflect.Struct:

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,12 @@ go 1.18
 require (
 	github.com/jinzhu/inflection v1.0.0
 	github.com/jinzhu/now v1.1.5
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/text v0.20.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/text v0.20.0 h1:gK/Kv2otX8gz+wn7Rmb3vT96ZwuoxnQlY+HlJVj7Qug=
 golang.org/x/text v0.20.0/go.mod h1:D4IsuqiFMhST5bX19pQ9ikHC2GsaKyk/oF+pn3ducp4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/gorm.go
+++ b/gorm.go
@@ -60,6 +60,8 @@ type Config struct {
 	TranslateError bool
 	// PropagateUnscoped propagate Unscoped to every other nested statement
 	PropagateUnscoped bool
+	// CaseInsensitiveSchemaFields enabling case insensitivity for schema fields
+	CaseInsensitiveSchemaFields bool
 
 	// ClauseBuilders clause builder
 	ClauseBuilders map[string]clause.ClauseBuilder
@@ -111,21 +113,22 @@ type DB struct {
 
 // Session session config when create session with Session() method
 type Session struct {
-	DryRun                   bool
-	PrepareStmt              bool
-	NewDB                    bool
-	Initialized              bool
-	SkipHooks                bool
-	SkipDefaultTransaction   bool
-	DisableNestedTransaction bool
-	AllowGlobalUpdate        bool
-	FullSaveAssociations     bool
-	PropagateUnscoped        bool
-	QueryFields              bool
-	Context                  context.Context
-	Logger                   logger.Interface
-	NowFunc                  func() time.Time
-	CreateBatchSize          int
+	DryRun                      bool
+	PrepareStmt                 bool
+	NewDB                       bool
+	Initialized                 bool
+	SkipHooks                   bool
+	SkipDefaultTransaction      bool
+	DisableNestedTransaction    bool
+	AllowGlobalUpdate           bool
+	FullSaveAssociations        bool
+	PropagateUnscoped           bool
+	QueryFields                 bool
+	CaseInsensitiveSchemaFields bool
+	Context                     context.Context
+	Logger                      logger.Interface
+	NowFunc                     func() time.Time
+	CreateBatchSize             int
 }
 
 // Open initialize db session based on dialector
@@ -275,6 +278,10 @@ func (db *DB) Session(config *Session) *DB {
 
 	if config.PropagateUnscoped {
 		txConfig.PropagateUnscoped = true
+	}
+
+	if config.CaseInsensitiveSchemaFields {
+		txConfig.CaseInsensitiveSchemaFields = true
 	}
 
 	if config.Context != nil || config.PrepareStmt || config.SkipHooks {

--- a/scan.go
+++ b/scan.go
@@ -211,7 +211,7 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 
 		if sch != nil {
 			if reflectValueType != sch.ModelType && reflectValueType.Kind() == reflect.Struct {
-				sch, _ = schema.Parse(db.Statement.Dest, db.cacheStore, db.NamingStrategy)
+				sch, _ = schema.ParseWithCaseInsensitivity(db.Statement.Dest, db.cacheStore, db.NamingStrategy, db.CaseInsensitiveSchemaFields)
 			}
 
 			if len(columns) == 1 {

--- a/schema/field.go
+++ b/schema/field.go
@@ -398,7 +398,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 
 			cacheStore := &sync.Map{}
 			cacheStore.Store(embeddedCacheKey, true)
-			if field.EmbeddedSchema, err = getOrParse(fieldValue.Interface(), cacheStore, embeddedNamer{Table: schema.Table, Namer: schema.namer}); err != nil {
+			if field.EmbeddedSchema, err = getOrParse(fieldValue.Interface(), cacheStore, embeddedNamer{Table: schema.Table, Namer: schema.namer}, schema.FieldsCaseInsensitive); err != nil {
 				schema.err = err
 			}
 

--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -75,7 +75,7 @@ func (schema *Schema) parseRelation(field *Field) *Relationship {
 		}
 	)
 
-	if relation.FieldSchema, err = getOrParse(fieldValue, schema.cacheStore, schema.namer); err != nil {
+	if relation.FieldSchema, err = getOrParse(fieldValue, schema.cacheStore, schema.namer, schema.FieldsCaseInsensitive); err != nil {
 		schema.err = fmt.Errorf("failed to parse field: %s, error: %w", field.Name, err)
 		return nil
 	}
@@ -360,8 +360,8 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 		Tag:  `gorm:"-"`,
 	})
 
-	if relation.JoinTable, err = Parse(reflect.New(reflect.StructOf(joinTableFields)).Interface(), schema.cacheStore,
-		schema.namer); err != nil {
+	if relation.JoinTable, err = ParseWithCaseInsensitivity(reflect.New(reflect.StructOf(joinTableFields)).Interface(), schema.cacheStore,
+		schema.namer, schema.FieldsCaseInsensitive); err != nil {
 		schema.err = err
 	}
 	relation.JoinTable.Name = many2many

--- a/statement.go
+++ b/statement.go
@@ -408,7 +408,7 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 				reflectValue = reflectValue.Elem()
 			}
 
-			if s, err := schema.Parse(arg, stmt.DB.cacheStore, stmt.DB.NamingStrategy); err == nil {
+			if s, err := schema.ParseWithCaseInsensitivity(arg, stmt.DB.cacheStore, stmt.DB.NamingStrategy, stmt.DB.CaseInsensitiveSchemaFields); err == nil {
 				selectedColumns := map[string]bool{}
 				if idx == 0 {
 					for _, v := range args[1:] {
@@ -510,7 +510,7 @@ func (stmt *Statement) Parse(value interface{}) (err error) {
 }
 
 func (stmt *Statement) ParseWithSpecialTableName(value interface{}, specialTableName string) (err error) {
-	if stmt.Schema, err = schema.ParseWithSpecialTableName(value, stmt.DB.cacheStore, stmt.DB.NamingStrategy, specialTableName); err == nil && stmt.Table == "" {
+	if stmt.Schema, err = schema.ParseWithSpecialTableName(value, stmt.DB.cacheStore, stmt.DB.NamingStrategy, stmt.DB.CaseInsensitiveSchemaFields, specialTableName); err == nil && stmt.Table == "" {
 		if tables := strings.Split(stmt.Schema.Table, "."); len(tables) == 2 {
 			stmt.TableExpr = &clause.Expr{SQL: stmt.Quote(stmt.Schema.Table)}
 			stmt.Table = tables[1]


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Adds a new configuration option to ignore case sensitivity when associating table and column names with the target schema. Requires opting in. The default behavior is unchanged.

### User Case Description

As a developer supporting an application which supports multiple databases, all with different default casing and case sensitivity implementations, I want to use structs with consistent naming from a Go perspective while keeping table and column names consistent with the casing for the target database. This avoids the need to quote all future interactions with the database to match a specific casing. In order to preserve the current behavior, matching schema fields without case sensitivity should be optional.