### PR TITLE
fix(migrator): normalize quoted default values in non-string type comparison

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -568,7 +568,7 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 					alterColumn = true
 				}
 			default:
-				if dv != field.DefaultValue {
+				if dv != field.DefaultValue && dv != strings.Trim(field.DefaultValue, "'\"") {
 					alterColumn = true
 				}
 			}


### PR DESCRIPTION
Fixes #7553

## Summary

Fix default value comparison in MigrateColumn for non-String GORMDataTypes (e.g. custom types like jsonb) that don't strip surrounding quotes before comparison.

When a field has both a custom type tag (type:jsonb) and a serializer tag (serializer:json), the GORMDataType becomes the custom type name (jsonb) instead of String. This causes the default value comparison to fall into the default case, which compares values directly without normalizing quotes.

For example, with default:'{}' on a jsonb field:
- field.DefaultValue = '{}' (literal single quotes from struct tag)
- Database returns dv = '{}' (without quotes)
- Direct comparison detects mismatch, causing unnecessary ALTER TABLE SET DEFAULT on every AutoMigrate

The fix applies the same quote-stripping normalization used by the String case to the default case.

## Test plan

- go build ./... passes
- go test ./... -short passes (existing TestSlogLogger failure is pre-existing, unrelated)
- Verify with reproduction case from #7553