### PR TITLE
Fix omission of fields in deeply nested joins with long identifiers (#7513)

### DIFF
--- a/schema/naming_test.go
+++ b/schema/naming_test.go
@@ -193,7 +193,7 @@ func TestFormatNameWithStringLongerThan63Characters(t *testing.T) {
 	ns := NamingStrategy{IdentifierMaxLength: 63}
 
 	formattedName := ns.formatName("prefix", "table", "thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString")
-	if formattedName != "prefix_table_thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVer180f2c67" {
+	if formattedName != "prefix_table_thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVerb463f8ff" {
 		t.Errorf("invalid formatted name generated, got %v", formattedName)
 	}
 }
@@ -202,7 +202,7 @@ func TestFormatNameWithStringLongerThan64Characters(t *testing.T) {
 	ns := NamingStrategy{IdentifierMaxLength: 64}
 
 	formattedName := ns.formatName("prefix", "table", "thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString")
-	if formattedName != "prefix_table_thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVery180f2c67" {
+	if formattedName != "prefix_table_thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryb463f8ff" {
 		t.Errorf("invalid formatted name generated, got %v", formattedName)
 	}
 }

--- a/schema/relationship_test.go
+++ b/schema/relationship_test.go
@@ -985,7 +985,7 @@ func TestParseConstraintNameWithSchemaQualifiedLongTableName(t *testing.T) {
 		t.Fatalf("Failed to parse schema")
 	}
 
-	expectedConstraintName := "fk_my_schema_a_very_very_very_very_very_very_very_very_l4db13eec"
+	expectedConstraintName := "fk_my_schema_a_very_very_very_very_very_very_very_very_l46bfd72a"
 	constraint := s.Relationships.Relations["Author"].ParseConstraint()
 
 	if constraint.Name != expectedConstraintName {

--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"sort"
 	"testing"
@@ -475,4 +476,82 @@ func TestJoinsPreload_Issue7013_NoEntries(t *testing.T) {
 	})
 
 	AssertEqual(t, len(entries), 0)
+}
+
+func TestJoinsLongName_Issue7513(t *testing.T) {
+	if os.Getenv("GORM_DIALECT") != "postgres" {
+		// Another DB may not support UTF-8 characters in identifiers
+		return
+	}
+	type (
+		Owner struct {
+			gorm.Model
+			Name string
+		}
+
+		Land struct {
+			gorm.Model
+			Address                                                                             string
+			OwneeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeerID uint `gorm:"column:owner_id"`
+			Owneeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeer   *Owner
+		}
+
+		Design struct {
+			gorm.Model
+			Name𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃x string
+		}
+
+		Building struct {
+			gorm.Model
+			Name                                                                  string
+			Laaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaand𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃xID uint `gorm:"column:land_id"`
+			Laaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaand𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃x   *Land
+
+			DesignID uint `gorm:"column:design_id"`
+			Design   *Design
+		}
+	)
+
+	DB.Migrator().DropTable(&Building{}, &Owner{}, &Land{}, Design{})
+	DB.Migrator().AutoMigrate(&Building{}, &Owner{}, &Land{}, Design{})
+
+	home := &Building{
+		Model: gorm.Model{
+			ID: 1,
+		},
+		Name: "Awesome Building",
+		Laaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaand𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃xID: 2,
+		Laaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaand𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃x: &Land{
+			Model: gorm.Model{
+				ID: 2,
+			},
+			Address: "Awesome Street",
+			OwneeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeerID: 3,
+			Owneeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeer: &Owner{
+				Model: gorm.Model{
+					ID: 3,
+				},
+				Name: "Awesome Person",
+			},
+		},
+		DesignID: 4,
+		Design: &Design{
+			Model: gorm.Model{
+				ID: 4,
+			},
+			Name𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃x: "Awesome Design",
+		},
+	}
+	DB.Create(home)
+
+	var entries []Building
+	assert.NotPanics(t, func() {
+		assert.NoError(t,
+			DB.Joins("Laaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaand𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃x").
+				Joins("Laaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaand𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃𒀃x.Owneeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeer").
+				Joins("Design").
+				Find(&entries).Error)
+	})
+
+	AssertEqual(t, entries, []Building{*home})
 }


### PR DESCRIPTION

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Fixes https://github.com/go-gorm/gorm/issues/7513
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
PostgreSQL has 63-character limit for identifiers (including select field aliases).
In a long chain of joins we may have a troubles:
```
err = db.Model(&Table1{}).Debug().
	Joins("Looooooooooooooooooooooooooooooooooooooooooooooooooooooooong").
        Joins("Looooooooooooooooooooooooooooooooooooooooooooooooooooooooong.Table2").
        Joins("Looooooooooooooooooooooooooooooooooooooooooooooooooooooooong.Table2.Table3").Find(&objList).Error
```

This code truncates long aliases similar `Namer.UniqueName` and stores a truncated to original map in `db.Statement` that allow to not touch old fileld mapping strategy.
