### PR TITLE
ci: switch tests Go matrix to stable/oldstable and update setup-go

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,13 @@ jobs:
   sqlite:
     strategy:
       matrix:
-        go: ['1.25', 'stable']
+        go: ['stable', 'oldstable']
         platform: [ubuntu-latest] # can not run in windows OS
     runs-on: ${{ matrix.platform }}
 
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['mysql:9', 'mysql:8', 'mysql:5.7']
-        go: ['1.25', 'stable']
+        go: ['stable', 'oldstable']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
 
@@ -65,7 +65,7 @@ jobs:
 
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         dbversion: [ 'mariadb:latest' ]
-        go: ['1.25', 'stable']
+        go: ['stable', 'oldstable']
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
 
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['postgres:latest', 'postgres:15', 'postgres:14', 'postgres:13']
-        go: ['1.25', 'stable']
+        go: ['stable', 'oldstable']
         platform: [ubuntu-latest] # can not run in macOS and Windows
     runs-on: ${{ matrix.platform }}
 
@@ -151,7 +151,7 @@ jobs:
 
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
@@ -170,7 +170,7 @@ jobs:
   sqlserver:
     strategy:
       matrix:
-        go: ['1.25', 'stable']
+        go: ['stable', 'oldstable']
         platform: [ubuntu-latest] # can not run test in macOS and windows
     runs-on: ${{ matrix.platform }}
 
@@ -192,7 +192,7 @@ jobs:
 
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
@@ -212,7 +212,7 @@ jobs:
     strategy:
       matrix:
         dbversion: [ 'v6.5.0' ]
-        go: ['1.25', 'stable']
+        go: ['stable', 'oldstable']
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
 
@@ -224,7 +224,7 @@ jobs:
           version: ${{matrix.dbversion}}
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
@@ -245,7 +245,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['opengauss/opengauss:7.0.0-RC1.B023']
-        go: ['1.25', 'stable']
+        go: ['stable', 'oldstable']
         platform: [ubuntu-latest] # can not run in macOS and Windows
     runs-on: ${{ matrix.platform }}
 
@@ -261,7 +261,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
   sqlite:
     strategy:
       matrix:
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ubuntu-latest] # can not run in windows OS
     runs-on: ${{ matrix.platform }}
 
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['mysql:9', 'mysql:8', 'mysql:5.7']
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
 
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         dbversion: [ 'mariadb:latest' ]
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
 
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['postgres:latest', 'postgres:15', 'postgres:14', 'postgres:13']
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ubuntu-latest] # can not run in macOS and Windows
     runs-on: ${{ matrix.platform }}
 
@@ -170,7 +170,7 @@ jobs:
   sqlserver:
     strategy:
       matrix:
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ubuntu-latest] # can not run test in macOS and windows
     runs-on: ${{ matrix.platform }}
 
@@ -212,7 +212,7 @@ jobs:
     strategy:
       matrix:
         dbversion: [ 'v6.5.0' ]
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
 
@@ -245,7 +245,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['opengauss/opengauss:7.0.0-RC1.B023']
-        go: ['1.24', '1.25']
+        go: ['1.25', 'stable']
         platform: [ubuntu-latest] # can not run in macOS and Windows
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
This updates the tests workflow Go matrix from `['1.24', '1.25']` to `['1.25', 'stable']`.

Reason:
`tests/tests_all.sh` runs `go get -u -t ./...` inside `tests/`, so CI can pick up newer transitive dependencies than the versions currently recorded in the repo.

At the moment, this path is no longer compatible with Go 1.24. I reproduced it locally with the current script:

- `github.com/microsoft/go-mssqldb@v1.9.8 requires go >= 1.25.7`
- `golang.org/x/sync@v0.20.0 requires go >= 1.25.0`

So the failing Go 1.24 jobs are blocked by dependency/toolchain requirements during test environment setup, before the actual repository changes are meaningfully exercised.

This PR keeps the change minimal and only updates the CI Go matrix.
It does not change test logic or application code.
