### PR TITLE
Refactor Statement.Parse to support dynamic table names via Tabler interfaces

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -514,7 +514,7 @@ func (stmt *Statement) Parse(value interface{}) (err error) {
 }
 
 func (stmt *Statement) ParseWithSpecialTableName(value interface{}, specialTableName string) error {
-	cachedSchema, err := schema.ParseWithSpecialTableName(value, stmt.DB.cacheStore, stmt.DB.NamingStrategy, specialTableName)
+	cachedSchema, err := schema.ParseWithSpecialTableName(value, stmt.cacheStore, stmt.NamingStrategy, specialTableName)
 	if err != nil {
 		return err
 	}
@@ -523,7 +523,7 @@ func (stmt *Statement) ParseWithSpecialTableName(value interface{}, specialTable
 		if tabler, ok := value.(schema.Tabler); ok {
 			stmt.Table = tabler.TableName()
 		} else if tabler, ok := value.(schema.TablerWithNamer); ok {
-			stmt.Table = tabler.TableName(stmt.DB.NamingStrategy)
+			stmt.Table = tabler.TableName(stmt.NamingStrategy)
 		}
 	}
 	if stmt.Table == "" { // Get table name from schema


### PR DESCRIPTION
在 gorm v2 最初的设计上，Tabler 和 TablerWithNamer 接口不支持动态表名。经过一番调研，我已经知晓为何。但是当前存在大量的 gorm v1 代码需要迁移到 v2 上来，未必所有的开发人员都仔细阅读过升级 gorm v2 的文档。而且在历史的 issue 中我也发现了不少人反馈同样的问题。所以如果可能，我还是希望尽量能够支持在 Tabler 和 TablerWithNamer 接口中返回动态表名的特性。

我想了两种方案。

一种是在 `schema.ParseWithSpecialTableName` 的实现中使用 modelType 的 nil 指针去调用上面的两个接口，如果用户使用了 model 类型的字段，那么应该会触发一个 panic，这样能够起到强提醒的效果，但是上线过程中发生 panic 总归不是很好的方案。

另外一种就是本次 PR 提出的方案，既然 schema 的 table name 不能使用动态表名，那我们是不是可以在 stmt 的 table name 上想想办法，即在 `Statement.ParseWithSpecialTableName` 函数实现过程中增加一个 Tabler 和 TablerWithNamer 接口的检查，详情见 PR 代码。

我对 gorm 代码了解没有非常深入，请作者评估该方案的可行性。

---

10.27 该话题关闭，旧  case 跑不过。也许可以使用新的 if 覆盖旧的 if，那样代码太乱了，索性不改了。
不过我建议未来可以将 Tabler 和 TablerWithNamer 接口标记为废弃，不然一种书写方式只能提供一半的功能，并且可能造成经常性的踩坑，那么不要也罢。其实无论好坏，只有一种书写方式也是不错的。如果有百分百的更好替换，当然可以，否则一直打补丁，就不是一个好的设计了。

---

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR aims to solve this problem, [https://github.com/go-gorm/gorm/issues/7620](https://github.com/go-gorm/gorm/issues/7620). The code before repair cann't use field `ID`.

```go
type UserWithTable struct {
	ID   int64
	Name string
}

func (u *UserWithTable) TableName() string {
	return fmt.Sprintf("gorm.user_%d", u.ID%1000)
}
```

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->

As above.
