### PR TITLE
feat: Add table name separator configuration function to support mult…

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -17,6 +17,9 @@ import (
 // for Config.cacheStore store PreparedStmtDB key
 const preparedStmtDBKey = "preparedStmt"
 
+// DefaultTableNameSplit default table name split
+var DefaultTableNameSplit = 2
+
 // Config GORM config
 type Config struct {
 	// GORM perform single create, update, delete operations in transactions by default to ensure database data integrity
@@ -71,6 +74,11 @@ type Config struct {
 
 	callbacks  *callbacks
 	cacheStore *sync.Map
+}
+
+// SetTableNameSplit set default table name split
+func SetTableNameSplit(split int) {
+	DefaultTableNameSplit = split
 }
 
 // Apply update config to new config
@@ -218,10 +226,11 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 	}
 
 	db.Statement = &Statement{
-		DB:       db,
-		ConnPool: db.ConnPool,
-		Context:  context.Background(),
-		Clauses:  map[string]clause.Clause{},
+		DB:             db,
+		ConnPool:       db.ConnPool,
+		Context:        context.Background(),
+		Clauses:        map[string]clause.Clause{},
+		TableNameSplit: DefaultTableNameSplit,
 	}
 
 	if err == nil && !config.DisableAutomaticPing {

--- a/statement.go
+++ b/statement.go
@@ -48,6 +48,7 @@ type Statement struct {
 	assigns              []interface{}
 	scopes               []func(*DB) *DB
 	Result               *result
+	TableNameSplit       int
 }
 
 type join struct {
@@ -503,9 +504,9 @@ func (stmt *Statement) Parse(value interface{}) (err error) {
 
 func (stmt *Statement) ParseWithSpecialTableName(value interface{}, specialTableName string) (err error) {
 	if stmt.Schema, err = schema.ParseWithSpecialTableName(value, stmt.DB.cacheStore, stmt.DB.NamingStrategy, specialTableName); err == nil && stmt.Table == "" {
-		if tables := strings.Split(stmt.Schema.Table, "."); len(tables) == 2 {
+		if tables := strings.Split(stmt.Schema.Table, "."); len(tables) == stmt.TableNameSplit {
 			stmt.TableExpr = &clause.Expr{SQL: stmt.Quote(stmt.Schema.Table)}
-			stmt.Table = tables[1]
+			stmt.Table = tables[stmt.TableNameSplit-1]
 			return
 		}
 


### PR DESCRIPTION
### What did this pull request do?

The table name separator configuration function supports multi-level database table names instead of the default fixed format.


