### PR TITLE
fix: Use DO NOTHING when associated model lacks primary keys

### DIFF
--- a/callbacks/associations.go
+++ b/callbacks/associations.go
@@ -364,6 +364,15 @@ func onConflictOption(stmt *gorm.Statement, s *schema.Schema, defaultUpdatingCol
 			onConflict.Columns = append(onConflict.Columns, clause.Column{Name: dbName})
 		}
 
+		// If the associated model has no primary key columns, we cannot build a valid
+		// ON CONFLICT (columns) DO UPDATE clause. Fall back to DO NOTHING to avoid
+		// generating invalid SQL (e.g. ON CONFLICT DO UPDATE SET ... without column
+		// specification, which PostgreSQL rejects).
+		if len(onConflict.Columns) == 0 {
+			onConflict.DoNothing = true
+			return
+		}
+
 		onConflict.UpdateAll = stmt.DB.FullSaveAssociations
 		if !onConflict.UpdateAll {
 			onConflict.DoUpdates = clause.AssignmentColumns(defaultUpdatingColumns)

--- a/callbacks/associations_test.go
+++ b/callbacks/associations_test.go
@@ -1,0 +1,84 @@
+package callbacks
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+func TestOnConflictOption_NoPrimaryKeys_DoNothing(t *testing.T) {
+	// Model without any primary key fields
+	type NoPKModel struct {
+		Name  string
+		Value string
+	}
+
+	s, err := schema.Parse(&NoPKModel{}, schemaCache, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	if len(s.PrimaryFieldDBNames) != 0 {
+		t.Fatalf("expected no primary key fields, got %v", s.PrimaryFieldDBNames)
+	}
+
+	stmt := &gorm.Statement{
+		DB: &gorm.DB{
+			Config: &gorm.Config{
+				NowFunc: func() time.Time { return time.Time{} },
+			},
+			Statement: &gorm.Statement{
+				Settings: sync.Map{},
+				Schema:   s,
+			},
+		},
+		Schema: s,
+	}
+
+	// When defaultUpdatingColumns is non-empty, onConflictOption enters the
+	// branch that builds ON CONFLICT columns from primary keys. With zero
+	// primary keys, it should fall back to DoNothing.
+	onConflict := onConflictOption(stmt, s, []string{"name"})
+	if !onConflict.DoNothing {
+		t.Errorf("expected DoNothing to be true when schema has no primary keys, got false")
+	}
+	if len(onConflict.Columns) != 0 {
+		t.Errorf("expected no conflict columns, got %v", onConflict.Columns)
+	}
+}
+
+func TestOnConflictOption_WithPrimaryKeys_DoUpdate(t *testing.T) {
+	type PKModel struct {
+		ID   int `gorm:"primaryKey"`
+		Name string
+	}
+
+	s, err := schema.Parse(&PKModel{}, schemaCache, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	stmt := &gorm.Statement{
+		DB: &gorm.DB{
+			Config: &gorm.Config{
+				NowFunc: func() time.Time { return time.Time{} },
+			},
+			Statement: &gorm.Statement{
+				Settings: sync.Map{},
+				Schema:   s,
+			},
+		},
+		Schema: s,
+	}
+
+	onConflict := onConflictOption(stmt, s, []string{"name"})
+	if onConflict.DoNothing {
+		t.Errorf("expected DoNothing to be false when schema has primary keys")
+	}
+	if len(onConflict.Columns) != 1 || onConflict.Columns[0].Name != "id" {
+		t.Errorf("expected conflict column [id], got %v", onConflict.Columns)
+	}
+}


### PR DESCRIPTION
Fixes #6622

When saving has-many associations where the child model doesn't have explicit `primaryKey` tags (or has no `ID` field), `onConflictOption` would still try to generate `ON CONFLICT DO UPDATE SET ...` but without any conflict target columns. PostgreSQL rightfully rejects this:

```
ERROR: ON CONFLICT DO UPDATE requires inference specification or constraint name (SQLSTATE 42601)
```

The generated SQL looked like:
```sql
INSERT INTO "tags" (...) VALUES (...) ON CONFLICT DO UPDATE SET "pet_first_name"=...
```

when it should either have columns after `ON CONFLICT` or use `DO NOTHING`.

This PR adds a check: if the associated schema has no primary key columns, we fall back to `ON CONFLICT DO NOTHING` rather than generating invalid SQL.

All existing tests pass.