### PR TITLE
fix: panic when using clause.Returning with CreateInBatches

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -16,16 +16,6 @@ import (
 )
 
 // Create inserts value, returning the inserted data's primary key in value's id
-func (db *DB) Create(value interface{}) (tx *DB) {
-	if db.CreateBatchSize > 0 {
-		return db.CreateInBatches(value, db.CreateBatchSize)
-	}
-
-	tx = db.getInstance()
-	tx.Statement.Dest = value
-	return tx.callbacks.Create().Execute(tx)
-}
-
 // CreateInBatches inserts value in batches of batchSize
 func (db *DB) CreateInBatches(value interface{}, batchSize int) (tx *DB) {
 	reflectValue := reflect.Indirect(reflect.ValueOf(value))
@@ -33,6 +23,7 @@ func (db *DB) CreateInBatches(value interface{}, batchSize int) (tx *DB) {
 	switch reflectValue.Kind() {
 	case reflect.Slice, reflect.Array:
 		var rowsAffected int64
+
 		tx = db.getInstance()
 
 		// the reflection length judgment of the optimized value
@@ -46,11 +37,31 @@ func (db *DB) CreateInBatches(value interface{}, batchSize int) (tx *DB) {
 				}
 
 				subtx := tx.getInstance()
-				subtx.Statement.Dest = reflectValue.Slice(i, ends).Interface()
+
+				// reflectValue.Slice(i, ends).Interface() returns an unaddressable sub-slice.
+				// When clause.Returning{} tries to call SetLen on it via reflection,
+				// Go runtime panics with "reflect.Value.SetLen using unaddressable value".
+				//
+				// Fix: allocate a new addressable slice of the same type (*[]T),
+				// copy the batch elements into it, and pass the pointer as Dest.
+				// This allows clause.Returning{} to safely write back scanned rows.
+				batchSlice := reflect.New(reflectValue.Type())
+				batchSlice.Elem().Set(reflectValue.Slice(i, ends))
+				subtx.Statement.Dest = batchSlice.Interface()
+
 				subtx.callbacks.Create().Execute(subtx)
 				if subtx.Error != nil {
 					return subtx.Error
 				}
+
+				// After execution, sync the RETURNING results written into batchSlice
+				// back into the original slice so the caller sees the updated values
+				// (e.g. server-generated fields like updated_at, created_at).
+				resultSlice := reflect.Indirect(batchSlice)
+				for j := 0; j < resultSlice.Len(); j++ {
+					reflectValue.Index(i + j).Set(resultSlice.Index(j))
+				}
+
 				rowsAffected += subtx.RowsAffected
 			}
 			return nil
@@ -63,11 +74,13 @@ func (db *DB) CreateInBatches(value interface{}, batchSize int) (tx *DB) {
 		}
 
 		tx.RowsAffected = rowsAffected
+
 	default:
 		tx = db.getInstance()
 		tx.Statement.Dest = value
 		tx = tx.callbacks.Create().Execute(tx)
 	}
+
 	return
 }
 

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -16,6 +16,16 @@ import (
 )
 
 // Create inserts value, returning the inserted data's primary key in value's id
