### PR TITLE
fix: do not apply special table name to dependency models in ReorderModels

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -928,16 +928,16 @@ func (m Migrator) ReorderModels(values []interface{}, autoAdd bool) (results []i
 		parsedSchemas                 = map[*schema.Schema]bool{}
 		valuesMap                     = map[string]Dependency{}
 		insertIntoOrderedList         func(name string)
-		parseDependence               func(value interface{}, addToList bool)
+		parseDependence               func(value interface{}, addToList bool, specialTableName string)
 	)
 
-	parseDependence = func(value interface{}, addToList bool) {
+	parseDependence = func(value interface{}, addToList bool, specialTableName string) {
 		dep := Dependency{
 			Statement: &gorm.Statement{DB: m.DB, Dest: value},
 		}
 		beDependedOn := map[*schema.Schema]bool{}
 		// support for special table name
-		if err := dep.ParseWithSpecialTableName(value, m.DB.Statement.Table); err != nil {
+		if err := dep.ParseWithSpecialTableName(value, specialTableName); err != nil {
 			m.DB.Logger.Error(context.Background(), "failed to parse value %#v, got error %v", value, err)
 		}
 		if _, ok := parsedSchemas[dep.Statement.Schema]; ok {
@@ -965,9 +965,9 @@ func (m Migrator) ReorderModels(values []interface{}, autoAdd bool) (results []i
 							dep.Depends = append(dep.Depends, rel.FieldSchema)
 						} else {
 							fieldValue := reflect.New(rel.FieldSchema.ModelType).Interface()
-							parseDependence(fieldValue, autoAdd)
+							parseDependence(fieldValue, autoAdd, "")
 						}
-						parseDependence(joinValue, autoAdd)
+						parseDependence(joinValue, autoAdd, "")
 					}(rel, reflect.New(rel.JoinTable.ModelType).Interface())
 				}
 			}
@@ -992,7 +992,7 @@ func (m Migrator) ReorderModels(values []interface{}, autoAdd bool) (results []i
 				if _, ok := valuesMap[d.Table]; ok {
 					insertIntoOrderedList(d.Table)
 				} else {
-					parseDependence(reflect.New(d.ModelType).Interface(), autoAdd)
+					parseDependence(reflect.New(d.ModelType).Interface(), autoAdd, "")
 					insertIntoOrderedList(d.Table)
 				}
 			}
@@ -1005,7 +1005,7 @@ func (m Migrator) ReorderModels(values []interface{}, autoAdd bool) (results []i
 		if v, ok := value.(string); ok {
 			results = append(results, v)
 		} else {
-			parseDependence(value, true)
+			parseDependence(value, true, m.DB.Statement.Table)
 		}
 	}
 

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -83,6 +83,33 @@ func TestMigrate(t *testing.T) {
 	}
 }
 
+func TestReorderModelsWithTableNameAndRelation(t *testing.T) {
+	type ReorderRelCompany struct {
+		ID   uint
+		Name string
+	}
+
+	type ReorderRelUser struct {
+		ID        uint
+		Name      string
+		CompanyID uint
+		Company   ReorderRelCompany
+	}
+
+	m := migrator.Migrator{Config: migrator.Config{DB: DB.Table("reorder_rel_users_tmp"), Dialector: DB.Dialector}}
+	ordered := m.ReorderModels([]interface{}{&ReorderRelUser{}}, true)
+
+	if len(ordered) != 2 {
+		t.Fatalf("expected 2 ordered models, got %d", len(ordered))
+	}
+	for _, value := range ordered {
+		stmt := &gorm.Statement{DB: DB}
+		if err := stmt.Parse(value); err != nil {
+			t.Fatalf("failed to parse reordered model %T: %v", value, err)
+		}
+	}
+}
+
 func TestAutoMigrateInt8PGAndGaussDB(t *testing.T) {
 	if DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "gaussdb" {
 		return


### PR DESCRIPTION
When `db.Table("x").AutoMigrate(&Model{})` is used and the model has relations, `ReorderModels` parsed the auto-discovered dependency models with the same special table name, which made their schemas collide in `valuesMap` and produced a `reflect: Field index out of range` / nil pointer panic. The special table name is now only applied to the originally passed values. Closes #6578.