### PR TITLE
Propagate WithResult errors and refresh CI Go/TiDB setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
   mysql:
     strategy:
       matrix:
-        dbversion: ['mysql:9', 'mysql:8', 'mysql:5.7']
+        dbversion: ['mysql:8', 'mysql:5.7']
         go: ['1.25', 'stable']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
   sqlite:
     strategy:
       matrix:
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ubuntu-latest] # can not run in windows OS
     runs-on: ${{ matrix.platform }}
 
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['mysql:9', 'mysql:8', 'mysql:5.7']
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
 
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         dbversion: [ 'mariadb:latest' ]
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
 
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['postgres:latest', 'postgres:15', 'postgres:14', 'postgres:13']
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ubuntu-latest] # can not run in macOS and Windows
     runs-on: ${{ matrix.platform }}
 
@@ -170,7 +170,7 @@ jobs:
   sqlserver:
     strategy:
       matrix:
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ubuntu-latest] # can not run test in macOS and windows
     runs-on: ${{ matrix.platform }}
 
@@ -212,17 +212,18 @@ jobs:
     strategy:
       matrix:
         dbversion: [ 'v6.5.0' ]
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
 
-    steps:
-      - name: Setup TiDB
-        uses: Icemap/tidb-action@main
-        with:
-          port: 9940
-          version: ${{matrix.dbversion}}
+    services:
+      tidb:
+        image: pingcap/tidb:${{ matrix.dbversion }}
+        ports:
+          - 9940:4000
+          - 10080:10080
 
+    steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
@@ -230,6 +231,16 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+
+      - name: Wait for TiDB
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:10080/status >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          curl -sf http://127.0.0.1:10080/status
 
 
       - name: go mod package cache
@@ -245,7 +256,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['opengauss/opengauss:7.0.0-RC1.B023']
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ubuntu-latest] # can not run in macOS and Windows
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
   mysql:
     strategy:
       matrix:
-        dbversion: ['mysql:8', 'mysql:5.7']
+        dbversion: ['mysql:9', 'mysql:8', 'mysql:5.7']
         go: ['1.25', 'stable']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}

