### PR TITLE
fix(schema): using `dest` to determine the `Tabler` or `TablerWithNamer` first

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -174,9 +174,21 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 	} else if en, ok := namer.(embeddedNamer); ok {
 		tableName = en.Table
 	} else if tabler, ok := modelValue.Interface().(Tabler); ok {
-		tableName = tabler.TableName()
+		// Using dest to determine the [Tabler] interface first,
+		// in order to support dynamic table names.
+		if destValue, destOK := dest.(Tabler); destOK {
+			tableName = destValue.TableName()
+		} else {
+			tableName = tabler.TableName()
+		}
 	} else if tabler, ok := modelValue.Interface().(TablerWithNamer); ok {
-		tableName = tabler.TableName(namer)
+		// Using dest to determine the [TablerWithNamer] interface first,
+		// in order to support dynamic table names.
+		if destValue, destOK := dest.(TablerWithNamer); destOK {
+			tableName = destValue.TableName(namer)
+		} else {
+			tableName = tabler.TableName(namer)
+		}
 	} else {
 		tableName = namer.TableName(modelType.Name())
 	}


### PR DESCRIPTION
Using `dest` to determine the `Tabler` or `TablerWithNamer` first, in order to support dynamic table names.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR aims to solve this problem, [https://github.com/go-gorm/gorm/issues/7620](https://github.com/go-gorm/gorm/issues/7620). The code before repair cann't use field `ID`.

```go
type UserWithTable struct {
	ID   int64
	Name string
}

func (u *UserWithTable) TableName() string {
	return fmt.Sprintf("gorm.user_%d", u.ID%1000)
}
```

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->

As above.
