### PR TITLE
fix(migrator): support functional prefix indexes for PostgreSQL

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -811,7 +811,16 @@ func (m Migrator) BuildIndexOptions(opts []schema.IndexOption, stmt *gorm.Statem
 		if opt.Expression != "" {
 			str = opt.Expression
 		} else if opt.Length > 0 {
-			str += fmt.Sprintf("(LEFT(%s,%d))", str, opt.Length)
+			// Use Postgres-specific prefix only if dialect is Postgres
+			dialectName := ""
+			if m.DB != nil && m.DB.Dialector != nil {
+				dialectName = strings.ToLower(fmt.Sprintf("%T", m.DB.Dialector))
+			}
+			if strings.Contains(dialectName, "postgres") {
+				str = fmt.Sprintf("LEFT(%s,%d)", str, opt.Length)
+			} else {
+				str += fmt.Sprintf("(%d)", opt.Length)
+			}
 		}
 
 		if opt.Collate != "" {

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -811,7 +811,7 @@ func (m Migrator) BuildIndexOptions(opts []schema.IndexOption, stmt *gorm.Statem
 		if opt.Expression != "" {
 			str = opt.Expression
 		} else if opt.Length > 0 {
-			str += fmt.Sprintf("(%d)", opt.Length)
+			str += fmt.Sprintf("(LEFT(%s,%d))", str, opt.Length)
 		}
 
 		if opt.Collate != "" {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### 1. The Problem
GORM currently uses MySQL-specific syntax `column(length)` when generating indexes with a `length `tag. While this works for MySQL, it is invalid in PostgreSQL. Currently, when a user defines` gorm:"index:idx_name,length:10"` in a Postgres environment, GORM generates:
`CREATE INDEX "idx_name" ON "table" ("column"(10))`
This results in either a syntax error or a standard B-tree index that ignores the length, depending on the driver version.

### 2. The Solution
This PR introduces two changes:

**Schema Parser**: Updates `parseFieldIndexes `to be case-insensitive when looking for the `length `tag, ensuring `length:10 `and `LENGTH:10` both populate the` IndexOption.Length `field.

**Migrator**: Updates `BuildIndexOptions `to check the database dialect. If the dialect is PostgreSQL, it uses the functional LEFT(column, length) syntax wrapped in parentheses.

### 3. Impact
- **MySQL/SQLite**: No change (standard syntax preserved).
- **PostgreSQL**: Now correctly creates prefix indexes as functional indexes.

### User Case Description

1. Define a model with a prefix index:
```
type User struct {
    Name string `gorm:"index:idx_name,length:10"`
}
```
2. Run `AutoMigrate `on a PostgreSQL database. 
3. Verify the index using `\d users`.
4. **Expected result**: `idx_name btree (left(name, 10))`


Resolves #7752