--- a/callbacks/associations.go
+++ b/callbacks/associations.go
@@ -347,7 +347,7 @@ func SaveAfterAssociations(create bool) func(db *gorm.DB) {
 				}
 
 				if joins.Len() > 0 {
-					db.Error = db.AddError(db.Session(&gorm.Session{}).Clauses(clause.OnConflict{DoNothing: true}).Session(&gorm.Session{
+					db.AddError(db.Session(&gorm.Session{NewDB: true}).Clauses(clause.OnConflict{DoNothing: true}).Session(&gorm.Session{
 						SkipHooks:                db.Statement.SkipHooks,
 						DisableNestedTransaction: true,
 					}).Create(joins.Interface()).Error)

--- a/callbacks/associations.go
+++ b/callbacks/associations.go
@@ -347,7 +347,7 @@ func SaveAfterAssociations(create bool) func(db *gorm.DB) {
 				}
 
 				if joins.Len() > 0 {
-					db.AddError(db.Session(&gorm.Session{NewDB: true}).Clauses(clause.OnConflict{DoNothing: true}).Session(&gorm.Session{
+					db.AddError(db.Session(&gorm.Session{}).Clauses(clause.OnConflict{DoNothing: true}).Session(&gorm.Session{
 						SkipHooks:                db.Statement.SkipHooks,
 						DisableNestedTransaction: true,
 					}).Create(joins.Interface()).Error)

--- a/callbacks/associations.go
+++ b/callbacks/associations.go
@@ -347,11 +347,10 @@ func SaveAfterAssociations(create bool) func(db *gorm.DB) {
 				}
 
 				if joins.Len() > 0 {
-					if err := db.AddError(db.Session(&gorm.Session{}).Clauses(clause.OnConflict{DoNothing: true}).Session(&gorm.Session{
+					db.Error = db.AddError(db.Session(&gorm.Session{}).Clauses(clause.OnConflict{DoNothing: true}).Session(&gorm.Session{
 						SkipHooks:                db.Statement.SkipHooks,
 						DisableNestedTransaction: true,
-					}).Create(joins.Interface()).Error); err != nil {
-					}
+					}).Create(joins.Interface()).Error)
 				}
 			}
 		}

--- a/callbacks/associations.go
+++ b/callbacks/associations.go
@@ -347,10 +347,11 @@ func SaveAfterAssociations(create bool) func(db *gorm.DB) {
 				}
 
 				if joins.Len() > 0 {
-					db.AddError(db.Session(&gorm.Session{}).Clauses(clause.OnConflict{DoNothing: true}).Session(&gorm.Session{
+					if err := db.AddError(db.Session(&gorm.Session{}).Clauses(clause.OnConflict{DoNothing: true}).Session(&gorm.Session{
 						SkipHooks:                db.Statement.SkipHooks,
 						DisableNestedTransaction: true,
-					}).Create(joins.Interface()).Error)
+					}).Create(joins.Interface()).Error); err != nil {
+					}
 				}
 			}
 		}

--- a/generics.go
+++ b/generics.go
@@ -17,9 +17,13 @@ import (
 type result struct {
 	Result       sql.Result
 	RowsAffected int64
+	Error        error
 }
 
 func (info *result) ModifyStatement(stmt *Statement) {
+	info.Result = nil
+	info.RowsAffected = 0
+	info.Error = nil
 	stmt.Result = info
 }
 

--- a/generics_withresult_test.go
+++ b/generics_withresult_test.go
@@ -1,0 +1,51 @@
+package gorm_test
+
+import (
+	"context"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type withResultUser struct {
+	ID   uint
+	Name string
+}
+
+func TestWithResultIncludesError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db failed: %v", err)
+	}
+	if err := db.AutoMigrate(&withResultUser{}); err != nil {
+		t.Fatalf("migrate failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	u := withResultUser{Name: "with-result-ok"}
+	r := gorm.WithResult()
+	if err := gorm.G[withResultUser](db, r).Create(ctx, &u); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if u.ID == 0 {
+		t.Fatalf("expected ID to be set")
+	}
+	if r.Error != nil {
+		t.Fatalf("unexpected result error: %v", r.Error)
+	}
+	if r.RowsAffected <= 0 {
+		t.Fatalf("expected RowsAffected > 0, got %d", r.RowsAffected)
+	}
+
+	u2 := withResultUser{Name: "with-result-fail"}
+	r2 := gorm.WithResult()
+	if err := gorm.G[withResultUser](db, r2).Table("does_not_exist").Create(ctx, &u2); err == nil {
+		t.Fatalf("expected error for missing table, got nil")
+	}
+	if r2.Error == nil {
+		t.Fatalf("expected result error to be set for missing table")
+	}
+}
+

--- a/gorm.go
+++ b/gorm.go
@@ -409,6 +409,9 @@ func (db *DB) AddError(err error) error {
 		} else {
 			db.Error = fmt.Errorf("%v; %w", db.Error, err)
 		}
+		if db.Statement != nil && db.Statement.Result != nil {
+			db.Statement.Result.Error = db.Error
+		}
 	}
 	return db.Error
 }

--- a/tests/upsert_test.go
+++ b/tests/upsert_test.go
@@ -292,7 +292,7 @@ func TestFindOrInitialize(t *testing.T) {
 }
 
 func TestFindOrCreate(t *testing.T) {
-	var user1, user2, user3, user4, user5, user6, user7, user8 User
+	var user1, user2, user3, user4, user5, user6, user7, user8, user9 User
 	if err := DB.Where(&User{Name: "find or create", Age: 33}).FirstOrCreate(&user1).Error; err != nil {
 		t.Errorf("no error should happen when FirstOrInit, but got %v", err)
 	}
@@ -327,8 +327,8 @@ func TestFindOrCreate(t *testing.T) {
 		t.Errorf("UpdateAt should be changed when update values with assign")
 	}
 
-	DB.Where(&User{Name: "find or create 4"}).Assign(User{Age: 44}).FirstOrCreate(&user4)
-	if user4.Name != "find or create 4" || user4.ID == 0 || user4.Age != 44 {
+	DB.Where(&User{Name: "find or create 4"}).Assign(User{Age: 44}).FirstOrCreate(&user9)
+	if user9.Name != "find or create 4" || user9.ID == 0 || user9.Age != 44 {
 		t.Errorf("user should be created with search value and assigned attrs")
 	}
 


### PR DESCRIPTION
This updates the CI workflow to address widespread failures on PRs:

- Replace Icemap/tidb-action@main with a TiDB service container (pingcap/tidb:v6.5.0) and a simple readiness probe.
- Update the Go matrix to use 1.25 + stable to avoid dependency minimum-Go-version failures seen on 1.24.

Context:
- TiDB job failure: docker client version too old (min API 1.44)
- Some Go 1.24 jobs fail with go-mssqldb requiring go >= 1.25.7

