### PR TITLE
fix: set model clause in preload function after conds loop for correct query building  

### DIFF
--- a/callbacks/preload.go
+++ b/callbacks/preload.go
@@ -275,8 +275,6 @@ func preload(tx *gorm.DB, rel *schema.Relationship, conds []interface{}, preload
 	column, values := schema.ToQueryValues(clause.CurrentTable, relForeignKeys, foreignValues)
 
 	if len(values) != 0 {
-		tx = tx.Model(reflectResults.Addr().Interface()).Where(clause.IN{Column: column, Values: values})
-
 		for _, cond := range conds {
 			if fc, ok := cond.(func(*gorm.DB) *gorm.DB); ok {
 				tx = fc(tx)
@@ -284,6 +282,7 @@ func preload(tx *gorm.DB, rel *schema.Relationship, conds []interface{}, preload
 				inlineConds = append(inlineConds, cond)
 			}
 		}
+		tx = tx.Model(reflectResults.Addr().Interface()).Where(clause.IN{Column: column, Values: values})
 
 		if len(inlineConds) > 0 {
 			tx = tx.Where(inlineConds[0], inlineConds[1:]...)


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
This pull request fixes the order of query construction in GORM's preload logic.
It moves the assignment of the Model clause to after the conditions loop, ensuring all conditions are applied before building the final query.
This change prevents conditions from being overridden and guarantees correct SQL generation for preloading associations.

### User Case Description

When preloading an entity in GORM, if you use a raw query as a condition in the preload function, like:
```
.Preload("ExampleEntity", func(db *gorm.DB) *gorm.DB {
    return db.Where("id IN (?)", db.Raw("<raw_query>"))
})
```
the raw query replaces the default preload query, so only entities matching the raw query are loaded.
This is useful when you need to filter preloaded associations using custom SQL logic
