### PR TITLE
tests: skip customized foreign key many2many on MySQL 8.4+

### DIFF
--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -281,6 +281,39 @@ func isMysql() bool {
 	return os.Getenv("GORM_DIALECT") == "mysql"
 }
 
+func mysqlVersionAtLeast(major, minor int) bool {
+	if !isMysql() {
+		return false
+	}
+
+	var version string
+	if err := DB.Raw("SELECT VERSION()").Row().Scan(&version); err != nil {
+		return false
+	}
+
+	base := strings.SplitN(strings.TrimSpace(version), "-", 2)[0]
+	parts := strings.Split(base, ".")
+	if len(parts) < 2 {
+		return false
+	}
+
+	currentMajor, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+
+	currentMinor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+
+	if currentMajor != major {
+		return currentMajor > major
+	}
+
+	return currentMinor >= minor
+}
+
 func isSqlite() bool {
 	return os.Getenv("GORM_DIALECT") == "sqlite"
 }

--- a/tests/multi_primary_keys_test.go
+++ b/tests/multi_primary_keys_test.go
@@ -139,6 +139,10 @@ func TestManyToManyWithCustomizedForeignKeys(t *testing.T) {
 		t.Skip("skip sqlite, sqlserver due to it doesn't support multiple primary keys with auto increment")
 	}
 
+	if mysqlVersionAtLeast(8, 4) {
+		t.Skip("skip mysql 8.4+ due to stricter foreign key requirements for non-unique referenced keys")
+	}
+
 	if name := DB.Dialector.Name(); name == "postgres" {
 		t.Skip("skip postgres due to it only allow unique constraint matching given keys")
 	}


### PR DESCRIPTION
## Summary
- skip `TestManyToManyWithCustomizedForeignKeys` on MySQL 8.4+
- keep existing behavior on older MySQL versions
- limit the change to tests only

## Why
MySQL 8.4+ applies stricter foreign key validation for referenced columns that are not unique. This test builds a many2many relation that references `tags(id)` while `Tag` uses a composite primary key `(id, locale)`, so `id` alone is not unique.

That makes this test pass on MySQL 5.7 but fail on newer MySQL images used in CI.

## Validation
I reproduced this locally with the same test against multiple MySQL images:
- `mysql:5.7` (`5.7.44`): pass
- `mysql:8` (`8.4.8`): fail before this patch, skip after this patch
- `mysql:9` (`9.6.0`): fail before this patch, skip after this patch