### PR TITLE
Fix: Log parameterised variables by default

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -76,6 +76,7 @@ var (
 		SlowThreshold:             200 * time.Millisecond,
 		LogLevel:                  Warn,
 		IgnoreRecordNotFoundError: false,
+		ParameterizedQueries:      true,
 		Colorful:                  true,
 	})
 	// Recorder logger records running SQL into a recorder instance


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR aims to update the default logger to not log out unparameterised variables in a query by default. Because this field is not set, it falls back to the default value of the boolean which is `false`.

### User Case Description

If I was to use the default Logger and I perform a query that returns no records, because of the `IgnoreRecordNotFoundError: false` parameter that is also set by default, then my full unparameterised query would be logged and potentially sent to whatever log aggregator I am making use of.

For example, if I were to perform a SELECT with an email address as the conditional filter and no results were returned, the plain email address could be accidentally sent over to a log aggregator system in plain text, rather than an anonymous placeholder (this is a crude example, but a query could contain any sensitive information).

Instead of it being the default behaviour, should this be something that I should have to explicitly enable? Happy to discuss further 👍🏻 