### PR TITLE
Fix PostgreSQL INCLUDE option parsing for multi-column indexes

### DIFF
--- a/schema/index.go
+++ b/schema/index.go
@@ -106,7 +106,7 @@ func parseFieldIndexes(field *Field) (indexes []Index, err error) {
 					name       string
 					tag        = strings.Join(v[1:], ":")
 					idx        = strings.IndexByte(tag, ',')
-					tagParts   = SplitTagCommas(tag)
+					tagParts   = splitTagCommas(tag)
 					tagSetting = strings.Join(tagParts[1:], ",")
 					settings   = ParseTagSetting(tagSetting, ",")
 					length, _  = strconv.Atoi(settings["LENGTH"])

--- a/schema/index.go
+++ b/schema/index.go
@@ -106,10 +106,20 @@ func parseFieldIndexes(field *Field) (indexes []Index, err error) {
 					name       string
 					tag        = strings.Join(v[1:], ":")
 					idx        = strings.IndexByte(tag, ',')
-					tagSetting = strings.Join(strings.Split(tag, ",")[1:], ",")
+					tagParts   = SplitTagCommas(tag)
+					tagSetting = strings.Join(tagParts[1:], ",")
 					settings   = ParseTagSetting(tagSetting, ",")
 					length, _  = strconv.Atoi(settings["LENGTH"])
 				)
+
+				for _, part := range tagParts[1:] {
+					part = strings.TrimSpace(part)
+					upper := strings.ToUpper(part)
+					if strings.HasPrefix(upper, "OPTION:") {
+						settings["OPTION"] = part[len("OPTION:"):]
+						break
+					}
+				}
 
 				if idx == -1 {
 					idx = len(tag)

--- a/schema/index_test.go
+++ b/schema/index_test.go
@@ -3,7 +3,9 @@ package schema_test
 import (
 	"sync"
 	"testing"
+	"time"
 
+	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
 	"gorm.io/gorm/utils/tests"
 )
@@ -271,5 +273,34 @@ func CheckIndices(t *testing.T, expected, actual []*schema.Index) {
 				tests.AssertObjEqual(t, af, ef, "Name", "Unique", "UniqueIndex", "Expression", "Sort", "Collate", "Length", "NotNull")
 			}
 		})
