### PR TITLE
fix: Close connection after ping failure to prevent goroutine leak

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -236,8 +236,10 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 	if err == nil && !config.DisableAutomaticPing {
 		if pinger, ok := db.ConnPool.(interface{ Ping() error }); ok {
 			err = pinger.Ping()
-			if db, _ := db.DB(); db != nil {
-				_ = db.Close()
+			if err != nil {
+				if db, _ := db.DB(); db != nil {
+					_ = db.Close()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
like pr https://github.com/go-gorm/gorm/pull/6249

When calling gorm.Open, there is the following code:

```
if config.Dialector != nil {
	err = config.Dialector.Initialize(db)
}
```
config.Dialector.Initialize(db) typically calls [sql.OpenDB](https://github.com/golang/go/blob/go1.20.3/src/database/sql/sql.go#L781) to create an *sql.DB, and starts an goroutine db.connectionOpener(ctx).

This coroutine doesn’t do anything; it just waits for the next query request before establishing a connection to the database. Therefore, when the network is unreachable, the coroutine can start successfully, but it will fail during subsequent ping attempts. When the ping fails, it isn’t closed, which leads to a coroutine leak.

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
Same as above.