### PR TITLE
Add package comments to fix ST1000 warnings

### DIFF
--- a/callbacks/callbacks.go
+++ b/callbacks/callbacks.go
@@ -1,3 +1,4 @@
+// Package callbacks provides the default callback functions for GORM operations such as create, query, update, and delete.
 package callbacks
 
 import (

--- a/clause/clause.go
+++ b/clause/clause.go
@@ -1,3 +1,4 @@
+// Package clause provides the clause interface and common clause implementations for GORM.
 package clause
 
 // Interface clause interface

--- a/gorm.go
+++ b/gorm.go
@@ -1,3 +1,5 @@
+// Package gorm is a full-featured, developer-friendly ORM for Golang.
+// See https://gorm.io for documentation, and community.
 package gorm
 
 import (

--- a/gorm.go
+++ b/gorm.go
@@ -1,5 +1,5 @@
 // Package gorm is a full-featured, developer-friendly ORM for Golang.
-// See https://gorm.io for documentation, and community.
+// See https://gorm.io for documentation and community.
 package gorm
 
 import (

--- a/internal/lru/lru.go
+++ b/internal/lru/lru.go
@@ -1,3 +1,4 @@
+// Package lru provides a thread-safe Least Recently Used (LRU) cache with expirable entries.
 package lru
 
 // golang -lru

--- a/internal/stmt_store/stmt_store.go
+++ b/internal/stmt_store/stmt_store.go
@@ -1,3 +1,4 @@
+// Package stmt_store provides an implementation of a statement cache for SQL statements.
 package stmt_store
 
 import (

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,3 +1,4 @@
+// Package logger provides a logger interface and its implementation for GORM.
 package logger
 
 import (

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -1,3 +1,4 @@
+// Package migrator provides the interface and implementation for database schema migration in GORM.
 package migrator
 
 import (

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,3 +1,4 @@
+// Package schema provides the Schema struct and related functions for parsing and managing database schemas in GORM.
 package schema
 
 import (

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -1,3 +1,4 @@
+// Package tests_test contains tests for GORM's utility functions and error handling.
 package tests_test
 
 import (

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,3 +1,4 @@
+// Package utils provides internal utility functions for GORM.
 package utils
 
 import (


### PR DESCRIPTION

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

I can see the following report from gopls staticcheck:

> ST1000: at least one file in a package should have a package comment 

This is documented: https://go.dev/gopls/analyzers#st1000-incorrect-or-missing-package-comment

To replicate this, add in .vscode workspace settings:

```json
"gopls": {
  "staticcheck": true
}
```

Now when we open a file with gopls staticcheck enabled on files in gorm.io/gorm, we see the ST1000 warning on all .go files as none have package comments.

After adding package comments, we no longer see any of the ST1000 warning appear.



This pull request mitigates the error reporting by adding package comments to each of the packages.

- callbacks/callbacks.go
	- "Package callbacks provides the default callback functions for GORM operations such as create, query, update, and delete."
- clause/clause.go
	- "Package clause provides the clause interface and common clause implementations for GORM."
- gorm.go
	- "Package gorm is a full-featured, developer-friendly ORM for Golang."
	- "See https://gorm.io for documentation and community."
- internal/lru/lru.go
	- "Package lru provides a thread-safe Least Recently Used (LRU) cache with expirable entries."
- internal/stmt_store/stmt_store.go
	- "Package stmt_store provides an implementation of a statement cache for SQL statements."
- logger/logger.go
	- "Package logger provides a logger interface and its implementation for GORM."
- migrator/migrator.go
	- "Package migrator provides the interface and implementation for database schema migration in GORM."
- schema/schema.go
	- "Package schema provides the Schema struct and related functions for parsing and managing database schemas in GORM."
- tests/main_test.go
	- "Package tests_test contains tests for GORM's utility functions and error handling."
- utils/utils.go
	- "Package utils provides internal utility functions for GORM."

### User Case Description

After importing gorm.io/gorm, when developers hover over the package name "gorm", their IDE may display the package comment includes the https://gorm.io website, which improves the visibility of the documentation. When browsing the gorm code, they will not see ST1000 warnings even with gopls staticcheck enabled.
