### PR TITLE
fix(generics): align Select signature with DB.Select

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -52,7 +52,7 @@ type CreateInterface[T any] interface {
 	Offset(offset int) ChainInterface[T]
 	Joins(query clause.JoinTarget, on func(db JoinBuilder, joinTable clause.Table, curTable clause.Table) error) ChainInterface[T]
 	Preload(association string, query func(db PreloadBuilder) error) ChainInterface[T]
-	Select(query string, args ...interface{}) CreateInterface[T]
+	Select(query interface{}, args ...interface{}) CreateInterface[T]
 	Omit(columns ...string) CreateInterface[T]
 	MapColumns(m map[string]string) ChainInterface[T]
 	Distinct(args ...interface{}) ChainInterface[T]
@@ -82,7 +82,7 @@ type ChainInterface[T any] interface {
 	Offset(offset int) ChainInterface[T]
 	Joins(query clause.JoinTarget, on func(db JoinBuilder, joinTable clause.Table, curTable clause.Table) error) ChainInterface[T]
 	Preload(association string, query func(db PreloadBuilder) error) ChainInterface[T]
-	Select(query string, args ...interface{}) ChainInterface[T]
+	Select(query interface{}, args ...interface{}) ChainInterface[T]
 	Omit(columns ...string) ChainInterface[T]
 	MapColumns(m map[string]string) ChainInterface[T]
 	Distinct(args ...interface{}) ChainInterface[T]
@@ -207,7 +207,7 @@ func (c createG[T]) Table(name string, args ...interface{}) CreateInterface[T] {
 	})}
 }
 
-func (c createG[T]) Select(query string, args ...interface{}) CreateInterface[T] {
+func (c createG[T]) Select(query interface{}, args ...interface{}) CreateInterface[T] {
 	return createG[T]{c.with(func(db *DB) *DB {
 		return db.Select(query, args...)
 	})}
@@ -432,7 +432,7 @@ func (c chainG[T]) Joins(jt clause.JoinTarget, on func(db JoinBuilder, joinTable
 	})
 }
 
-func (c chainG[T]) Select(query string, args ...interface{}) ChainInterface[T] {
+func (c chainG[T]) Select(query interface{}, args ...interface{}) ChainInterface[T] {
 	return c.with(func(db *DB) *DB {
 		return db.Select(query, args...)
 	})

--- a/tests/generics_test.go
+++ b/tests/generics_test.go
@@ -986,6 +986,22 @@ func TestGenericsToSQL(t *testing.T) {
 	}
 }
 
+func TestGenericsSelectWithArrayInput(t *testing.T) {
+	ctx := context.Background()
+	sql := DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
+		gorm.G[User](tx).Select([]string{"id", "name"}).Find(ctx)
+		return tx
+	})
+
+	if !regexp.MustCompile("SELECT .*id.*,.*name.* FROM .users.").MatchString(sql) {
+		t.Fatalf("ToSQL: got wrong sql with Generics Select array input %v", sql)
+	}
+
+	if strings.Contains(sql, "('id','name')") || strings.Contains(sql, "('name','id')") {
+		t.Fatalf("ToSQL: should build column list instead of string literals, got %v", sql)
+	}
+}
+
 func TestGenericsScanUUID(t *testing.T) {
 	ctx := context.Background()
 	users := []User{


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ - ] Do only one thing
- [ - ] Non breaking API changes
- [ - ] Tested

### What did this pull request do?
Changed the Generics API Select signature from string to any so it matches DB.Select. This allows passing []string directly and fixes incorrect SQL generation when using dynamic field lists.

### User Case Description

This fixes issue #7743 When the selected columns are built dynamically as []string, the previous Generics API required using Select("?", fields), which could generate incorrect SQL in PostgreSQL by treating column names as string literals. After this change, callers can use gorm.G[User](db).Select(fields) directly, consistent with the underlying API.
