### PR TITLE
Fix: Unexpected OR Conditions force converted to AND

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -341,7 +341,9 @@ func (stmt *Statement) BuildCondition(query interface{}, args ...interface{}) []
 				if where, ok := cs.Expression.(clause.Where); ok {
 					if len(where.Exprs) == 1 {
 						if orConds, ok := where.Exprs[0].(clause.OrConditions); ok {
-							where.Exprs[0] = clause.AndConditions(orConds)
+							if len(orConds.Exprs) == 1 {
+								where.Exprs[0] = clause.AndConditions(orConds)
+							}
 						}
 					}
 					conds = append(conds, clause.And(where.Exprs...))

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -632,6 +632,21 @@ func TestOr(t *testing.T) {
 		t.Fatalf("Build OR condition, but got %v", result.Statement.SQL.String())
 	}
 
+	sub := dryDB.Clauses(clause.Where{
+		Exprs: []clause.Expression{
+			clause.OrConditions{
+				Exprs: []clause.Expression{
+					clause.Expr{SQL: "role = ?", Vars: []interface{}{"super_admin"}},
+					clause.Expr{SQL: "role = ?", Vars: []interface{}{"admin"}},
+				},
+			},
+		},
+	})
+	result = dryDB.Where(sub).Find(&User{})
+	if !regexp.MustCompile("SELECT \\* FROM .*users.* WHERE .*role.* = .+ OR .*role.* = .+").MatchString(result.Statement.SQL.String()) {
+		t.Fatalf("Build OR condition, but got %v", result.Statement.SQL.String())
+	}
+
 	result = dryDB.Where("role = ?", "admin").Or("role = ?", "super_admin").Find(&User{})
 	if !regexp.MustCompile("SELECT \\* FROM .*users.* WHERE .*role.* = .+ OR .*role.* = .+").MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("Build OR condition, but got %v", result.Statement.SQL.String())


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fix a bug I found.



<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

* When there is only one `OR` clause inside a where clause, we want ignore the `OR` condition and just make it `AND`. 

However,  current implementation didn't check  when actually there are multi expressions inside `OR` condition,  these expressions are not expected to be modified to `AND`.

Check the demo below.

```go
package main

import (
	"fmt"

	"gorm.io/driver/sqlite"
	"gorm.io/gorm"
	"gorm.io/gorm/clause"
)

type User struct {
	ID   uint
	Name string
	Age  int
}

func main() {
	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
	db.AutoMigrate(&User{})

	// insert data
	db.Create(&User{Name: "Alice", Age: 30})
	db.Create(&User{Name: "Bob", Age: 25})

	sub := db.Clauses(clause.Where{
		Exprs: []clause.Expression{
			clause.OrConditions{
				Exprs: []clause.Expression{
					clause.Expr{SQL: "name = ?", Vars: []interface{}{"Alice"}},
					clause.Expr{SQL: "age = ?", Vars: []interface{}{25}},
				},
			},
		},
	})

	db = db.Debug().Model(&User{})
	var users []User
	db.Where(sub).Find(&users)

	fmt.Println("result：")
	for _, u := range users {
		fmt.Printf("ID=%d Name=%s Age=%d\n", u.ID, u.Name, u.Age)
	}
}

```

Before
```
[0.012ms] [rows:0] SELECT * FROM `users` WHERE name = "Alice" AND age = 25
result：

```


After
```
[0.018ms] [rows:2] SELECT * FROM `users` WHERE (name = "Alice" OR age = 25)
result：
ID=1 Name=Alice Age=30
ID=2 Name=Bob Age=25

```

<!-- Your use case -->
