### PR TITLE
Use `" AS "` when aliasing tables

### DIFF
--- a/clause/expression_test.go
+++ b/clause/expression_test.go
@@ -137,11 +137,11 @@ func TestNamedExpr(t *testing.T) {
 	}, {
 		SQL:    "?",
 		Vars:   []interface{}{clause.Table{Name: "table", Alias: "alias"}},
-		Result: "`table` `alias`",
+		Result: "`table` AS `alias`",
 	}, {
 		SQL:    "?",
 		Vars:   []interface{}{clause.Table{Name: "table", Alias: "alias", Raw: true}},
-		Result: "table alias",
+		Result: "table AS alias",
 	}}
 
 	for idx, result := range results {

--- a/statement.go
+++ b/statement.go
@@ -106,7 +106,7 @@ func (stmt *Statement) QuoteTo(writer clause.Writer, field interface{}) {
 		}
 
 		if v.Alias != "" {
-			writer.WriteByte(' ')
+			writer.WriteString(" AS ")
 			write(v.Raw, v.Alias)
 		}
 	case clause.Column:


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Addresses #6391

Uses `" AS "` instead of `" "` between a table and its alias.

### User Case Description

As described in the related issue, #6391:

> My specific use case is that I want to be able to use the table alias in `clause.OnConflict.DoUpdates` because the table names I'm working with are mixed case, which means I need to manually quote them to reference them directly in the expressions for those updates when I'm using postgres (and I have to use a table name or alias to disambiguate the column from the row that failed to insert, which is available as `excluded`), which I do not want to do.
