### PR TITLE
Add support for Go 1.23 iter.Seq as SQL parameter values

### DIFF
--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"iter"
 	"reflect"
 	"regexp"
 	"sort"
@@ -239,6 +240,19 @@ func TestFind(t *testing.T) {
 				CheckUser(t, models3[idx], user)
 			})
 		}
+	}
+
+	// Test Go 1.23+ iterator support
+	var nameIterator iter.Seq[string] = func(yield func(string) bool) {
+		names := []string{"find"}
+		for _, name := range names {
+			if !yield(name) {
+				return
+			}
+		}
+	}
+	if err := DB.Where("name in (?)", nameIterator).Find(&models).Error; err != nil || len(models) != 3 {
+		t.Errorf("errors happened when query find with in clause and iterator parameter: %v, length: %v", err, len(models))
 	}
 
 	var none []User

--- a/utils/iterator_go122.go
+++ b/utils/iterator_go122.go
@@ -1,0 +1,11 @@
+//go:build !go1.23
+// +build !go1.23
+
+package utils
+
+import "reflect"
+
+// ConvertIteratorToSlice is a no-op for Go versions < 1.23
+func ConvertIteratorToSlice(v reflect.Value) (reflect.Value, bool) {
+	return v, false
+}

--- a/utils/iterator_go123.go
+++ b/utils/iterator_go123.go
@@ -1,0 +1,76 @@
+//go:build go1.23
+// +build go1.23
+
+package utils
+
+import (
+	"reflect"
+)
+
+// isIteratorSeq checks if the given reflect.Value is an iter.Seq[T]
+func isIteratorSeq(v reflect.Value) bool {
+	if !v.IsValid() {
+		return false
+	}
+
+	t := v.Type()
+	if t.Kind() != reflect.Func {
+		return false
+	}
+
+	// Check if it's a function with the signature: func(func(T) bool)
+	if t.NumIn() != 1 || t.NumOut() != 0 {
+		return false
+	}
+
+	// Check if the parameter is func(T) bool
+	paramType := t.In(0)
+	if paramType.Kind() != reflect.Func {
+		return false
+	}
+
+	if paramType.NumIn() != 1 || paramType.NumOut() != 1 {
+		return false
+	}
+
+	// Check if the return type is bool
+	if paramType.Out(0) != reflect.TypeOf(true) {
+		return false
+	}
+
+	return true
+}
+
+// convertIteratorSeqToSlice converts an iter.Seq[T] to a slice of T
+func convertIteratorSeqToSlice(v reflect.Value) reflect.Value {
+	// Get the element type from the yield function parameter
+	yieldFuncType := v.Type().In(0)
+	elemType := yieldFuncType.In(0)
+
+	// Create a slice type for the elements
+	sliceType := reflect.SliceOf(elemType)
+	result := reflect.MakeSlice(sliceType, 0, 0)
+
+	// Create the yield function that appends to our slice
+	yieldFunc := reflect.MakeFunc(yieldFuncType, func(args []reflect.Value) []reflect.Value {
+		if len(args) > 0 {
+			result = reflect.Append(result, args[0])
+		}
+		// Always return true to continue iteration
+		return []reflect.Value{reflect.ValueOf(true)}
+	})
+
+	// Call the iterator with our yield function
+	v.Call([]reflect.Value{yieldFunc})
+
+	return result
+}
+
+// ConvertIteratorToSlice converts iter.Seq[T] to the appropriate slice []T
+func ConvertIteratorToSlice(v reflect.Value) (reflect.Value, bool) {
+	if isIteratorSeq(v) {
+		return convertIteratorSeqToSlice(v), true
+	}
+
+	return v, false
+}

--- a/utils/iterator_test.go
+++ b/utils/iterator_test.go
@@ -1,0 +1,96 @@
+//go:build go1.23
+// +build go1.23
+
+package utils
+
+import (
+	"iter"
+	"maps"
+	"reflect"
+	"testing"
+)
+
+func TestIsIteratorSeq(t *testing.T) {
+	// Create a simple Seq iterator
+	m := map[int]any{0: nil, 1: nil, 2: nil}
+	seq := maps.Keys(m)
+
+	v := reflect.ValueOf(seq)
+	if !isIteratorSeq(v) {
+		t.Error("Expected IsIteratorSeq to return true for iter.Seq[int]")
+	}
+
+	// Test with non-iterator
+	notSeq := func() {}
+	v2 := reflect.ValueOf(notSeq)
+	if isIteratorSeq(v2) {
+		t.Error("Expected IsIteratorSeq to return false for regular function")
+	}
+}
+
+func TestConvertIteratorSeqToSlice(t *testing.T) {
+	// Create test data
+	expected := []int{1, 2, 3}
+
+	// Create iterator
+	var seq iter.Seq[int] = func(yield func(int) bool) {
+		for _, val := range expected {
+			if !yield(val) {
+				return
+			}
+		}
+	}
+
+	v := reflect.ValueOf(seq)
+	result := convertIteratorSeqToSlice(v)
+
+	if result.Kind() != reflect.Slice {
+		t.Errorf("Expected slice, got %v", result.Kind())
+	}
+
+	resultSlice := result.Interface().([]int)
+	if len(resultSlice) != len(expected) {
+		t.Errorf("Expected length %d, got %d", len(expected), len(resultSlice))
+	}
+
+	for i, val := range resultSlice {
+		if val != expected[i] {
+			t.Errorf("Expected %d at index %d, got %d", expected[i], i, val)
+		}
+	}
+}
+
+func TestConvertIteratorToSlice(t *testing.T) {
+	// Test with Seq
+	seq := func(yield func(string) bool) {
+		words := []string{"foo", "bar", "baz"}
+		for _, word := range words {
+			if !yield(word) {
+				return
+			}
+		}
+	}
+
+	v := reflect.ValueOf(seq)
+	result, converted := ConvertIteratorToSlice(v)
+
+	if !converted {
+		t.Error("Expected conversion to succeed for iter.Seq")
+	}
+
+	resultSlice := result.Interface().([]string)
+	expected := []string{"foo", "bar", "baz"}
+
+	if len(resultSlice) != len(expected) {
+		t.Errorf("Expected length %d, got %d", len(expected), len(resultSlice))
+	}
+
+	// Test with non-iterator
+	notIterator := "not an iterator"
+	v2 := reflect.ValueOf(notIterator)
+	_, converted2 := ConvertIteratorToSlice(v2)
+
+	if converted2 {
+		t.Error("Expected conversion to fail for non-iterator")
+	}
+}


### PR DESCRIPTION


- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fixes: https://github.com/go-gorm/gorm/issues/7192

```go
// Note that maps.Keys() returns an `iter.Seq` element in Go 1.23+
db.Delete(&User, "name  IN (?)", maps.Keys(namesToIDs))

panic: failed to encode args[0]: unable to encode (iter.Seq[string])(0x102f20cf0) into text format for text (OID 25): cannot find encode plan
```