+	}
+}
+
+func TestIndexOptionWithMultipleIncludeColumns(t *testing.T) {
+	type Item struct {
+		gorm.Model
+		Status    string
+		Friendly  string
+		CreatedAt time.Time `gorm:"index:idx_created,option:INCLUDE (status, friendly)"`
+	}
+
+	s, err := schema.Parse(&Item{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	indexes := s.ParseIndexes()
+
+	var idx schema.Index
+
+	for _, index := range indexes {
+		if index.Name == "idx_created" {
+			idx = *index
+		}
+	}
+
+	want := "INCLUDE (status, friendly)"
+	if idx.Option != want {
+		t.Errorf("expected Option = %q, got %q", want, idx.Option)
 	}
 }

--- a/schema/index_test.go
+++ b/schema/index_test.go
@@ -277,30 +277,57 @@ func CheckIndices(t *testing.T, expected, actual []*schema.Index) {
 }
 
 func TestIndexOptionWithMultipleIncludeColumns(t *testing.T) {
-	type Item struct {
-		gorm.Model
-		Status    string
-		Friendly  string
-		CreatedAt time.Time `gorm:"index:idx_created,option:INCLUDE (status, friendly)"`
-	}
-
-	s, err := schema.Parse(&Item{}, &sync.Map{}, schema.NamingStrategy{})
-	if err != nil {
-		t.Fatalf("failed to parse schema: %v", err)
-	}
-
-	indexes := s.ParseIndexes()
-
-	var idx schema.Index
-
-	for _, index := range indexes {
-		if index.Name == "idx_created" {
-			idx = *index
+	t.Run("single column INCLUDE", func(t *testing.T) {
+		type Item struct {
+			gorm.Model
+			Status    string
+			CreatedAt time.Time `gorm:"index:idx_single,option:INCLUDE (status)"`
 		}
-	}
+		tests.AssertIndexOption(t, &Item{}, "idx_single", "INCLUDE (status)")
+	})
 
-	want := "INCLUDE (status, friendly)"
-	if idx.Option != want {
-		t.Errorf("expected Option = %q, got %q", want, idx.Option)
-	}
+	t.Run("multiple columns INCLUDE", func(t *testing.T) {
+		type Item struct {
+			gorm.Model
+			Status    string
+			Friendly  string
+			CreatedAt time.Time `gorm:"index:idx_multi,option:INCLUDE (status, friendly)"`
+		}
+		tests.AssertIndexOption(t, &Item{}, "idx_multi", "INCLUDE (status, friendly)")
+	})
+
+	t.Run("three columns INCLUDE", func(t *testing.T) {
+		type Item struct {
+			gorm.Model
+			Status    string
+			Friendly  string
+			Email     string
+			CreatedAt time.Time `gorm:"index:idx_three,option:INCLUDE (status, friendly, email)"`
+		}
+		tests.AssertIndexOption(t, &Item{}, "idx_three", "INCLUDE (status, friendly, email)")
+	})
+
+	t.Run("no option", func(t *testing.T) {
+		type Item struct {
+			gorm.Model
+			CreatedAt time.Time `gorm:"index:idx_no_option"`
+		}
+		tests.AssertIndexOption(t, &Item{}, "idx_no_option", "")
+	})
+
+	t.Run("option without parentheses", func(t *testing.T) {
+		type Item struct {
+			gorm.Model
+			CreatedAt time.Time `gorm:"index:idx_parser,option:WITH PARSER parser_name"`
+		}
+		tests.AssertIndexOption(t, &Item{}, "idx_parser", "WITH PARSER parser_name")
+	})
+
+	t.Run("NULLS NOT DISTINCT", func(t *testing.T) {
+		type Item struct {
+			gorm.Model
+			CreatedAt time.Time `gorm:"index:idx_nulls,option:NULLS NOT DISTINCT"`
+		}
+		tests.AssertIndexOption(t, &Item{}, "idx_nulls", "NULLS NOT DISTINCT")
+	})
 }

--- a/schema/utils.go
+++ b/schema/utils.go
@@ -233,7 +233,9 @@ func splitTagCommas(s string) []string {
 			depth++
 			current.WriteRune(r)
 		case ')':
-			depth--
+			if depth > 0 {
+				depth--
+			}
 			current.WriteRune(r)
 		case ',':
 			if depth == 0 {
@@ -246,6 +248,6 @@ func splitTagCommas(s string) []string {
 			current.WriteRune(r)
 		}
 	}
-	parts = append(parts, current.String()) // always append, even if empty
+	parts = append(parts, current.String())
 	return parts
 }

--- a/schema/utils.go
+++ b/schema/utils.go
@@ -221,7 +221,7 @@ type embeddedNamer struct {
 	Namer
 }
 
-func SplitTagCommas(s string) []string {
+func splitTagCommas(s string) []string {
 	var (
 		parts   []string
 		current strings.Builder

--- a/schema/utils.go
+++ b/schema/utils.go
@@ -220,3 +220,32 @@ type embeddedNamer struct {
 	Table string
 	Namer
 }
+
+func SplitTagCommas(s string) []string {
+	var (
+		parts   []string
+		current strings.Builder
+		depth   int
+	)
+	for _, r := range s {
+		switch r {
+		case '(':
+			depth++
+			current.WriteRune(r)
+		case ')':
+			depth--
+			current.WriteRune(r)
+		case ',':
+			if depth == 0 {
+				parts = append(parts, current.String())
+				current.Reset()
+			} else {
+				current.WriteRune(r)
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+	parts = append(parts, current.String()) // always append, even if empty
+	return parts
+}

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -131,12 +131,18 @@ func AssertIndexOption(t *testing.T, model interface{}, indexName, wantOption st
 		t.Fatalf("failed to parse schema: %v", err)
 	}
 
+	var found bool
 	var idx schema.Index
 	for _, index := range s.ParseIndexes() {
 		if index.Name == indexName {
 			idx = *index
+			found = true
 			break
 		}
+	}
+
+	if !found {
+		t.Fatalf("index %q not found", indexName)
 	}
 
 	if idx.Option != wantOption {

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"go/ast"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
+	"gorm.io/gorm/schema"
 	"gorm.io/gorm/utils"
 )
 
@@ -119,6 +121,26 @@ func AssertEqual(t *testing.T, got, expect interface{}) {
 			t.Errorf("%v: expect: %+v, got %+v", utils.FileWithLineNum(), expect, got)
 			return
 		}
+	}
+}
+
+func AssertIndexOption(t *testing.T, model interface{}, indexName, wantOption string) {
+	t.Helper()
+	s, err := schema.Parse(model, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	var idx schema.Index
+	for _, index := range s.ParseIndexes() {
+		if index.Name == indexName {
+			idx = *index
+			break
+		}
+	}
+
+	if idx.Option != wantOption {
+		t.Errorf("expected Option = %q, got %q", wantOption, idx.Option)
 	}
 }
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Fixed a bug where PostgreSQL covering indexes with multiple INCLUDE columns were silently truncated due to GORM's tag parser splitting on every comma. Added a paren-aware SplitTagCommas helper and re-extract the OPTION value to correctly handle commas inside parentheses.

### User Case Description

Fixes #7707 

## Summary
When using PostgreSQL covering indexes with multiple `INCLUDE` columns, GORM silently truncates the option value and generates invalid SQL.

**Consider the following test case**
 ```go
 func TestIndexOptionWithMultipleIncludeColumns(t *testing.T) {
	type Item struct {
		gorm.Model
		Status    string
		Friendly  string
		CreatedAt time.Time `gorm:"index:idx_created,option:INCLUDE (status, friendly)"`
	}

	s, err := schema.Parse(&Item{}, &sync.Map{}, schema.NamingStrategy{})
	if err != nil {
		t.Fatalf("failed to parse schema: %v", err)
	}

	indexes := s.ParseIndexes()

	var idx schema.Index

	for _, index := range indexes {
		if index.Name == "idx_created" {
			idx = *index
		}
	}

	want := "INCLUDE (status, friendly)"
	if idx.Option != want {
		t.Errorf("expected Option = %q, got %q", want, idx.Option)
	}
}
 ```

**Output**:
<img width="871" height="202" alt="Screenshot 2026-03-01 at 12 55 07 PM" src="https://github.com/user-attachments/assets/f4bf8e0f-872a-4aed-a8ff-28760a559c08" />


## Root Cause
In `parseFieldIndexes`, the tag is split on every comma to extract settings:
```go
tagSetting = strings.Join(strings.Split(tag, ",")[1:], ",")
settings   = ParseTagSetting(tagSetting, ",")
```

For a tag like:
```go
`gorm:"index:idx_created,option:INCLUDE (status, friendly)"`
```

The `strings.Split` splits on **every** comma including the one inside `INCLUDE (status, friendly)` — so `settings["OPTION"]` becomes `INCLUDE (status` instead of `INCLUDE (status, friendly)`, producing broken SQL on AutoMigrate.

This works fine with a single column (`INCLUDE (status)`) because there is no comma, which is exactly why the bug is hard to spot.

## Fix

**1. Added `SplitTagCommas()` helper** in `schema/utils.go`:**

Splits by commas while ignoring commas inside parentheses:
```go
func SplitTagCommas(s string) []string {
    // ...
    // "idx_created,option:INCLUDE (status, friendly)"
    // → ["idx_created", "option:INCLUDE (status, friendly)"]
}
```

**2. Use `SplitTagCommas` in `parseFieldIndexes`** and re-extract `OPTION` value directly from the paren-aware split:

```go
// After
tagParts   = SplitTagCommas(tag)
tagSetting = strings.Join(tagParts[1:], ",")
settings   = ParseTagSetting(tagSetting, ",")

// Re-extract OPTION directly from tagParts to avoid truncation
for _, part := range tagParts[1:] {
    part = strings.TrimSpace(part)
    if strings.HasPrefix(strings.ToUpper(part), "OPTION:") {
        settings["OPTION"] = part[len("OPTION:"):]
        break
    }
}
```

> **Note:** `ParseTagSetting` is intentionally left unchanged. It is used broadly across GORM (field tags, relationships,
> constraints) and changing it would risk breaking other tag parsing. The OPTION value is re-extracted surgically after the fact.

### After Fix
<img width="527" height="166" alt="Screenshot 2026-03-01 at 2 02 58 PM" src="https://github.com/user-attachments/assets/cb8727d0-43d9-46a8-aad3-54e69ef1f6d6" />