### PR TITLE
test: update MySQL test matrix to use official images and add 9.0, 8.4 versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
   mysql:
     strategy:
       matrix:
-        dbversion: ['mysql/mysql-server:latest', 'mysql:5.7']
+        dbversion: ['mysql:9.0', 'mysql:8.4', 'mysql:8.0', 'mysql:5.7']
         go: ['1.23', '1.24']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
   mysql:
     strategy:
       matrix:
-        dbversion: ['mysql:9.0', 'mysql:8.4', 'mysql:8.0', 'mysql:5.7']
+        dbversion: ['mysql:9', 'mysql:8', 'mysql:5.7']
         go: ['1.23', '1.24']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

#### Summary
- Update MySQL test matrix to use official Docker images
- Add MySQL 9.0 and 8.4 to CI tests

#### Changes
- Replace `mysql/mysql-server:latest` with `mysql:8.0` for consistency with official images
- Add MySQL 9.0 (latest) and 8.4 to ensure compatibility with newer versions
- Keep MySQL 5.7 for backward compatibility testing

### User Case Description

<!-- Your use case -->
