### PR TITLE
fixes #7486

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -457,7 +457,7 @@ func (field *Field) setupValuerAndSetter() {
 	switch {
 	case len(field.StructField.Index) == 1 && fieldIndex > 0:
 		field.ValueOf = func(ctx context.Context, value reflect.Value) (interface{}, bool) {
-			fieldValue := reflect.Indirect(value).Field(fieldIndex)
+			fieldValue := reflect.Indirect(value).FieldByName(field.Name)
 			return fieldValue.Interface(), fieldValue.IsZero()
 		}
 	default:

--- a/tests/check_subset_model_change_test.go
+++ b/tests/check_subset_model_change_test.go
@@ -2,42 +2,87 @@ package tests_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 type Man struct {
-	ID  int
-	Age int
-	Name string
+	ID     int
+	Age    int
+	Name   string
+	Detail string
+}
+
+// Panic-safe BeforeUpdate hook that checks for Changed("age")
+func (m *Man) BeforeUpdate(tx *gorm.DB) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic in BeforeUpdate: %v", r)
+		}
+	}()
+
+	if !tx.Statement.Changed("age") {
+		return nil
+	}
+	return nil
+}
+
+func (m *Man) update(data interface{}) error {
+	return DB.Set("data", data).Model(m).Where("id = ?", m.ID).Updates(data).Error
 }
 
 func TestBeforeUpdateStatementChanged(t *testing.T) {
+	DB.AutoMigrate(&Man{})
 	type TestCase struct {
 		BaseObjects Man
-		change interface{}
+		change      interface{}
+		expectError bool
 	}
-	fmt.Println("Running Eshan Jogwar Test")
+
 	testCases := []TestCase{
 		{
-			BaseObjects: Man{ID: 12231234, Age: 18, Name: "random-name"},
+			BaseObjects: Man{ID: 1, Age: 18, Name: "random-name"},
 			change: struct {
 				Age int
 			}{Age: 20},
+			expectError: false,
 		},
 		{
-			BaseObjects: Man{ID: 12231234, Age: 18, Name: "random-name"},
+			BaseObjects: Man{ID: 2, Age: 18, Name: "random-name"},
 			change: struct {
-				Age int
 				Name string
-			}{Age: 20, Name: "another-random-name"},
+			}{Name: "name-only"},
+			expectError: true,
+		},
+		{
+			BaseObjects: Man{ID: 2, Age: 18, Name: "random-name"},
+			change: struct {
+				Name string
+				Age int
+			}{Name: "name-only", Age: 20},
+			expectError: false,
 		},
 	}
 
 	for _, test := range testCases {
-		// err := test.BaseObjects.update(test.change)
-		err := DB.Set("data", test.change).Model(test.BaseObjects).Where("id = ?", test.BaseObjects.ID).Updates(test.change).Error
-		if err != nil {
-			t.Errorf(err.Error())
+		DB.Create(&test.BaseObjects)
+
+		// below comment is stored for future reference
+		// err := DB.Set("data", test.change).Model(&test.BaseObjects).Where("id = ?", test.BaseObjects.ID).Updates(test.change).Error
+		err := test.BaseObjects.update(test.change)
+		if strings.Contains(fmt.Sprint(err), "panic in BeforeUpdate") {
+			if !test.expectError {
+				t.Errorf("unexpected panic in BeforeUpdate for input: %+v\nerror: %v", test.change, err)
+			}
+		} else {
+			if test.expectError {
+				t.Errorf("expected panic did not occur for input: %+v", test.change)
+			}
+			if err != nil {
+				t.Errorf("unexpected GORM error: %v", err)
+			}
 		}
 	}
 }

--- a/tests/check_subset_model_change_test.go
+++ b/tests/check_subset_model_change_test.go
@@ -1,0 +1,43 @@
+package tests_test
+
+import (
+	"fmt"
+	"testing"
+)
+
+type Man struct {
+	ID  int
+	Age int
+	Name string
+}
+
+func TestBeforeUpdateStatementChanged(t *testing.T) {
+	type TestCase struct {
+		BaseObjects Man
+		change interface{}
+	}
+	fmt.Println("Running Eshan Jogwar Test")
+	testCases := []TestCase{
+		{
+			BaseObjects: Man{ID: 12231234, Age: 18, Name: "random-name"},
+			change: struct {
+				Age int
+			}{Age: 20},
+		},
+		{
+			BaseObjects: Man{ID: 12231234, Age: 18, Name: "random-name"},
+			change: struct {
+				Age int
+				Name string
+			}{Age: 20, Name: "another-random-name"},
+		},
+	}
+
+	for _, test := range testCases {
+		// err := test.BaseObjects.update(test.change)
+		err := DB.Set("data", test.change).Model(test.BaseObjects).Where("id = ?", test.BaseObjects.ID).Updates(test.change).Error
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
it fixes #7486. a subset of struct of the main model when passed through to update would create an error in the tx.Statement.Changed() function. this PR fixed this problem

below is a example code which demonstrates that condition
![image](https://github.com/user-attachments/assets/390de51d-fece-4147-844c-527868784096)

struct used for the reference
type Man struct {
	Id string
	Age string
	Name string
	Detail string
}

The problem was that if a complete man struct gorm can predict which the column by column index but if a shorter subset of the struct is passed for quick changes then the index of the column lets say Age will not equate to the index in the struct.

<!--
provide a general description of the code changes in your pull request

changed the field.valueOf to return by the name of the field getting passed by the user and not using existing precalculated indexes
-->

### User Case Description

<!-- Your use case -->
fixed issue of #7486