### PR TITLE
fix: Row() and Rows() functions should automaticaly apply the generic type as model

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -659,11 +659,13 @@ func (g execG[T]) FindInBatches(ctx context.Context, batchSize int, fc func(data
 }
 
 func (g execG[T]) Row(ctx context.Context) *sql.Row {
-	return g.g.apply(ctx).Row()
+	var r T
+	return g.g.apply(ctx).Model(r).Row()
 }
 
 func (g execG[T]) Rows(ctx context.Context) (*sql.Rows, error) {
-	return g.g.apply(ctx).Rows()
+	var r T
+	return g.g.apply(ctx).Model(r).Rows()
 }
 
 func (c chainG[T]) processSet(items ...clause.Assigner) setCreateOrUpdateG[T] {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Changes the `Row` and `Rows` functions in the generic api to specify the generic type as the model for the db operations internally, similar to `setCreateOrUpdateG` or `Exec`.

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->

When using `Row()` and `Rows()` functions in the traditional api the caller has to specify the Model to use in the db operations. 

```
rows, err :=  db.Model(&User{}).Where("name = ?", "Alice").Rows()

```

However, in the generic api, I think the behaviour expected is that the generic api uses the generic types to do the operations without specifying the model in a separate step.  Specifically:

```
rows, err := gorm.G[User](db).Where("name = ?", "Alice").Rows(ctx)

```
should successfully return the users that are named "Alice", instead we get:

```
/usr/local/go/src/runtime/proc.go:283 unsupported data type: <nil>
[0.306ms] [rows:0] SELECT * FROM  WHERE type = "1"
panic: runtime error: invalid memory address or nil pointer dereference
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x61 pc=0x104dc7a38]

```

since without caller specifying the model for the operation in a separate step, the Table remains empty.

