### PR TITLE
ci: avoid dependency upgrades during tests

### DIFF
--- a/tests/tests_all.sh
+++ b/tests/tests_all.sh
@@ -9,9 +9,7 @@ fi
 if [ -d tests ]
 then
   cd tests
-  go get -u -t ./...
   go mod download
-  go mod tidy
   cd ..
 fi
 


### PR DESCRIPTION
CI reliability: stop upgrading module dependencies at runtime.

 ran  (and ) before executing tests. This can upgrade transitive deps during CI and cause failures unrelated to the PR under test (e.g. deps starting to require a newer Go version).

This PR removes the runtime upgrade/tidy step and keeps only  so CI tests run against the dependencies already recorded in /.

This should help PRs like #7717 avoid dependency-drift failures.