### PR TITLE
correct typo and rename fileType to fieldType in AlterColumn

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -408,15 +408,15 @@ func (m Migrator) DropColumn(value interface{}, name string) error {
 	})
 }
 
-// AlterColumn alter value's `field` column' type based on schema definition
+// AlterColumn alter value's `field` column's type based on schema definition
 func (m Migrator) AlterColumn(value interface{}, field string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if stmt.Schema != nil {
 			if field := stmt.Schema.LookUpField(field); field != nil {
-				fileType := m.FullDataTypeOf(field)
+				fieldType := m.FullDataTypeOf(field)
 				return m.DB.Exec(
 					"ALTER TABLE ? ALTER COLUMN ? TYPE ?",
-					m.CurrentTable(stmt), clause.Column{Name: field.DBName}, fileType,
+					m.CurrentTable(stmt), clause.Column{Name: field.DBName}, fieldType,
 				).Error
 
 			}


### PR DESCRIPTION
# Renames the misnamed 'fileType' to 'fieldType', as well as fixed the typo for column' to column's.

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?
- Changed a typo in the `AlterColumn` method description, was missing an s for the column's ownership of its type.
- Changed variable name `fileType` to `fieldType` as it refers to a column or a field not a file type.

### User Case Description
Any reader of `AlterColumn` would be confused by a variable called `fileType` in a database migration context. `fieldType` matches the intent.
