### PR TITLE
staticcheck QF1001

### DIFF
--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -669,8 +669,9 @@ func (rel *Relationship) ParseConstraint() *Constraint {
 			if r != rel && r.FieldSchema == rel.Schema && len(rel.References) == len(r.References) {
 				matched := true
 				for idx, ref := range r.References {
-					if !(rel.References[idx].PrimaryKey == ref.PrimaryKey && rel.References[idx].ForeignKey == ref.ForeignKey &&
-						rel.References[idx].PrimaryValue == ref.PrimaryValue) {
+					if rel.References[idx].PrimaryKey != ref.PrimaryKey ||
+						rel.References[idx].ForeignKey != ref.ForeignKey ||
+						rel.References[idx].PrimaryValue != ref.PrimaryValue {
 						matched = false
 						break
 					}


### PR DESCRIPTION

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ x] Do only one thing
- [ x] Non breaking API changes
- [ x] Tested

### What did this pull request do?

Replace a negated conjunction in `schema/relationship.go` flagged by staticcheck QF1001.

### User Case Description



#### Changes:
Edited `schema/relationship.go` to replace !(A && B && C) style check with A != x || B != y || C != z (logical equivalent without negated &&).

#### Why:
Satisfies staticcheck QF1001 recommendation without changing behavior.

<!-- 

 -->
