### PR TITLE
fix: isolate zero-value Model on Statement clone

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -527,10 +527,20 @@ func (stmt *Statement) ParseWithSpecialTableName(value interface{}, specialTable
 }
 
 func (stmt *Statement) clone() *Statement {
+	var clonedModel interface{} = stmt.Model
+	if rv := reflect.ValueOf(stmt.Model); rv.IsValid() && rv.Kind() == reflect.Ptr && !rv.IsNil() && rv.Elem().Kind() == reflect.Struct {
+		zero := reflect.New(rv.Elem().Type()).Elem()
+		if reflect.DeepEqual(rv.Elem().Interface(), zero.Interface()) {
+			cp := reflect.New(rv.Elem().Type())
+			cp.Elem().Set(rv.Elem())
+			clonedModel = cp.Interface()
+		}
+	}
+
 	newStmt := &Statement{
 		TableExpr:            stmt.TableExpr,
 		Table:                stmt.Table,
-		Model:                stmt.Model,
+		Model:                clonedModel,
 		Unscoped:             stmt.Unscoped,
 		Dest:                 stmt.Dest,
 		ReflectValue:         stmt.ReflectValue,

--- a/statement_test.go
+++ b/statement_test.go
@@ -35,6 +35,26 @@ func TestWhereCloneCorruption(t *testing.T) {
 	}
 }
 
+func TestStatementCloneDoesNotShareZeroModelPointer(t *testing.T) {
+	type TestUser struct {
+		Model
+		Age uint
+	}
+
+	base := new(Statement)
+	base.Model = &TestUser{}
+
+	cloned := base.clone()
+	if reflect.ValueOf(cloned.Model).Pointer() == reflect.ValueOf(base.Model).Pointer() {
+		t.Fatalf("expected cloned.Model to be isolated from base.Model")
+	}
+
+	reflect.ValueOf(cloned.Model).Elem().FieldByName("ID").SetUint(111)
+	if id := reflect.ValueOf(base.Model).Elem().FieldByName("ID").Uint(); id != 0 {
+		t.Fatalf("expected base.Model ID to remain 0, got %d", id)
+	}
+}
+
 func TestNilCondition(t *testing.T) {
 	s := new(Statement)
 	if len(s.BuildCondition(nil)) != 0 {


### PR DESCRIPTION
Fixes #7725.
When Statement.clone() reuses the same zero-value *Model pointer (e.g. Model(&User{})) across cloned sessions, the update path can write the primary key back into that shared Model, and subsequent clones may append a stale pk predicate into WHERE
This isolates Model() only when it is a pointer to a zero-value struct, preventing cross-call contamination while leaving non-zero models untouched.
Tests: go test ./...