### PR TITLE
fix(migrator): don't clear alterColumn when defaults match

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -559,13 +559,17 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 			case schema.Bool:
 				v1, _ := strconv.ParseBool(dv)
 				v2, _ := strconv.ParseBool(field.DefaultValue)
-				alterColumn = v1 != v2
+				if v1 != v2 {
+					alterColumn = true
+				}
 			case schema.String:
 				if dv != field.DefaultValue && dv != strings.Trim(field.DefaultValue, "'\"") {
 					alterColumn = true
 				}
 			default:
-				alterColumn = dv != field.DefaultValue
+				if dv != field.DefaultValue {
+					alterColumn = true
+				}
 			}
 		}
 	}

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -1602,6 +1602,41 @@ func TestMigrateWithDefaultValue(t *testing.T) {
 	AssertEqual(t, ok, false)
 }
 
+func TestMigrateDontOverrideAlterColumnByDefaultValue(t *testing.T) {
+	if DB.Dialector.Name() != "sqlite" {
+		t.Skip()
+	}
+
+	type BytesDefaultModel struct {
+		ID   int    `gorm:"primaryKey"`
+		Data []byte `gorm:"type:bytes;default:hello"`
+	}
+
+	tableName := "bytes_default_models"
+	DB.Migrator().DropTable(tableName)
+	if err := DB.Exec("CREATE TABLE bytes_default_models (id integer primary key, data TEXT DEFAULT 'hello')").Error; err != nil {
+		t.Fatalf("failed to create table, got error: %v", err)
+	}
+
+	columnType, err := findColumnType(tableName, "data")
+	if err != nil {
+		t.Fatalf("failed to get column type, got error: %v", err)
+	}
+	AssertEqual(t, strings.ToLower(columnType.DatabaseTypeName()), "text")
+
+	if err := DB.AutoMigrate(&BytesDefaultModel{}); err != nil {
+		t.Fatalf("failed to migrate, got error: %v", err)
+	}
+
+	columnType, err = findColumnType(tableName, "data")
+	if err != nil {
+		t.Fatalf("failed to get column type, got error: %v", err)
+	}
+	if !strings.Contains(strings.ToUpper(columnType.DatabaseTypeName()), "BLOB") {
+		t.Fatalf("expected data column to be migrated to BLOB, got: %s", columnType.DatabaseTypeName())
+	}
+}
+
 func TestMigrateMySQLWithCustomizedTypes(t *testing.T) {
 	if DB.Dialector.Name() != "mysql" {
 		t.Skip()


### PR DESCRIPTION
- Fix: default-value comparison no longer overwrites an already-true alterColumn flag (schema.Bool + default branch)
- Test: adds sqlite regression test where type mismatch (TEXT -> bytes/BLOB) must still alter even if default matches

Closes: #7644