### PR TITLE
fix(migrator): allow AutoMigrate to update explicit PK defaults

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -542,35 +542,33 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 	}
 
 	// check default value
-	if !field.PrimaryKey {
-		currentDefaultNotNull := field.HasDefaultValue && (field.DefaultValueInterface != nil || !strings.EqualFold(field.DefaultValue, "NULL"))
-		dv, dvNotNull := columnType.DefaultValue()
-		if dvNotNull && !currentDefaultNotNull {
-			// default value -> null
-			alterColumn = true
-		} else if !dvNotNull && currentDefaultNotNull {
-			// null -> default value
-			alterColumn = true
-		} else if currentDefaultNotNull || dvNotNull {
-			switch field.GORMDataType {
-			case schema.Time:
-				if !strings.EqualFold(strings.TrimSuffix(dv, "()"), strings.TrimSuffix(field.DefaultValue, "()")) {
-					alterColumn = true
-				}
-			case schema.Bool:
-				v1, _ := strconv.ParseBool(dv)
-				v2, _ := strconv.ParseBool(field.DefaultValue)
-				if v1 != v2 {
-					alterColumn = true
-				}
-			case schema.String:
-				if dv != field.DefaultValue && dv != strings.Trim(field.DefaultValue, "'\"") {
-					alterColumn = true
-				}
-			default:
-				if dv != field.DefaultValue {
-					alterColumn = true
-				}
+	currentDefaultNotNull := field.HasDefaultValue && (field.DefaultValueInterface != nil || !strings.EqualFold(field.DefaultValue, "NULL"))
+	dv, dvNotNull := columnType.DefaultValue()
+	if dvNotNull && !currentDefaultNotNull {
+		// default value -> null
+		alterColumn = true
+	} else if !dvNotNull && currentDefaultNotNull {
+		// null -> default value
+		alterColumn = true
+	} else if currentDefaultNotNull || dvNotNull {
+		switch field.GORMDataType {
+		case schema.Time:
+			if !strings.EqualFold(strings.TrimSuffix(dv, "()"), strings.TrimSuffix(field.DefaultValue, "()")) {
+				alterColumn = true
+			}
+		case schema.Bool:
+			v1, _ := strconv.ParseBool(dv)
+			v2, _ := strconv.ParseBool(field.DefaultValue)
+			if v1 != v2 {
+				alterColumn = true
+			}
+		case schema.String:
+			if dv != field.DefaultValue && dv != strings.Trim(field.DefaultValue, "'\"") {
+				alterColumn = true
+			}
+		default:
+			if dv != field.DefaultValue {
+				alterColumn = true
 			}
 		}
 	}

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -544,13 +544,14 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 	// check default value
 	currentDefaultNotNull := field.HasDefaultValue && (field.DefaultValueInterface != nil || !strings.EqualFold(field.DefaultValue, "NULL"))
 	dv, dvNotNull := columnType.DefaultValue()
-	if dvNotNull && !currentDefaultNotNull {
+	switch {
+	case dvNotNull && !currentDefaultNotNull:
 		// default value -> null
 		alterColumn = true
-	} else if !dvNotNull && currentDefaultNotNull {
+	case !dvNotNull && currentDefaultNotNull:
 		// null -> default value
 		alterColumn = true
-	} else if currentDefaultNotNull || dvNotNull {
+	case currentDefaultNotNull || dvNotNull:
 		switch field.GORMDataType {
 		case schema.Time:
 			if !strings.EqualFold(strings.TrimSuffix(dv, "()"), strings.TrimSuffix(field.DefaultValue, "()")) {

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -542,34 +542,42 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 	}
 
 	// check default value
-	currentDefaultNotNull := field.HasDefaultValue && (field.DefaultValueInterface != nil || !strings.EqualFold(field.DefaultValue, "NULL"))
-	dv, dvNotNull := columnType.DefaultValue()
-	switch {
-	case dvNotNull && !currentDefaultNotNull:
-		// default value -> null
-		alterColumn = true
-	case !dvNotNull && currentDefaultNotNull:
-		// null -> default value
-		alterColumn = true
-	case currentDefaultNotNull || dvNotNull:
-		switch field.GORMDataType {
-		case schema.Time:
-			if !strings.EqualFold(strings.TrimSuffix(dv, "()"), strings.TrimSuffix(field.DefaultValue, "()")) {
-				alterColumn = true
-			}
-		case schema.Bool:
-			v1, _ := strconv.ParseBool(dv)
-			v2, _ := strconv.ParseBool(field.DefaultValue)
-			if v1 != v2 {
-				alterColumn = true
-			}
-		case schema.String:
-			if dv != field.DefaultValue && dv != strings.Trim(field.DefaultValue, "'\"") {
-				alterColumn = true
-			}
-		default:
-			if dv != field.DefaultValue {
-				alterColumn = true
+	// For primary keys, only check default value changes when an explicit
+	// default: tag is set. Auto-increment primary keys have HasDefaultValue
+	// set by AUTOINCREMENT but should not be compared against the database
+	// default, as the DB returns engine-specific values (e.g. AUTO_INCREMENT)
+	// that differ from the empty model DefaultValue.
+	shouldCheckDefaultValue := !field.PrimaryKey || field.TagSettings["DEFAULT"] != ""
+	if shouldCheckDefaultValue {
+		currentDefaultNotNull := field.HasDefaultValue && (field.DefaultValueInterface != nil || !strings.EqualFold(field.DefaultValue, "NULL"))
+		dv, dvNotNull := columnType.DefaultValue()
+		switch {
+		case dvNotNull && !currentDefaultNotNull:
+			// default value -> null
+			alterColumn = true
+		case !dvNotNull && currentDefaultNotNull:
+			// null -> default value
+			alterColumn = true
+		case currentDefaultNotNull || dvNotNull:
+			switch field.GORMDataType {
+			case schema.Time:
+				if !strings.EqualFold(strings.TrimSuffix(dv, "()"), strings.TrimSuffix(field.DefaultValue, "()")) {
+					alterColumn = true
+				}
+			case schema.Bool:
+				v1, _ := strconv.ParseBool(dv)
+				v2, _ := strconv.ParseBool(field.DefaultValue)
+				if v1 != v2 {
+					alterColumn = true
+				}
+			case schema.String:
+				if dv != field.DefaultValue && dv != strings.Trim(field.DefaultValue, "'\"") {
+					alterColumn = true
+				}
+			default:
+				if dv != field.DefaultValue {
+					alterColumn = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Remove the `!field.PrimaryKey` guard in the default value change detection section of `migrator/migrator.go` so that AutoMigrate can detect and apply default value changes on primary key columns.

## Problem

When using AutoMigrate to add or change a default value on a primary key column (e.g. `default:gen_random_uuid()` on a UUID primary key), the change is silently ignored. The initial table creation correctly applies the default, but subsequent AutoMigrate calls skip the default value check entirely due to the `!field.PrimaryKey` guard at line 545.

This affects a common pattern where users add UUID defaults to existing primary keys after initial migration.

## Fix

Removed the `if !field.PrimaryKey { ... }` wrapper around the default value detection logic only. The type check (line 483) and size check (line 510) guards remain in place since most databases do not support ALTER COLUMN on primary key types, but default value changes are widely supported.

## Test Plan

- [x] `go build ./...` compiles cleanly
- [ ] Reproducible via playground PR go-gorm/playground#716
- [ ] CI will verify against SQLite/PostgreSQL/MySQL drivers

Closes #6963