+func (db *DB) Create(value interface{}) (tx *DB) {
+	if db.CreateBatchSize > 0 {
+		return db.CreateInBatches(value, db.CreateBatchSize)
+	}
+
+	tx = db.getInstance()
+	tx.Statement.Dest = value
+	return tx.callbacks.Create().Execute(tx)
+}
+
 // CreateInBatches inserts value in batches of batchSize
 func (db *DB) CreateInBatches(value interface{}, batchSize int) (tx *DB) {
 	reflectValue := reflect.Indirect(reflect.ValueOf(value))
@@ -23,7 +33,6 @@ func (db *DB) CreateInBatches(value interface{}, batchSize int) (tx *DB) {
 	switch reflectValue.Kind() {
 	case reflect.Slice, reflect.Array:
 		var rowsAffected int64
-
 		tx = db.getInstance()
 
 		// the reflection length judgment of the optimized value
@@ -37,26 +46,16 @@ func (db *DB) CreateInBatches(value interface{}, batchSize int) (tx *DB) {
 				}
 
 				subtx := tx.getInstance()
-
-				// reflectValue.Slice(i, ends).Interface() returns an unaddressable sub-slice.
-				// When clause.Returning{} tries to call SetLen on it via reflection,
-				// Go runtime panics with "reflect.Value.SetLen using unaddressable value".
-				//
-				// Fix: allocate a new addressable slice of the same type (*[]T),
-				// copy the batch elements into it, and pass the pointer as Dest.
-				// This allows clause.Returning{} to safely write back scanned rows.
 				batchSlice := reflect.New(reflectValue.Type())
 				batchSlice.Elem().Set(reflectValue.Slice(i, ends))
 				subtx.Statement.Dest = batchSlice.Interface()
 
 				subtx.callbacks.Create().Execute(subtx)
+
 				if subtx.Error != nil {
 					return subtx.Error
 				}
 
-				// After execution, sync the RETURNING results written into batchSlice
-				// back into the original slice so the caller sees the updated values
-				// (e.g. server-generated fields like updated_at, created_at).
 				resultSlice := reflect.Indirect(batchSlice)
 				for j := 0; j < resultSlice.Len(); j++ {
 					reflectValue.Index(i + j).Set(resultSlice.Index(j))
@@ -74,13 +73,11 @@ func (db *DB) CreateInBatches(value interface{}, batchSize int) (tx *DB) {
 		}
 
 		tx.RowsAffected = rowsAffected
-
 	default:
 		tx = db.getInstance()
 		tx.Statement.Dest = value
 		tx = tx.callbacks.Create().Execute(tx)
 	}
-
 	return
 }
 

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -808,3 +808,54 @@ func TestCreateFromMapWithTable(t *testing.T) {
 		t.Errorf("failed to create data from map with table, @id != id")
 	}
 }
+
+func TestCreateInBatchesWithReturning(t *testing.T) {
+	// Regression test for:
+	// panic: reflect: reflect.Value.SetLen using unaddressable value
+	//
+	// When CreateBatchSize > 0, CreateInBatches sets Statement.Dest to
+	// reflectValue.Slice(i, ends).Interface() — an unaddressable sub-slice.
+	// clause.Returning{} then panics when calling SetLen via reflection.
+	//
+	// Fix: allocate a new addressable *[]T per batch and sync results back
+	// into the original slice after execution.
+	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" {
+		t.Skip("RETURNING is only supported on SQLite >= 3.35.0 and PostgreSQL")
+	}
+
+	// Use a session with CreateBatchSize > 0 to force CreateInBatches internally
+	batchDB := DB.Session(&gorm.Session{}).Set("gorm:create_batch_size", 2)
+	// Override CreateBatchSize directly to simulate gorm.Config{CreateBatchSize: 2}
+	batchDB.CreateBatchSize = 2
+
+	users := []User{
+		*GetUser("create_in_batches_returning_1", Config{}),
+		*GetUser("create_in_batches_returning_2", Config{}),
+		*GetUser("create_in_batches_returning_3", Config{}),
+	}
+
+	// Must NOT panic — this was the bug
+	result := batchDB.Clauses(clause.Returning{}).Create(&users)
+	if result.Error != nil {
+		t.Fatalf("expected no error, got: %v", result.Error)
+	}
+
+	// IDs must be populated by RETURNING
+	for i, u := range users {
+		if u.ID == 0 {
+			t.Errorf("users[%d].ID should be populated by RETURNING, got 0", i)
+		}
+	}
+
+	// RowsAffected must match number of created rows
+	if result.RowsAffected != int64(len(users)) {
+		t.Errorf("expected RowsAffected = %d, got %d", len(users), result.RowsAffected)
+	}
+
+	// Verify records actually exist in DB
+	var count int64
+	DB.Model(&User{}).Where("name LIKE ?", "create_in_batches_returning%").Count(&count)
+	if count != int64(len(users)) {
+		t.Errorf("expected %d records in DB, got %d", len(users), count)
+	}
+}

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -810,15 +810,6 @@ func TestCreateFromMapWithTable(t *testing.T) {
 }
 
 func TestCreateInBatchesWithReturning(t *testing.T) {
-	// Regression test for:
-	// panic: reflect: reflect.Value.SetLen using unaddressable value
-	//
-	// When CreateBatchSize > 0, CreateInBatches sets Statement.Dest to
-	// reflectValue.Slice(i, ends).Interface() — an unaddressable sub-slice.
-	// clause.Returning{} then panics when calling SetLen via reflection.
-	//
-	// Fix: allocate a new addressable *[]T per batch and sync results back
-	// into the original slice after execution.
 	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" {
 		t.Skip("RETURNING is only supported on SQLite >= 3.35.0 and PostgreSQL")
 	}


### PR DESCRIPTION

## Problem

When `CreateBatchSize > 0` is set in `gorm.Config` (or `CreateInBatches`
is called directly) alongside `clause.Returning{}`, GORM panics at runtime:

panic: reflect: reflect.Value.SetLen using unaddressable value

Reproduces when:
- `gorm.Config.CreateBatchSize > 0`, OR `db.CreateInBatches()` is called directly
- AND `clause.Returning{}` is used
- AND the database supports RETURNING (SQLite >= 3.35.0, PostgreSQL)

## Root Cause

In `CreateInBatches`, `Statement.Dest` is set to:

    subtx.Statement.Dest = reflectValue.Slice(i, ends).Interface()

`reflect.Value.Slice()` produces an unaddressable value. When the create
callback processes `clause.Returning{}`, it calls `SetLen` on this value
via reflection, which panics.

## Fix

Allocate a new addressable `*[]T` for each batch using `reflect.New`,
copy the batch elements into it, and pass the pointer as `Statement.Dest`.
After execution, sync the results back into the original slice so callers
receive server-generated field values (id, created_at, updated_at, etc.).

## User Case

```go
users := []User{{Name: "Alice"}, {Name: "Bob"}, {Name: "Carol"}}

// Panics before this fix when CreateBatchSize > 0
db.Clauses(clause.Returning{}).Create(&users)
```

## Checklist
- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested
