### PR TITLE
fix(UnixSecondSerializer.Value): Avoid panic when handling unsigned integer values

### DIFF
--- a/schema/serializer_test.go
+++ b/schema/serializer_test.go
@@ -10,27 +10,29 @@ import (
 
 func TestUnixSecondSerializer_Value(t *testing.T) {
 	var (
-		intValue    = math.MaxInt32
-		int8Value   = int8(math.MaxInt8)
-		int16Value  = int16(math.MaxInt16)
-		int32Value  = int32(math.MaxInt32)
-		int64Value  = int64(math.MaxInt32)
-		uintValue   = uint(math.MaxUint32)
-		uint8Value  = uint8(math.MaxUint8)
-		uint16Value = uint16(math.MaxUint16)
-		uint32Value = uint32(math.MaxUint32)
-		uint64Value = uint64(math.MaxUint32)
+		intValue      = math.MaxInt64
+		int8Value     = int8(math.MaxInt8)
+		int16Value    = int16(math.MaxInt16)
+		int32Value    = int32(math.MaxInt32)
+		int64Value    = int64(math.MaxInt64)
+		uintValue     = uint(math.MaxInt64)
+		uint8Value    = uint8(math.MaxUint8)
+		uint16Value   = uint16(math.MaxUint16)
+		uint32Value   = uint32(math.MaxUint32)
+		uint64Value   = uint64(math.MaxInt64)
+		maxInt64Plus1 = uint64(math.MaxInt64 + 1)
 
-		intPtrValue    = &intValue
-		int8PtrValue   = &int8Value
-		int16PtrValue  = &int16Value
-		int32PtrValue  = &int32Value
-		int64PtrValue  = &int64Value
-		uintPtrValue   = &uintValue
-		uint8PtrValue  = &uint8Value
-		uint16PtrValue = &uint16Value
-		uint32PtrValue = &uint32Value
-		uint64PtrValue = &uint64Value
+		intPtrValue      = &intValue
+		int8PtrValue     = &int8Value
+		int16PtrValue    = &int16Value
+		int32PtrValue    = &int32Value
+		int64PtrValue    = &int64Value
+		uintPtrValue     = &uintValue
+		uint8PtrValue    = &uint8Value
+		uint16PtrValue   = &uint16Value
+		uint32PtrValue   = &uint32Value
+		uint64PtrValue   = &uint64Value
+		maxInt64Plus1Ptr = &maxInt64Plus1
 	)
 	tests := []struct {
 		name    string
@@ -99,6 +101,12 @@ func TestUnixSecondSerializer_Value(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "maxInt64+1",
+			value:   maxInt64Plus1,
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name:    "*int",
 			value:   intPtrValue,
 			want:    time.Unix(int64(*intPtrValue), 0).UTC(),
@@ -157,6 +165,12 @@ func TestUnixSecondSerializer_Value(t *testing.T) {
 			value:   uint64PtrValue,
 			want:    time.Unix(int64(*uint64PtrValue), 0).UTC(), //nolint:gosec
 			wantErr: false,
+		},
+		{
+			name:    "pointer to maxInt64+1",
+			value:   maxInt64Plus1Ptr,
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name:    "nil pointer",


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

This pull request fixes a panic caused by calling `Int()` on uint values in `UnixSecondSerializer.Value()`, and adds a corresponding unit test to ensure the serializer handles unsigned integers safely.

### User Case Description

nil.
