### PR TITLE
fix: returning all columns with "on conflict do update" 

### DIFF
--- a/callbacks/create.go
+++ b/callbacks/create.go
@@ -80,8 +80,11 @@ func Create(config *Config) func(db *gorm.DB) {
 		ok, mode := hasReturning(db, supportReturning)
 		if ok {
 			if c, ok := db.Statement.Clauses["ON CONFLICT"]; ok {
-				if onConflict, _ := c.Expression.(clause.OnConflict); onConflict.DoNothing {
+				onConflict, _ := c.Expression.(clause.OnConflict)
+				if onConflict.DoNothing {
 					mode |= gorm.ScanOnConflictDoNothing
+				} else if len(onConflict.DoUpdates) > 0 || onConflict.UpdateAll {
+					mode |= gorm.ScanUpdate
 				}
 			}
 


### PR DESCRIPTION
When using returning clauses in conjunction with `on conflicted do update` must be considered as ScanUpdate.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non-breaking API changes
- [x] Tested

### What did this pull request do?

This should fix https://github.com/go-gorm/gorm/issues/7538
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
When using `CreateInBatches` with `Returning{}` in conjunction with `ON CONFLICTED DO UPDATE`, it will either crash with panic, or run successfully without updating the object.

The test will fails on both cases.

Panic example:
```
2025/07/25 19:07:38 testing sqlite3...
=== RUN   TestGORM
--- FAIL: TestGORM (0.00s)
panic: reflect: reflect.Value.SetLen using unaddressable value [recovered]
	panic: reflect: reflect.Value.SetLen using unaddressable value

goroutine 5 [running]:
testing.tRunner.func1.2({0x10342bae0, 0xc000045d70})
	/opt/homebrew/Cellar/go/1.24.5/libexec/src/testing/testing.go:1734 +0x2bc
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.24.5/libexec/src/testing/testing.go:1737 +0x47c
panic({0x10342bae0?, 0xc000045d70?})
	/opt/homebrew/Cellar/go/1.24.5/libexec/src/runtime/panic.go:792 +0x124
reflect.flag.mustBeAssignableSlow(0x97)
	/opt/homebrew/Cellar/go/1.24.5/libexec/src/reflect/value.go:260 +0x88
reflect.flag.mustBeAssignable(...)
	/opt/homebrew/Cellar/go/1.24.5/libexec/src/reflect/value.go:247
reflect.Value.SetLen({0x103418d40?, 0xc00000e018?, 0xc0000113aa?}, 0x0)
	/opt/homebrew/Cellar/go/1.24.5/libexec/src/reflect/value.go:2157 +0x4c
gorm.io/gorm.Scan({0x103543868, 0xc000359540}, 0xc00042d9b0, 0x0)
	/Users/phongphan/gorm-playground/gorm/scan.go:304 +0xd74
gorm.io/gorm/callbacks.RegisterDefaultCallbacks.Create.func3(0xc00042d9b0)
	/Users/phongphan/gorm-playground/gorm/callbacks/create.go:95 +0x764
gorm.io/gorm.(*processor).Execute(0xc00031d1d0, 0xc00042d9b0)
	/Users/phongphan/gorm-playground/gorm/callbacks.go:130 +0x7fc
gorm.io/gorm.(*DB).CreateInBatches.func1(...)
	/Users/phongphan/gorm-playground/gorm/finisher_api.go:50
gorm.io/gorm.(*DB).CreateInBatches(0xc00042d920, {0x103418d80, 0xc0001adf68}, 0x2)
	/Users/phongphan/gorm-playground/gorm/finisher_api.go:60 +0x4a8
gorm.io/playground.TestGORM(0xc000003c00)
	/Users/phongphan/gorm-playground/main_test.go:22 +0x418
testing.tRunner(0xc000003c00, 0x1035345e0)
	/opt/homebrew/Cellar/go/1.24.5/libexec/src/testing/testing.go:1792 +0x184
created by testing.(*T).Run in goroutine 1
	/opt/homebrew/Cellar/go/1.24.5/libexec/src/testing/testing.go:1851 +0x688
FAIL	gorm.io/playground	0.387s
FAIL
```

This PR add the `RETURNING` with `ON CONFLICTED DO UPDATE` as ScanUpdate.