### PR TITLE
Support deferred constraints

### DIFF
--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -631,6 +631,7 @@ type Constraint struct {
 	References      []*Field
 	OnDelete        string
 	OnUpdate        string
+	Deferrable      string
 }
 
 func (constraint *Constraint) GetName() string { return constraint.Name }
@@ -643,6 +644,10 @@ func (constraint *Constraint) Build() (sql string, vars []interface{}) {
 
 	if constraint.OnUpdate != "" {
 		sql += " ON UPDATE " + constraint.OnUpdate
+	}
+
+	if constraint.Deferrable != "" {
+		sql += " DEFERRABLE " + constraint.Deferrable
 	}
 
 	foreignKeys := make([]interface{}, 0, len(constraint.ForeignKeys))
@@ -700,10 +705,11 @@ func (rel *Relationship) ParseConstraint() *Constraint {
 	}
 
 	constraint := Constraint{
-		Name:     name,
-		Field:    rel.Field,
-		OnUpdate: settings["ONUPDATE"],
-		OnDelete: settings["ONDELETE"],
+		Name:       name,
+		Field:      rel.Field,
+		OnUpdate:   settings["ONUPDATE"],
+		OnDelete:   settings["ONDELETE"],
+		Deferrable: strings.ToUpper(settings["DEFERRABLE"]),
 	}
 
 	for _, ref := range rel.References {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Adds support for the DEFERRABLE keyword on constraints

### User Case Description

I have a couple of tables which are updated by truncating and reinserting rows, but they have strong references for which deletes shouldn't be cascading if they're still consistent with the new data. I solved this by making the constraints deferrable, and deferring them for the transaction.
This required recreating the constraints by hand, since DEFERRED support is missing from the constraint structtag. Simply adding support turned out to be trivial, so that's what I ended up doing so that AutoMigrate suffices.