### PR TITLE
feat(slog-integration)

### DIFF
--- a/logger/slog.go
+++ b/logger/slog.go
@@ -66,12 +66,10 @@ func (l *slogLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql 
 	if rows != -1 {
 		fields = append(fields, slog.Int64("rows", rows))
 	}
-	if err != nil {
-		fields = append(fields, slog.String("error", err.Error()))
-	}
 
 	switch {
 	case err != nil && (!l.IgnoreRecordNotFoundError || !errors.Is(err, ErrRecordNotFound)):
+		fields = append(fields, slog.String("error", err.Error()))
 		l.Logger.ErrorContext(ctx, "SQL executed", slog.Attr{
 			Key:   "trace",
 			Value: slog.GroupValue(fields...),


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Adds a basic `slog-based` logger for GORM.

### User Case Description

Many projects use `slog` as the standard logger. This PR provides a simple GORM logger that integrates with `slog` for consistency and ease of use.
