### PR TITLE
feat(update): apply QueryFields to RETURNING *

### DIFF
--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -138,7 +138,7 @@ func applyQueryFieldsToReturningClause(db *gorm.DB) {
 
 	columns := make([]clause.Column, len(db.Statement.Schema.DBNames))
 	for idx, dbName := range db.Statement.Schema.DBNames {
-		columns[idx] = clause.Column{Name: dbName}
+		columns[idx] = clause.Column{Table: db.Statement.Table, Name: dbName}
 	}
 
 	db.Statement.Clauses["RETURNING"] = clause.Clause{

--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -65,6 +65,10 @@ func Update(config *Config) func(db *gorm.DB) {
 			for _, c := range db.Statement.Schema.UpdateClauses {
 				db.Statement.AddClause(c)
 			}
+
+			if supportReturning {
+				applyQueryFieldsToReturningClause(db)
+			}
 		}
 
 		if db.Statement.SQL.Len() == 0 {
@@ -110,6 +114,36 @@ func Update(config *Config) func(db *gorm.DB) {
 				}
 			}
 		}
+	}
+}
+
+func applyQueryFieldsToReturningClause(db *gorm.DB) {
+	if !db.QueryFields || db.Statement.Schema == nil {
+		return
+	}
+
+	c, ok := db.Statement.Clauses["RETURNING"]
+	if !ok {
+		return
+	}
+
+	returning, ok := c.Expression.(clause.Returning)
+	if !ok {
+		return
+	}
+
+	if len(returning.Columns) > 1 || (len(returning.Columns) == 1 && returning.Columns[0].Name != "*") {
+		return
+	}
+
+	columns := make([]clause.Column, len(db.Statement.Schema.DBNames))
+	for idx, dbName := range db.Statement.Schema.DBNames {
+		columns[idx] = clause.Column{Name: dbName}
+	}
+
+	db.Statement.Clauses["RETURNING"] = clause.Clause{
+		Name:       "RETURNING",
+		Expression: clause.Returning{Columns: columns},
 	}
 }
 

--- a/callbacks/update_test.go
+++ b/callbacks/update_test.go
@@ -26,8 +26,8 @@ func TestUpdateReturningUsesExplicitColumnsWhenQueryFieldsEnabled(t *testing.T) 
 		t.Fatalf("SQL should not include wildcard returning when QueryFields is enabled, got %v", sql)
 	}
 
-	returningColumns := `(?i)RETURNING .*id.*created_at.*updated_at.*deleted_at.*name.*age.*birthday.*company_id.*manager_id.*active`
+	returningColumns := "(?i)RETURNING .*`users`\\.`id`.*`users`\\.`created_at`.*`users`\\.`updated_at`.*`users`\\.`deleted_at`.*`users`\\.`name`.*`users`\\.`age`.*`users`\\.`birthday`.*`users`\\.`company_id`.*`users`\\.`manager_id`.*`users`\\.`active`"
 	if !regexp.MustCompile(returningColumns).MatchString(sql) {
-		t.Fatalf("SQL should include explicit returning columns when QueryFields is enabled, got %v", sql)
+		t.Fatalf("SQL should include explicit qualified returning columns when QueryFields is enabled, got %v", sql)
 	}
 }

--- a/callbacks/update_test.go
+++ b/callbacks/update_test.go
@@ -1,0 +1,33 @@
+package callbacks_test
+
+import (
+	"regexp"
+	"testing"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/utils/tests"
+)
+
+func TestUpdateReturningUsesExplicitColumnsWhenQueryFieldsEnabled(t *testing.T) {
+	db, err := gorm.Open(tests.DummyDialector{}, &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db failed: %v", err)
+	}
+
+	stmt := db.Session(&gorm.Session{DryRun: true, QueryFields: true}).
+		Model(&tests.User{}).
+		Clauses(clause.Returning{}).
+		Where("name = ?", "update-returning-query-fields").
+		Update("age", 88).Statement
+
+	sql := stmt.SQL.String()
+	if regexp.MustCompile(`(?i)RETURNING \*`).MatchString(sql) {
+		t.Fatalf("SQL should not include wildcard returning when QueryFields is enabled, got %v", sql)
+	}
+
+	returningColumns := `(?i)RETURNING .*id.*created_at.*updated_at.*deleted_at.*name.*age.*birthday.*company_id.*manager_id.*active`
+	if !regexp.MustCompile(returningColumns).MatchString(sql) {
+		t.Fatalf("SQL should include explicit returning columns when QueryFields is enabled, got %v", sql)
+	}
+}

--- a/tests/update_test.go
+++ b/tests/update_test.go
@@ -809,11 +809,11 @@ func TestUpdateReturningWithQueryFields(t *testing.T) {
 		Update("age", 88).Statement
 
 	sql := stmt.SQL.String()
-	if regexp.MustCompile(`(?i)RETURNING \*`).MatchString(sql) {
+	if regexp.MustCompile(`(?i)(RETURNING|OUTPUT)\s+(\*|INSERTED\.\*)`).MatchString(sql) {
 		t.Fatalf("SQL should not include wildcard returning when QueryFields is enabled, got %v", sql)
 	}
 
-	returningColumns := `(?i)RETURNING .*id.*created_at.*updated_at.*deleted_at.*name.*age.*birthday.*company_id.*manager_id.*active`
+	returningColumns := `(?i)(RETURNING|OUTPUT) .*id.*created_at.*updated_at.*deleted_at.*name.*age.*birthday.*company_id.*manager_id.*active`
 	if !regexp.MustCompile(returningColumns).MatchString(sql) {
 		t.Fatalf("SQL should include explicit returning columns when QueryFields is enabled, got %v", sql)
 	}

--- a/tests/update_test.go
+++ b/tests/update_test.go
@@ -797,6 +797,28 @@ func TestUpdateReturning(t *testing.T) {
 	}
 }
 
+func TestUpdateReturningWithQueryFields(t *testing.T) {
+	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "gaussdb" && DB.Dialector.Name() != "sqlserver" {
+		return
+	}
+
+	stmt := DB.Session(&gorm.Session{DryRun: true, QueryFields: true}).
+		Model(&User{}).
+		Clauses(clause.Returning{}).
+		Where("name = ?", "update-returning-query-fields").
+		Update("age", 88).Statement
+
+	sql := stmt.SQL.String()
+	if regexp.MustCompile(`(?i)RETURNING \*`).MatchString(sql) {
+		t.Fatalf("SQL should not include wildcard returning when QueryFields is enabled, got %v", sql)
+	}
+
+	returningColumns := `(?i)RETURNING .*id.*created_at.*updated_at.*deleted_at.*name.*age.*birthday.*company_id.*manager_id.*active`
+	if !regexp.MustCompile(returningColumns).MatchString(sql) {
+		t.Fatalf("SQL should include explicit returning columns when QueryFields is enabled, got %v", sql)
+	}
+}
+
 func TestUpdateWithDiffSchema(t *testing.T) {
 	user := GetUser("update-diff-schema-1", Config{})
 	DB.Create(&user)


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Apply `QueryFields` to `UPDATE ... RETURNING *` by replacing the wildcard returning clause with explicit schema columns.

### User Case Description

`QueryFields` already expands `SELECT *` into explicit columns in regular query paths.

However, `UPDATE ... RETURNING *` still uses a wildcard even when `QueryFields` is enabled.

This change makes update-returning queries consistent with the existing `QueryFields` behavior.

Fixes #7690