### PR TITLE
fix: Updates change from T to interface{}

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -63,7 +63,7 @@ type ChainInterface[T any] interface {
 
 	Delete(ctx context.Context) (rowsAffected int, err error)
 	Update(ctx context.Context, name string, value any) (rowsAffected int, err error)
-	Updates(ctx context.Context, t T) (rowsAffected int, err error)
+	Updates(ctx context.Context, values interface{}) (rowsAffected int, err error)
 	Count(ctx context.Context, column string) (result int64, err error)
 }
 
@@ -507,8 +507,8 @@ func (c chainG[T]) Update(ctx context.Context, name string, value any) (rowsAffe
 	return int(res.RowsAffected), res.Error
 }
 
-func (c chainG[T]) Updates(ctx context.Context, t T) (rowsAffected int, err error) {
-	res := c.g.apply(ctx).Updates(t)
+func (c chainG[T]) Updates(ctx context.Context, values interface{}) (rowsAffected int, err error) {
+	res := c.g.apply(ctx).Updates(values)
 	return int(res.RowsAffected), res.Error
 }
 


### PR DESCRIPTION
fix Updates() to use map

https://gorm.io/zh_CN/docs/update.html

// Update attributes with `map`
err := gorm.G[User](db).Where("id = ?", 111).Updates(ctx, map[string]interface{}{"name": "hello", "age": 18, "active": false})
// UPDATE users SET name='hello', age=18, active=false, updated_at='2013-11-17 21:34:10' WHERE id=111;