### PR TITLE
docs: add README for callbacks, clause, and schema packages

### DIFF
--- a/callbacks/README.md
+++ b/callbacks/README.md
@@ -1,0 +1,48 @@
+# callbacks
+
+This package registers the default lifecycle callbacks for each GORM database operation.
+
+## How it works
+
+Every GORM operation (Create, Query, Update, Delete) runs a chain of named callbacks in order. Database dialects call `RegisterDefaultCallbacks` during initialization and can pass a `Config` to override which SQL clauses are used.
+
+## Callback chains
+
+| Operation | Order |
+|-----------|-------|
+| **Create** | `begin_transaction` → `before_create` → `save_before_associations` → `create` → `save_after_associations` → `after_create` → `commit_or_rollback_transaction` |
+| **Query**  | `query` → `preload` → `after_query` |
+| **Update** | `begin_transaction` → `setup_reflect_value` → `before_update` → `save_before_associations` → `update` → `save_after_associations` → `after_update` → `commit_or_rollback_transaction` |
+| **Delete** | `begin_transaction` → `before_delete` → `delete_before_associations` → `delete` → `after_delete` → `commit_or_rollback_transaction` |
+| **Row**    | `row` |
+| **Raw**    | `raw` |
+
+## Key files
+
+| File | Description |
+|------|-------------|
+| `callbacks.go` | `RegisterDefaultCallbacks` — entry point called by dialects |
+| `create.go` | Insert logic and `BeforeCreate`/`AfterCreate` hooks |
+| `query.go` | Select logic and `AfterQuery` hook |
+| `update.go` | Update logic and `BeforeUpdate`/`AfterUpdate` hooks |
+| `delete.go` | Delete logic and `BeforeDelete`/`AfterDelete` hooks |
+| `associations.go` | Save/delete associated records |
+| `preload.go` | Eager-load associations after query |
+| `transaction.go` | Begin and commit/rollback transaction wrappers |
+| `callmethod.go` | Reflection helpers to invoke model hook methods |
+| `helper.go` | Shared utilities used across callbacks |
+
+## Customizing callbacks
+
+```go
+// Add a callback before an existing one
+db.Callback().Create().Before("gorm:create").Register("my_plugin:audit", auditFn)
+
+// Replace a callback
+db.Callback().Delete().Replace("gorm:delete", softDeleteFn)
+
+// Remove a callback
+db.Callback().Update().Remove("gorm:before_update")
+```
+
+See [GORM hooks documentation](https://gorm.io/docs/hooks.html) for the full list of model hook methods (`BeforeCreate`, `AfterSave`, etc.).

--- a/clause/README.md
+++ b/clause/README.md
@@ -1,0 +1,63 @@
+# clause
+
+This package provides the SQL clause building blocks used by GORM to construct queries.
+
+## Core interfaces
+
+- **`Interface`** — implemented by every clause; requires `Name()`, `Build()`, and `MergeClause()`
+- **`Expression`** — a value that can write itself into a SQL builder (e.g. `Eq`, `IN`, `And`)
+- **`Builder`** — the write target passed to `Build()`; wraps a `*Statement`
+
+## Available clauses
+
+| Clause | File | SQL keyword |
+|--------|------|-------------|
+| `Select` | `select.go` | `SELECT` |
+| `From` | `from.go` | `FROM` |
+| `Where` | `where.go` | `WHERE` |
+| `Joins` | `joins.go` | `JOIN` |
+| `GroupBy` | `group_by.go` | `GROUP BY` |
+| `OrderBy` | `order_by.go` | `ORDER BY` |
+| `Limit` | `limit.go` | `LIMIT` |
+| `Insert` | `insert.go` | `INSERT INTO` |
+| `Values` | `values.go` | `VALUES` |
+| `OnConflict` | `on_conflict.go` | `ON CONFLICT` |
+| `Update` | `update.go` | `UPDATE` |
+| `Set` | `set.go` | `SET` |
+| `Delete` | `delete.go` | `DELETE` |
+| `With` | `with.go` | `WITH` (CTE) |
+| `For` | `locking.go` | `FOR UPDATE / SHARE` |
+
+## Expressions
+
+Common expressions defined in `expression.go`:
+
+| Expression | Example SQL |
+|------------|-------------|
+| `Eq{Col, Val}` | `col = ?` |
+| `Neq{Col, Val}` | `col <> ?` |
+| `Gt` / `Gte` / `Lt` / `Lte` | `col > ?` etc. |
+| `In{Col, Values}` | `col IN (?,?)` |
+| `Like{Col, Val}` | `col LIKE ?` |
+| `And{...}` / `Or{...}` | `(a AND b)` |
+| `Not{...}` | `NOT (a)` |
+| `Expr{SQL, Vars}` | raw SQL fragment |
+
+## Special constants
+
+```go
+clause.PrimaryKey   // references the primary key column
+clause.CurrentTable // references the model's table
+clause.Associations // used in association operations
+```
+
+## Example: building a WHERE clause manually
+
+```go
+db.Where(clause.And(
+    clause.Eq{Column: "status", Value: "active"},
+    clause.Gt{Column: "age", Value: 18},
+)).Find(&users)
+```
+
+See [GORM query documentation](https://gorm.io/docs/query.html) for higher-level usage.

--- a/schema/README.md
+++ b/schema/README.md
@@ -51,10 +51,13 @@ Implement these interfaces on a custom type to control GORM behaviour per field:
 The `Namer` interface (defined in `naming.go`) controls how struct and field names are translated to table and column names. The default strategy converts `CamelCase` to `snake_case` and pluralises table names.
 
 ```go
-db, _ := gorm.Open(sqlite.Open("test.db"), &gorm.Config{
+db, err := gorm.Open(sqlite.Open("test.db"), &gorm.Config{
     NamingStrategy: schema.NamingStrategy{
         TablePrefix:   "app_",
         SingularTable: true,
     },
 })
+if err != nil {
+    panic(err)
+}
 ```

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,60 @@
+# schema
+
+This package is responsible for parsing Go structs into GORM's internal model representation used for query building and migration.
+
+## Core types
+
+| Type | File | Description |
+|------|------|-------------|
+| `Schema` | `schema.go` | Parsed representation of a model struct |
+| `Field` | `field.go` | A single struct field with its column mapping and metadata |
+| `Relationship` | `relationship.go` | Association between two schemas (HasOne, HasMany, BelongsTo, Many2Many) |
+| `Index` | `index.go` | Index definition parsed from struct tags |
+| `Constraint` | `constraint.go` | Database constraint (unique, foreign key, check) |
+
+## How parsing works
+
+1. `Parse(model, cacheStore, namer)` reflects on the struct type
+2. Each field is mapped to a `Field` with column name, data type, tag options
+3. Relationships are resolved by matching foreign keys across schemas
+4. The result is cached in `cacheStore` (an LRU cache) to avoid repeated reflection
+
+## Struct tag options
+
+GORM reads the `gorm:` struct tag. Common options:
+
+```go
+type User struct {
+    ID        uint   `gorm:"primaryKey"`
+    Name      string `gorm:"column:full_name;size:100;not null"`
+    Email     string `gorm:"uniqueIndex"`
+    DeletedAt *time.Time `gorm:"index"`
+}
+```
+
+See [GORM model documentation](https://gorm.io/docs/models.html) for the full tag reference.
+
+## Interfaces
+
+Implement these interfaces on a custom type to control GORM behaviour per field:
+
+| Interface | Method | Purpose |
+|-----------|--------|---------|
+| `GormDataTypeInterface` | `GormDataType() string` | Custom column type |
+| `CreateClausesInterface` | `CreateClauses(*Field)` | Extra clauses on insert |
+| `QueryClausesInterface` | `QueryClauses(*Field)` | Extra clauses on select |
+| `UpdateClausesInterface` | `UpdateClauses(*Field)` | Extra clauses on update |
+| `DeleteClausesInterface` | `DeleteClauses(*Field)` | Extra clauses on delete |
+
+## Naming strategies
+
+The `Namer` interface (defined in `naming.go`) controls how struct and field names are translated to table and column names. The default strategy converts `CamelCase` to `snake_case` and pluralises table names.
+
+```go
+db, _ := gorm.Open(sqlite.Open("test.db"), &gorm.Config{
+    NamingStrategy: schema.NamingStrategy{
+        TablePrefix:   "app_",
+        SingularTable: true,
+    },
+})
+```


### PR DESCRIPTION
### What did this pull request do?

Add `README.md` files to the `callbacks`, `clause`, and `schema` packages. Each README explains the package's purpose, lists key types/files, and includes short code examples to help new contributors navigate the codebase.

### User Case Description

When exploring the GORM source code for the first time, it's not obvious what each internal package does or how the pieces fit together. These READMEs provide a quick orientation without requiring the reader to trace through all the source files.
