### PR TITLE
fix: generics updates arg use map

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -59,7 +59,7 @@ type CreateInterface[T any] interface {
 
 	Delete(ctx context.Context) (rowsAffected int, err error)
 	Update(ctx context.Context, name string, value any) (rowsAffected int, err error)
-	Updates(ctx context.Context, t T) (rowsAffected int, err error)
+	Updates(ctx context.Context, t any) (rowsAffected int, err error)
 	Count(ctx context.Context, column string) (result int64, err error)
 
 	Table(name string, args ...interface{}) CreateInterface[T]
@@ -92,7 +92,7 @@ type ChainInterface[T any] interface {
 	Table(name string, args ...interface{}) ChainInterface[T]
 	Delete(ctx context.Context) (rowsAffected int, err error)
 	Update(ctx context.Context, name string, value any) (rowsAffected int, err error)
-	Updates(ctx context.Context, t T) (rowsAffected int, err error)
+	Updates(ctx context.Context, t any) (rowsAffected int, err error)
 	Count(ctx context.Context, column string) (result int64, err error)
 }
 
@@ -569,8 +569,9 @@ func (c chainG[T]) Update(ctx context.Context, name string, value any) (rowsAffe
 	return int(res.RowsAffected), res.Error
 }
 
-func (c chainG[T]) Updates(ctx context.Context, t T) (rowsAffected int, err error) {
-	res := c.g.apply(ctx).Updates(t)
+func (c chainG[T]) Updates(ctx context.Context, t any) (rowsAffected int, err error) {
+	var r *T
+	res := c.g.apply(ctx).Model(r).Updates(t)
 	return int(res.RowsAffected), res.Error
 }
 

--- a/tests/generics_test.go
+++ b/tests/generics_test.go
@@ -1117,3 +1117,38 @@ func TestGenericsAssociationSlice(t *testing.T) {
 		}
 	}
 }
+
+func TestIssue7709(t *testing.T) {
+	ctx := context.Background()
+	user := User{Name: "Issue7709", Age: 18}
+	if err := DB.Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user, got error: %v", err)
+	}
+
+	// Test case 1: Update with map (the original issue)
+	updates := map[string]interface{}{"name": "hello", "age": 18}
+	if _, err := gorm.G[User](DB).Where("id = ?", user.ID).Updates(ctx, updates); err != nil {
+		t.Errorf("Updates failed with map: %v", err)
+	}
+
+	var result User
+	if err := DB.First(&result, user.ID).Error; err != nil {
+		t.Fatalf("failed to find user: %v", err)
+	}
+	if result.Name != "hello" {
+		t.Errorf("expected name to be hello, but got %s", result.Name)
+	}
+
+	// Test case 2: Update with struct (ensure backward compatibility)
+	user.Name = "world"
+	if _, err := gorm.G[User](DB).Where("id = ?", user.ID).Updates(ctx, user); err != nil {
+		t.Errorf("Updates failed with struct: %v", err)
+	}
+
+	if err := DB.First(&result, user.ID).Error; err != nil {
+		t.Fatalf("failed to find user: %v", err)
+	}
+	if result.Name != "world" {
+		t.Errorf("expected name to be world, but got %s", result.Name)
+	}
+}


### PR DESCRIPTION


- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This pull request fixes issue #7709.

It relaxes the parameter type of the Updates method in the generic API gorm.G[T] to any. This change aligns the generic method's behavior with the polymorphic nature of gorm.DB.Updates, enabling it to correctly handle updates from both map[string]interface{} and struct types. Previously, the strict type constraint limited the method's usability in dynamic field update scenarios.

The implementation involves modifying the Updates method signature in the CreateInterface[T] and ChainInterface[T] interfaces. The core logic in chainG[T].Updates is adjusted to first set the model with Model(r) (where r is of type *T) and then apply the updates. This ensures the correct table schema is targeted before executing the update operation with the provided values.

```
// In CreateInterface[T] and ChainInterface[T]
Updates(ctx context.Context, values any) (rowsAffected int, err error)

// In chainG[T]
func (c chainG[T]) Updates(ctx context.Context, values any) (rowsAffected int, err error) {
    var r *T
    res := c.g.apply(ctx).Model(r).Updates(values)
    return int(res.RowsAffected), res.Error
}

```

Verification was completed by adding new tests in tests/generics_test.go, which cover both map and struct update paths. This change is non-breaking and maintains the behavior of existing calls while enhancing functionality for dynamic updates.


### User Case Description

#### Example 1: Updating with a map

update specific fields by passing a map[string]interface{}. 


```
// User wants to update only name and age
updates := map[string]interface{}{"name": "hello", "age": 18}
gorm.G[User](DB).Where("id = ?", user.ID).Updates(context.Background(), updates)
```


#### Example 2: Updating with a struct
The existing behavior of updating from a struct instance remains fully supported. 

```
// User updates the name and saves the object
user.Name = "world"
gorm.G[User](DB).Where("id = ?", user.ID).Updates(context.Background(), user)

```
