### PR TITLE
fix: remove rows.Err() from Scan to prevent deadlock (#7403)

### DIFF
--- a/callbacks/create.go
+++ b/callbacks/create.go
@@ -93,6 +93,9 @@ func Create(config *Config) func(db *gorm.DB) {
 			)
 			if db.AddError(err) == nil {
 				defer func() {
+					if !rows.Next() {
+						db.AddError(rows.Err())
+					}
 					db.AddError(rows.Close())
 				}()
 				gorm.Scan(rows, db, mode)

--- a/callbacks/delete.go
+++ b/callbacks/delete.go
@@ -176,6 +176,9 @@ func Delete(config *Config) func(db *gorm.DB) {
 				if db.Statement.Result != nil {
 					db.Statement.Result.RowsAffected = db.RowsAffected
 				}
+				if !rows.Next() {
+					db.AddError(rows.Err())
+				}
 				db.AddError(rows.Close())
 			}
 		}

--- a/callbacks/query.go
+++ b/callbacks/query.go
@@ -22,6 +22,9 @@ func Query(db *gorm.DB) {
 				return
 			}
 			defer func() {
+				if !rows.Next() {
+					db.AddError(rows.Err())
+				}
 				db.AddError(rows.Close())
 			}()
 			gorm.Scan(rows, db, 0)

--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -91,6 +91,9 @@ func Update(config *Config) func(db *gorm.DB) {
 					db.Statement.Dest = db.Statement.ReflectValue.Addr().Interface()
 					gorm.Scan(rows, db, mode)
 					db.Statement.Dest = dest
+					if !rows.Next() {
+						db.AddError(rows.Err())
+					}
 					db.AddError(rows.Close())
 
 					if db.Statement.Result != nil {

--- a/scan.go
+++ b/scan.go
@@ -359,10 +359,6 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 		}
 	}
 
-	if err := rows.Err(); err != nil && err != db.Error {
-		db.AddError(err)
-	}
-
 	if db.RowsAffected == 0 && db.Statement.RaiseErrorOnNotFound && db.Error == nil {
 		db.AddError(ErrRecordNotFound)
 	}


### PR DESCRIPTION
Scan() calls rows.Err() after scanning, which can deadlock when a context
cancellation goroutine (awaitDone) tries to WLock the internal closemu
RWMutex concurrently. Since rows.Err() needs an RLock, it blocks behind
the pending WLock — permanent deadlock, leaked DB connection.

This moves the rows.Err() responsibility to the 4 callback callers that
actually own the rows lifecycle. Each now calls `!rows.Next()` before
`rows.Err()`, ensuring all locks are released first. ScanRows (public API)
is unchanged — callers manage their own lifecycle per standard Go patterns.

Same logical fix as #7404, rebased cleanly on current HEAD.

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

Made with [Cursor](https://cursor.com)