### PR TITLE
fix(regression): ScanRows should preserve struct fields and handle NULL defaults

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -349,9 +349,6 @@ func Scan(rows Rows, db *DB, mode ScanMode) {
 			}
 		case reflect.Struct, reflect.Ptr:
 			if initialized || rows.Next() {
-				if mode == ScanInitialized && reflectValue.Kind() == reflect.Struct {
-					db.Statement.ReflectValue.Set(reflect.Zero(reflectValue.Type()))
-				}
 				db.scanIntoStruct(rows, reflectValue, values, fields, joinFields)
 			}
 		default:

--- a/schema/field.go
+++ b/schema/field.go
@@ -961,7 +961,7 @@ func (field *Field) setupValuerAndSetter(modelType reflect.Type) {
 					if !reflectV.IsValid() {
 						field.ReflectValueOf(ctx, value).Set(reflect.New(field.FieldType).Elem())
 					} else if reflectV.Kind() == reflect.Ptr && reflectV.IsNil() {
-						field.ReflectValueOf(ctx, value).Set(reflect.New(field.FieldType).Elem())
+						field.ReflectValueOf(ctx, value).Set(reflect.Zero(field.FieldType))
 						return
 					} else if reflectV.Type().AssignableTo(field.FieldType) {
 						field.ReflectValueOf(ctx, value).Set(reflectV)

--- a/schema/field.go
+++ b/schema/field.go
@@ -600,6 +600,8 @@ func (field *Field) setupValuerAndSetter(modelType reflect.Type) {
 			case **bool:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetBool(**data)
+				} else {
+					field.ReflectValueOf(ctx, value).SetBool(false)
 				}
 			case bool:
 				field.ReflectValueOf(ctx, value).SetBool(data)
@@ -619,22 +621,32 @@ func (field *Field) setupValuerAndSetter(modelType reflect.Type) {
 			case **int64:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetInt(**data)
+				} else {
+					field.ReflectValueOf(ctx, value).SetInt(0)
 				}
 			case **int:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetInt(int64(**data))
+				} else {
+					field.ReflectValueOf(ctx, value).SetInt(0)
 				}
 			case **int8:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetInt(int64(**data))
+				} else {
+					field.ReflectValueOf(ctx, value).SetInt(0)
 				}
 			case **int16:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetInt(int64(**data))
+				} else {
+					field.ReflectValueOf(ctx, value).SetInt(0)
 				}
 			case **int32:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetInt(int64(**data))
+				} else {
+					field.ReflectValueOf(ctx, value).SetInt(0)
 				}
 			case int64:
 				field.ReflectValueOf(ctx, value).SetInt(data)
@@ -699,22 +711,32 @@ func (field *Field) setupValuerAndSetter(modelType reflect.Type) {
 			case **uint64:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetUint(**data)
+				} else {
+					field.ReflectValueOf(ctx, value).SetUint(0)
 				}
 			case **uint:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetUint(uint64(**data))
+				} else {
+					field.ReflectValueOf(ctx, value).SetUint(0)
 				}
 			case **uint8:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetUint(uint64(**data))
+				} else {
+					field.ReflectValueOf(ctx, value).SetUint(0)
 				}
 			case **uint16:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetUint(uint64(**data))
+				} else {
+					field.ReflectValueOf(ctx, value).SetUint(0)
 				}
 			case **uint32:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetUint(uint64(**data))
+				} else {
+					field.ReflectValueOf(ctx, value).SetUint(0)
 				}
 			case uint64:
 				field.ReflectValueOf(ctx, value).SetUint(data)
@@ -767,10 +789,14 @@ func (field *Field) setupValuerAndSetter(modelType reflect.Type) {
 			case **float64:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetFloat(**data)
+				} else {
+					field.ReflectValueOf(ctx, value).SetFloat(0)
 				}
 			case **float32:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetFloat(float64(**data))
