### PR TITLE
Add support for dynamic GORM valuer registration and retrieval

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -243,6 +243,10 @@ func (stmt *Statement) AddVar(writer clause.Writer, vars ...interface{}) {
 			writer.WriteString(subdb.Statement.SQL.String())
 			stmt.Vars = subdb.Statement.Vars
 		default:
+			if valuer := GetDynamicGormValuer(reflect.TypeOf(v)); valuer != nil {
+				stmt.AddVar(writer, valuer(stmt.Context, stmt.DB, v))
+				return
+			}
 			switch rv := reflect.ValueOf(v); rv.Kind() {
 			case reflect.Slice, reflect.Array:
 				if rv.Len() == 0 {

--- a/valuer.go
+++ b/valuer.go
@@ -1,0 +1,19 @@
+package gorm
+
+import (
+	"context"
+	"reflect"
+
+	"gorm.io/gorm/clause"
+)
+
+var dynamicRegisteredGormValuer = make(map[reflect.Type]func(context.Context, *DB, any) clause.Expr)
+
+// RegisterDynamicGormValuerInit shouldn't be called outside the init function
+func RegisterDynamicGormValuerInit(valueType reflect.Type, valuer func(context.Context, *DB, any) clause.Expr) {
+	dynamicRegisteredGormValuer[valueType] = valuer
+}
+
+func GetDynamicGormValuer(valueType reflect.Type) func(context.Context, *DB, any) clause.Expr {
+	return dynamicRegisteredGormValuer[valueType]
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Since some bugly database is popular, everyone have to workaround to it.


### User Case Description

I have a library https://github.com/iseki0/goda, I don't think it's a better choice to use the `GormValuer` interface directly, it will make a strong dependency to gorm, and it's unwise since not everyone use gorm. So please give me a chance to register the handler dynamiclly, if someone need, they can register the gorm-enhance-module by the effect import statments, just time `time/tzdata`.

#### About the workaround

The MySQL has a very strange behavior:
```sql
prepare aa from 'select cast(? as time), ?';
set @a '09:00:00';
execute aa using @a, @a;
```
```
+-----------------+----------+
| cast(? as time) | ?        |
+-----------------+----------+
| 00:00:00        | 09:00:00 |
+-----------------+----------+
```
The problem is on MySQL server, not driver. The Go MySQL driver do paratermized query like the prepare command, I refer to the https://github.com/go-sql-driver/mysql.

The solution is:
```sql
prepare aa from 'select cast(cast(? as char) as time)';
```

<!-- Your use case -->

Do you have any suggestions? Maybe we should fix it in the MySQL dialect. 毕竟，又不是只有我会倒这个霉，所有传字符串的都会完蛋。