### PR TITLE
FileWithLineNum returns incorrect line number in v1.31.1

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -54,9 +54,17 @@ func CallerFrame() runtime.Frame {
 
 // FileWithLineNum return the file name and line number of the current file
 func FileWithLineNum() string {
-	frame := CallerFrame()
-	if frame.PC != 0 {
-		return string(strconv.AppendInt(append([]byte(frame.File), ':'), int64(frame.Line), 10))
+	pcs := [13]uintptr{}
+	// the third caller usually from gorm internal
+	len := runtime.Callers(3, pcs[:])
+	frames := runtime.CallersFrames(pcs[:len])
+	for i := 0; i < len; i++ {
+		// second return value is "more", not "ok"
+		frame, _ := frames.Next()
+		if (!strings.HasPrefix(frame.File, gormSourceDir) ||
+			strings.HasSuffix(frame.File, "_test.go")) && !strings.HasSuffix(frame.File, ".gen.go") {
+			return string(strconv.AppendInt(append([]byte(frame.File), ':'), int64(frame.Line), 10))
+		}
 	}
 
 	return ""

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -207,28 +208,13 @@ func where() string {
 }
 
 func TestFileWithLineNum(t *testing.T) {
-	// 1. Test direct call scenario
-	actual := where()
-	fmt.Println(actual)
+	_, _, expectedLine, _ := runtime.Caller(0)
+	actual := where() // Called from next line
+	expectedLine++    // where() is called one line after Caller(0)
 
-	// Expected result: Should output the correct line number of the caller.
-	// Since I cannot dynamically determine the exact line number easily,
-	// I hardcoded it based on my local setup for verification.
 	expectedFile := "utils_test.go"
-	// NOTE: Update line numbers (e.g., :211) to match your environment
-	if !strings.Contains(actual, expectedFile+":211") {
-		t.Errorf("Expected file path to contain %s, but got %s", expectedFile+":211", actual)
-	}
-
-	// 2. Test closure call scenario
-	var closureResult string
-	func() {
-		closureResult = FileWithLineNum()
-	}()
-
-	fmt.Println(closureResult)
-	// NOTE: Update line numbers (e.g., :227) to match your environment
-	if !strings.Contains(closureResult, expectedFile+":227") {
-		t.Errorf("Expected closure result to contain %s, but got %s", expectedFile+":227", closureResult)
+	expectedStr := fmt.Sprintf("%s:%d", expectedFile, expectedLine)
+	if !strings.Contains(actual, expectedStr) {
+		t.Errorf("Expected %s, but got %s", expectedStr, actual)
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -197,5 +198,37 @@ func TestRTrimSlice(t *testing.T) {
 				t.Errorf("RTrimSlice(%v, %d) = %v; want %v", testcase.input, testcase.trimLen, result, testcase.expected)
 			}
 		})
+	}
+}
+
+// Define the where function for testing
+func where() string {
+	return FileWithLineNum()
+}
+
+func TestFileWithLineNum(t *testing.T) {
+	// 1. Test direct call scenario
+	actual := where()
+	fmt.Println(actual)
+
+	// Expected result: Should output the correct line number of the caller.
+	// Since I cannot dynamically determine the exact line number easily,
+	// I hardcoded it based on my local setup for verification.
+	expectedFile := "utils_test.go"
+	// NOTE: Update line numbers (e.g., :211) to match your environment
+	if !strings.Contains(actual, expectedFile+":211") {
+		t.Errorf("Expected file path to contain %s, but got %s", expectedFile+":211", actual)
+	}
+
+	// 2. Test closure call scenario
+	var closureResult string
+	func() {
+		closureResult = FileWithLineNum()
+	}()
+
+	fmt.Println(closureResult)
+	// NOTE: Update line numbers (e.g., :227) to match your environment
+	if !strings.Contains(closureResult, expectedFile+":227") {
+		t.Errorf("Expected closure result to contain %s, but got %s", expectedFile+":227", closureResult)
 	}
 }


### PR DESCRIPTION
Fixes #7715
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Fixed a regression in FileWithLineNum introduced in v1.31.1. The new CallerFrame wrapper increased call stack depth, but runtime.Callers skip value was not updated. The skip value has been adjusted to correctly pinpoint the original caller.
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
When using v1.31.1 in the local project, FileWithLineNum() reports the line number of the internal FileWithLineNum() call itself instead of the business code line that triggered the GORM operation.
<!-- Your use case -->
