### PR TITLE
fix slogLogger to support ParameterizedQueries Config

### DIFF
--- a/logger/slog.go
+++ b/logger/slog.go
@@ -88,3 +88,11 @@ func (l *slogLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql 
 		})
 	}
 }
+
+// ParamsFilter filter params
+func (l *slogLogger) ParamsFilter(ctx context.Context, sql string, params ...interface{}) (string, []interface{}) {
+	if l.Parameterized {
+		return sql, nil
+	}
+	return sql, params
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Add ParamsFilter method to slogLogger

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
After update, `logger.NewSlogLogger` supports `ParameterizedQueries`. Now, it has no effect.
<!-- Your use case -->
