### PR TITLE
fix: build failure on Go versions below 1.21

### DIFF
--- a/logger/slog.go
+++ b/logger/slog.go
@@ -1,3 +1,5 @@
+//go:build go1.21
+
 package logger
 
 import (


### PR DESCRIPTION
add build constraint for [`slog.go`](https://github.com/go-gorm/gorm/blob/22d5239dec782d09f54bc11acbd7c99b85f770d2/logger/slog.go)

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
Fix build failure on Go versions below 1.21: add build constraint for slog logger.

### User Case Description

<!-- Your use case -->

Build fails in Go environments from version `1.18` to `1.20`.

- https://github.com/godoes/gorm-dameng/actions/runs/17305534898/job/49127393605#step:8:5
- https://github.com/godoes/gorm-dameng/actions/runs/17474191299/job/49629839198?pr=48#step:8:5

```shell
Error: ../../../go/pkg/mod/gorm.io/gorm@v1.30.3/logger/slog.go:7:2:
  package log/slog is not in GOROOT (/opt/hostedtoolcache/go/1.20.14/x64/src/log/slog)
Error: Process completed with exit code 1.
```