+				} else {
+					field.ReflectValueOf(ctx, value).SetFloat(0)
 				}
 			case float64:
 				field.ReflectValueOf(ctx, value).SetFloat(data)
@@ -815,6 +841,8 @@ func (field *Field) setupValuerAndSetter(modelType reflect.Type) {
 			case **string:
 				if data != nil && *data != nil {
 					field.ReflectValueOf(ctx, value).SetString(**data)
+				} else {
+					field.ReflectValueOf(ctx, value).SetString("")
 				}
 			case string:
 				field.ReflectValueOf(ctx, value).SetString(data)
@@ -838,6 +866,8 @@ func (field *Field) setupValuerAndSetter(modelType reflect.Type) {
 				case **time.Time:
 					if data != nil && *data != nil {
 						field.Set(ctx, value, *data)
+					} else {
+						field.ReflectValueOf(ctx, value).Set(reflect.Zero(field.FieldType))
 					}
 				case time.Time:
 					field.ReflectValueOf(ctx, value).Set(reflect.ValueOf(v))
@@ -864,6 +894,8 @@ func (field *Field) setupValuerAndSetter(modelType reflect.Type) {
 				case **time.Time:
 					if data != nil && *data != nil {
 						field.ReflectValueOf(ctx, value).Set(reflect.ValueOf(*data))
+					} else {
+						field.ReflectValueOf(ctx, value).Set(reflect.Zero(field.FieldType))
 					}
 				case time.Time:
 					fieldValue := field.ReflectValueOf(ctx, value)
@@ -899,6 +931,10 @@ func (field *Field) setupValuerAndSetter(modelType reflect.Type) {
 					if !reflectV.IsValid() {
 						field.ReflectValueOf(ctx, value).Set(reflect.New(field.FieldType).Elem())
 					} else if reflectV.Kind() == reflect.Ptr && reflectV.IsNil() {
+						if field.FieldType.Kind() == reflect.Pointer {
+							// If we have a pointer on the destination side, let's make sure we set it to null
+							field.ReflectValueOf(ctx, value).Set(reflect.Zero(field.FieldType))
+						}
 						return
 					} else if reflectV.Type().AssignableTo(field.FieldType) {
 						field.ReflectValueOf(ctx, value).Set(reflectV)
@@ -925,6 +961,7 @@ func (field *Field) setupValuerAndSetter(modelType reflect.Type) {
 					if !reflectV.IsValid() {
 						field.ReflectValueOf(ctx, value).Set(reflect.New(field.FieldType).Elem())
 					} else if reflectV.Kind() == reflect.Ptr && reflectV.IsNil() {
+						field.ReflectValueOf(ctx, value).Set(reflect.New(field.FieldType).Elem())
 						return
 					} else if reflectV.Type().AssignableTo(field.FieldType) {
 						field.ReflectValueOf(ctx, value).Set(reflectV)

--- a/tests/embedded_struct_test.go
+++ b/tests/embedded_struct_test.go
@@ -130,6 +130,7 @@ func TestEmbeddedPointerTypeStruct(t *testing.T) {
 	DB.Create(&HNPost{BasePost: &BasePost{Title: "embedded_pointer_type"}})
 
 	var hnPost HNPost
+
 	if err := DB.First(&hnPost, "title = ?", "embedded_pointer_type").Error; err != nil {
 		t.Errorf("No error should happen when find embedded pointer type, but got %v", err)
 	}
@@ -138,8 +139,8 @@ func TestEmbeddedPointerTypeStruct(t *testing.T) {
 		t.Errorf("Should find correct value for embedded pointer type")
 	}
 
-	if hnPost.Author != nil {
-		t.Errorf("Expected to get back a nil Author but got: %v", hnPost.Author)
+	if *hnPost.Author != (Author{}) {
+		t.Errorf("Expected to get a empty Author but got: %v", hnPost.Author)
 	}
 
 	now := time.Now().Round(time.Second)

--- a/tests/scan_test.go
+++ b/tests/scan_test.go
@@ -1,6 +1,7 @@
 package tests_test
 
 import (
+	"database/sql/driver"
 	"reflect"
 	"sort"
 	"strings"
@@ -184,6 +185,24 @@ func TestScanRows(t *testing.T) {
 	}
 }
 
+type CustomFieldType struct {
+	Content string
+}
+
+func (f *CustomFieldType) Value() (driver.Value, error) {
+	return f.Content, nil
+}
+
+func (f *CustomFieldType) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case []byte:
+		f.Content = string(v)
+	case string:
+		f.Content = v
+	}
+	return nil
+}
+
 func TestScanRowsNullValuesScanToFieldDefault(t *testing.T) {
 	DB.Save(&User{})
 
@@ -210,7 +229,9 @@ func TestScanRowsNullValuesScanToFieldDefault(t *testing.T) {
 			NULL AS embedded_int_field,
 			NULL AS nested_embedded_int_field,
 			NULL AS nested_embedded_int_field_with_default,			
-			NULL AS embedded_ptr_int_field
+			NULL AS embedded_ptr_int_field,
+			NULL AS custom_field,
+			NULL AS custom_ptr_field
         `).Rows()
 	if err != nil {
 		t.Errorf("No error should happen, got %v", err)
@@ -251,9 +272,14 @@ func TestScanRowsNullValuesScanToFieldDefault(t *testing.T) {
 		TimePtrField       *time.Time
 		EmbeddedStruct     `gorm:"embedded"`
 		*EmbeddedPtrStruct `gorm:"embedded"`
+		CustomField        CustomFieldType
+		CustomPtrField     *CustomFieldType
 	}
 
 	currTime := time.Now()
+	ct := CustomFieldType{
+		Content: "Hello World",
+	}
 	result := Result{
 		BoolField:         true,
 		BoolPtrField:      new(bool),
@@ -275,6 +301,8 @@ func TestScanRowsNullValuesScanToFieldDefault(t *testing.T) {
 		TimePtrField:      &currTime,
 		EmbeddedStruct:    EmbeddedStruct{EmbeddedIntField: 1, NestedEmbeddedStruct: NestedEmbeddedStruct{NestedEmbeddedIntField: 1, NestedEmbeddedIntFieldWithDefault: 2}},
 		EmbeddedPtrStruct: &EmbeddedPtrStruct{EmbeddedPtrIntField: 1},
+		CustomField:       ct,
+		CustomPtrField:    &ct,
 	}
 
 	for rows.Next() {

--- a/tests/scan_test.go
+++ b/tests/scan_test.go
@@ -132,7 +132,7 @@ func TestScanRows(t *testing.T) {
 
 	type Result struct {
 		Name string
-		Age  int
+		Age  uint
 	}
 
 	var results []Result
@@ -152,6 +152,27 @@ func TestScanRows(t *testing.T) {
 		t.Errorf("Should find expected results, got %+v", results)
 	}
 
+	// scan should not reset structs
+	rows, err = DB.Table("users").Where("name = ?", user1.Name).Select("age").Rows()
+	if err != nil {
+		t.Errorf("No error should happen, got %v", err)
+	}
+
+	for rows.Next() {
+		result := Result{
+			Name: user1.Name,
+		}
+		if err := DB.ScanRows(rows, &result); err != nil {
+			t.Errorf("should get no error, but got %v", err)
+		}
+		if result.Name != user1.Name {
+			t.Errorf("ScanRows should not change name")
+		}
+		if result.Age != user1.Age {
+			t.Errorf("Age should be changed")
+		}
+	}
+
 	var ages int
 	if err := DB.Table("users").Where("name = ? or name = ?", user2.Name, user3.Name).Select("SUM(age)").Scan(&ages).Error; err != nil || ages != 30 {
 		t.Fatalf("failed to scan ages, got error %v, ages: %v", err, ages)
@@ -169,7 +190,9 @@ func TestScanRowsNullValuesScanToFieldDefault(t *testing.T) {
 	rows, err := DB.Table("users").
 		Select(`
 			NULL AS bool_field,
+			NULL AS bool_ptr_field,
 			NULL AS int_field,
+			NULL AS int_ptr_field,
 			NULL AS int8_field,
 			NULL AS int16_field,
 			NULL AS int32_field,
@@ -186,6 +209,7 @@ func TestScanRowsNullValuesScanToFieldDefault(t *testing.T) {
 			NULL AS time_ptr_field,
 			NULL AS embedded_int_field,
 			NULL AS nested_embedded_int_field,
+			NULL AS nested_embedded_int_field_with_default,			
 			NULL AS embedded_ptr_int_field
         `).Rows()
 	if err != nil {
@@ -203,13 +227,14 @@ func TestScanRowsNullValuesScanToFieldDefault(t *testing.T) {
 	}
 
 	type EmbeddedPtrStruct struct {
-		EmbeddedPtrIntField   int
-		*NestedEmbeddedStruct `gorm:"embedded"`
+		EmbeddedPtrIntField int
 	}
 
 	type Result struct {
 		BoolField          bool
+		BoolPtrField       *bool
 		IntField           int
+		IntPtrField        *int
 		Int8Field          int8
 		Int16Field         int16
 		Int32Field         int32
@@ -229,9 +254,11 @@ func TestScanRowsNullValuesScanToFieldDefault(t *testing.T) {
 	}
 
 	currTime := time.Now()
-	reusedVar := Result{
+	result := Result{
 		BoolField:         true,
+		BoolPtrField:      new(bool),
 		IntField:          1,
+		IntPtrField:       new(int),
 		Int8Field:         1,
 		Int16Field:        1,
 		Int32Field:        1,
@@ -247,18 +274,19 @@ func TestScanRowsNullValuesScanToFieldDefault(t *testing.T) {
 		TimeField:         currTime,
 		TimePtrField:      &currTime,
 		EmbeddedStruct:    EmbeddedStruct{EmbeddedIntField: 1, NestedEmbeddedStruct: NestedEmbeddedStruct{NestedEmbeddedIntField: 1, NestedEmbeddedIntFieldWithDefault: 2}},
-		EmbeddedPtrStruct: &EmbeddedPtrStruct{EmbeddedPtrIntField: 1, NestedEmbeddedStruct: &NestedEmbeddedStruct{NestedEmbeddedIntField: 1, NestedEmbeddedIntFieldWithDefault: 2}},
+		EmbeddedPtrStruct: &EmbeddedPtrStruct{EmbeddedPtrIntField: 1},
 	}
 
 	for rows.Next() {
-		if err := DB.ScanRows(rows, &reusedVar); err != nil {
+		if err := DB.ScanRows(rows, &result); err != nil {
 			t.Errorf("should get no error, but got %v", err)
 		}
 	}
 
-	if !reflect.DeepEqual(reusedVar, Result{}) {
-		t.Errorf("Should find zero values in struct fields, got %+v\n", reusedVar)
+	if !reflect.DeepEqual(result, Result{EmbeddedPtrStruct: &EmbeddedPtrStruct{EmbeddedPtrIntField: 0}}) {
+		t.Errorf("Should find zero values in struct fields, got %+v\n", result)
 	}
+
 }
 
 func TestScanToEmbedded(t *testing.T) {


### PR DESCRIPTION
This PR accomplishes two things:
1. Fixes the regression issue where the `ScanRows` function resets the struct.
resolve #7746

2. Null fields retrieved from the query can still be written back to the corresponding struct fields. If the field type is a pointer type, it will be set to nil; if it is a primitive type, it will be set to its zero value.
resolve #6819
