### PR TITLE
generics: populate WithResult error

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -17,9 +17,13 @@ import (
 type result struct {
 	Result       sql.Result
 	RowsAffected int64
+	Error        error
 }
 
 func (info *result) ModifyStatement(stmt *Statement) {
+	info.Result = nil
+	info.RowsAffected = 0
+	info.Error = nil
 	stmt.Result = info
 }
 

--- a/generics_withresult_test.go
+++ b/generics_withresult_test.go
@@ -1,0 +1,51 @@
+package gorm_test
+
+import (
+	"context"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type withResultUser struct {
+	ID   uint
+	Name string
+}
+
+func TestWithResultIncludesError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db failed: %v", err)
+	}
+	if err := db.AutoMigrate(&withResultUser{}); err != nil {
+		t.Fatalf("migrate failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	u := withResultUser{Name: "with-result-ok"}
+	r := gorm.WithResult()
+	if err := gorm.G[withResultUser](db, r).Create(ctx, &u); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if u.ID == 0 {
+		t.Fatalf("expected ID to be set")
+	}
+	if r.Error != nil {
+		t.Fatalf("unexpected result error: %v", r.Error)
+	}
+	if r.RowsAffected <= 0 {
+		t.Fatalf("expected RowsAffected > 0, got %d", r.RowsAffected)
+	}
+
+	u2 := withResultUser{Name: "with-result-fail"}
+	r2 := gorm.WithResult()
+	if err := gorm.G[withResultUser](db, r2).Table("does_not_exist").Create(ctx, &u2); err == nil {
+		t.Fatalf("expected error for missing table, got nil")
+	}
+	if r2.Error == nil {
+		t.Fatalf("expected result error to be set for missing table")
+	}
+}
+

--- a/gorm.go
+++ b/gorm.go
@@ -409,6 +409,9 @@ func (db *DB) AddError(err error) error {
 		} else {
 			db.Error = fmt.Errorf("%v; %w", db.Error, err)
 		}
+		if db.Statement != nil && db.Statement.Result != nil {
+			db.Statement.Result.Error = db.Error
+		}
 	}
 	return db.Error
 }


### PR DESCRIPTION
Fix mismatch with gorm.io Create docs generics example: WithResult() now exposes Error and it is populated when statement execution fails.

Changes:
- Add Error field to WithResult result and reset it per statement.
- Populate result.Error via DB.AddError when a WithResult result is attached.
- Add sqlite-based unit test covering success + failure cases.

Tests:
- go test ./...