### PR TITLE
fix #7602: copy-paste typo

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -182,7 +182,7 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 		*bool, *string, *time.Time,
 		*sql.NullInt32, *sql.NullInt64, *sql.NullFloat64,
 		*sql.NullBool, *sql.NullString, *sql.NullTime:
-		for initialized || rows.Next() {
+		if initialized || rows.Next() {
 			initialized = false
 			db.RowsAffected++
 			db.AddError(rows.Scan(dest))


### PR DESCRIPTION
- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Unexpected `for` loop consumes all the rows from the result set. Looks like it's a copy-paste mistake from similar slice `case`. Here must be `if` instead.

### User Case Description

```go
for rows.Next() {
	var id int64
	if err := tx.ScanRows(rows, &id); err != nil {
		return err
	}
	// ... id ...
}
```
