### PR TITLE
avoid copying structures with embedded mutexs

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -425,12 +425,12 @@ func (c chainG[T]) Preload(association string, query func(db PreloadBuilder) err
 			relation, ok := db.Statement.Schema.Relationships.Relations[association]
 			if !ok {
 				if preloadFields := strings.Split(association, "."); len(preloadFields) > 1 {
-					relationships := db.Statement.Schema.Relationships
+					relationships := &db.Statement.Schema.Relationships
 					for _, field := range preloadFields {
 						var ok bool
 						relation, ok = relationships.Relations[field]
 						if ok {
-							relationships = relation.FieldSchema.Relationships
+							relationships = &relation.FieldSchema.Relationships
 						} else {
 							db.AddError(fmt.Errorf("relation %s not found", association))
 							return nil

--- a/schema/schema_helper_test.go
+++ b/schema/schema_helper_test.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm/utils/tests"
 )
 
-func checkSchema(t *testing.T, s *schema.Schema, v schema.Schema, primaryFields []string) {
+func checkSchema(t *testing.T, s *schema.Schema, v *schema.Schema, primaryFields []string) {
 	t.Run("CheckSchema/"+s.Name, func(t *testing.T) {
 		tests.AssertObjEqual(t, s, v, "Name", "Table")
 

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -46,7 +46,7 @@ func TestParseSchemaWithPointerFields(t *testing.T) {
 
 func checkUserSchema(t *testing.T, user *schema.Schema) {
 	// check schema
-	checkSchema(t, user, schema.Schema{Name: "User", Table: "users"}, []string{"ID"})
+	checkSchema(t, user, &schema.Schema{Name: "User", Table: "users"}, []string{"ID"})
 
 	// check fields
 	fields := []schema.Field{
@@ -139,7 +139,7 @@ func TestParseSchemaWithAdvancedDataType(t *testing.T) {
 	}
 
 	// check schema
-	checkSchema(t, user, schema.Schema{Name: "AdvancedDataTypeUser", Table: "advanced_data_type_users"}, []string{"ID"})
+	checkSchema(t, user, &schema.Schema{Name: "AdvancedDataTypeUser", Table: "advanced_data_type_users"}, []string{"ID"})
 
 	// check fields
 	fields := []schema.Field{


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fixes warning like this:

assignment copies lock value to relationships:
gorm.io/gorm/schema.Relationships contains sync.RWMutex
