### PR TITLE
fix: schema race condition in parsing

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jinzhu/now"
+
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/utils"
 )
@@ -104,6 +105,11 @@ func (field *Field) BindName() string {
 
 // ParseField parses reflect.StructField to Field
 func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
+	return schema.parseFieldWithCallers(fieldStruct, nil)
+}
+
+// nolint:cyclop
+func (schema *Schema) parseFieldWithCallers(fieldStruct reflect.StructField, inProgress map[reflect.Type]struct{}) *Field {
 	var (
 		err        error
 		tagSetting = ParseTagSetting(fieldStruct.Tag.Get("gorm"), ";")
@@ -198,7 +204,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 				field.DataType = String
 				field.Serializer = serializer
 			} else {
-				schema.err = fmt.Errorf("invalid serializer type %v", serializerName)
+				schema.setErr(fmt.Errorf("invalid serializer type %v", serializerName))
 			}
 		}
 	}
@@ -235,28 +241,28 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 		field.DataType = Bool
 		if field.HasDefaultValue && !skipParseDefaultValue {
 			if field.DefaultValueInterface, err = strconv.ParseBool(field.DefaultValue); err != nil {
-				schema.err = fmt.Errorf("failed to parse %s as default value for bool, got error: %v", field.DefaultValue, err)
+				schema.setErr(fmt.Errorf("failed to parse %s as default value for bool, got error: %v", field.DefaultValue, err))
 			}
 		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		field.DataType = Int
 		if field.HasDefaultValue && !skipParseDefaultValue {
 			if field.DefaultValueInterface, err = strconv.ParseInt(field.DefaultValue, 0, 64); err != nil {
-				schema.err = fmt.Errorf("failed to parse %s as default value for int, got error: %v", field.DefaultValue, err)
+				schema.setErr(fmt.Errorf("failed to parse %s as default value for int, got error: %v", field.DefaultValue, err))
 			}
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		field.DataType = Uint
 		if field.HasDefaultValue && !skipParseDefaultValue {
 			if field.DefaultValueInterface, err = strconv.ParseUint(field.DefaultValue, 0, 64); err != nil {
-				schema.err = fmt.Errorf("failed to parse %s as default value for uint, got error: %v", field.DefaultValue, err)
+				schema.setErr(fmt.Errorf("failed to parse %s as default value for uint, got error: %v", field.DefaultValue, err))
 			}
 		}
 	case reflect.Float32, reflect.Float64:
 		field.DataType = Float
 		if field.HasDefaultValue && !skipParseDefaultValue {
 			if field.DefaultValueInterface, err = strconv.ParseFloat(field.DefaultValue, 64); err != nil {
-				schema.err = fmt.Errorf("failed to parse %s as default value for float, got error: %v", field.DefaultValue, err)
+				schema.setErr(fmt.Errorf("failed to parse %s as default value for float, got error: %v", field.DefaultValue, err))
 			}
 		}
 	case reflect.String:
@@ -398,8 +404,8 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 
 			cacheStore := &sync.Map{}
 			cacheStore.Store(embeddedCacheKey, true)
-			if field.EmbeddedSchema, err = getOrParse(fieldValue.Interface(), cacheStore, embeddedNamer{Table: schema.Table, Namer: schema.namer}); err != nil {
-				schema.err = err
+			if field.EmbeddedSchema, err = getOrParseWithCallers(fieldValue.Interface(), cacheStore, embeddedNamer{Table: schema.Table, Namer: schema.namer}, inProgress); err != nil {
+				schema.setErr(err)
 			}
 
 			for _, ef := range field.EmbeddedSchema.Fields {
@@ -440,7 +446,7 @@ func (schema *Schema) ParseField(fieldStruct reflect.StructField) *Field {
 			}
 		case reflect.Invalid, reflect.Uintptr, reflect.Array, reflect.Chan, reflect.Func, reflect.Interface,
 			reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer, reflect.Complex64, reflect.Complex128:
-			schema.err = fmt.Errorf("invalid embedded struct for %s's field %s, should be struct, but got %v", field.Schema.Name, field.Name, field.FieldType)
+			schema.setErr(fmt.Errorf("invalid embedded struct for %s's field %s, should be struct, but got %v", field.Schema.Name, field.Name, field.FieldType))
 		}
 	}
 

--- a/schema/index.go
+++ b/schema/index.go
@@ -35,7 +35,7 @@ func (schema *Schema) ParseIndexes() []*Index {
 		if field.TagSettings["INDEX"] != "" || field.TagSettings["UNIQUEINDEX"] != "" {
 			fieldIndexes, err := parseFieldIndexes(field)
 			if err != nil {
-				schema.err = err
+				schema.setErr(err)
 				break
 			}
 			for _, index := range fieldIndexes {

--- a/schema/relationship.go
+++ b/schema/relationship.go
@@ -62,7 +62,8 @@ type Reference struct {
 	OwnPrimaryKey bool
 }
 
-func (schema *Schema) parseRelation(field *Field) *Relationship {
+// nolint:cyclop
+func (schema *Schema) parseRelationWithCallers(field *Field, inProgress map[reflect.Type]struct{}) *Relationship {
 	var (
 		err        error
 		fieldValue = reflect.New(field.IndirectFieldType).Interface()
@@ -75,8 +76,8 @@ func (schema *Schema) parseRelation(field *Field) *Relationship {
 		}
 	)
 
-	if relation.FieldSchema, err = getOrParse(fieldValue, schema.cacheStore, schema.namer); err != nil {
-		schema.err = fmt.Errorf("failed to parse field: %s, error: %w", field.Name, err)
+	if relation.FieldSchema, err = getOrParseWithCallers(fieldValue, schema.cacheStore, schema.namer, inProgress); err != nil {
+		schema.setErr(fmt.Errorf("failed to parse field: %s, error: %w", field.Name, err))
 		return nil
 	}
 
@@ -93,8 +94,8 @@ func (schema *Schema) parseRelation(field *Field) *Relationship {
 		case reflect.Slice:
 			schema.guessRelation(relation, field, guessHas)
 		default:
-			schema.err = fmt.Errorf("unsupported data type %v for %v on field %s", relation.FieldSchema, schema,
-				field.Name)
+			schema.setErr(fmt.Errorf("unsupported data type %v for %v on field %s", relation.FieldSchema, schema,
+				field.Name))
 		}
 	}
 
@@ -113,7 +114,10 @@ func (schema *Schema) parseRelation(field *Field) *Relationship {
 		}
 	}
 
-	if schema.err == nil {
+	schema.Relationships.Mux.RLock()
+	err = schema.err
+	schema.Relationships.Mux.RUnlock()
+	if err == nil {
 		schema.setRelation(relation)
 		switch relation.Type {
 		case HasOne:
@@ -220,16 +224,19 @@ func (schema *Schema) buildPolymorphicRelation(relation *Relationship, field *Fi
 	}
 
 	if relation.Polymorphic.PolymorphicType == nil {
-		schema.err = fmt.Errorf("invalid polymorphic type %v for %v on field %s, missing field %s",
-			relation.FieldSchema, schema, field.Name, polymorphic+"Type")
+		schema.setErr(fmt.Errorf("invalid polymorphic type %v for %v on field %s, missing field %s",
+			relation.FieldSchema, schema, field.Name, polymorphic+"Type"))
 	}
 
 	if relation.Polymorphic.PolymorphicID == nil {
-		schema.err = fmt.Errorf("invalid polymorphic type %v for %v on field %s, missing field %s",
-			relation.FieldSchema, schema, field.Name, polymorphic+"ID")
+		schema.setErr(fmt.Errorf("invalid polymorphic type %v for %v on field %s, missing field %s",
+			relation.FieldSchema, schema, field.Name, polymorphic+"ID"))
 	}
 
-	if schema.err == nil {
+	schema.Relationships.Mux.RLock()
+	err := schema.err
+	schema.Relationships.Mux.RUnlock()
+	if err == nil {
 		relation.References = append(relation.References, &Reference{
 			PrimaryValue: relation.Polymorphic.Value,
 			ForeignKey:   relation.Polymorphic.PolymorphicType,
@@ -238,14 +245,14 @@ func (schema *Schema) buildPolymorphicRelation(relation *Relationship, field *Fi
 		primaryKeyField := schema.PrioritizedPrimaryField
 		if len(relation.foreignKeys) > 0 {
 			if primaryKeyField = schema.LookUpField(relation.foreignKeys[0]); primaryKeyField == nil || len(relation.foreignKeys) > 1 {
-				schema.err = fmt.Errorf("invalid polymorphic foreign keys %+v for %v on field %s", relation.foreignKeys,
-					schema, field.Name)
+				schema.setErr(fmt.Errorf("invalid polymorphic foreign keys %+v for %v on field %s", relation.foreignKeys,
+					schema, field.Name))
 			}
 		}
 
 		if primaryKeyField == nil {
-			schema.err = fmt.Errorf("invalid polymorphic type %v for %v on field %s, missing primaryKey field",
-				relation.FieldSchema, schema, field.Name)
+			schema.setErr(fmt.Errorf("invalid polymorphic type %v for %v on field %s, missing primaryKey field",
+				relation.FieldSchema, schema, field.Name))
 			return
 		}
 
@@ -290,7 +297,7 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 			if field := schema.LookUpField(foreignKey); field != nil {
 				ownForeignFields = append(ownForeignFields, field)
 			} else {
-				schema.err = fmt.Errorf("invalid foreign key: %s", foreignKey)
+				schema.setErr(fmt.Errorf("invalid foreign key: %s", foreignKey))
 				return
 			}
 		}
@@ -302,7 +309,7 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 			if field := relation.FieldSchema.LookUpField(foreignKey); field != nil {
 				refForeignFields = append(refForeignFields, field)
 			} else {
-				schema.err = fmt.Errorf("invalid foreign key: %s", foreignKey)
+				schema.setErr(fmt.Errorf("invalid foreign key: %s", foreignKey))
 				return
 			}
 		}
@@ -362,7 +369,7 @@ func (schema *Schema) buildMany2ManyRelation(relation *Relationship, field *Fiel
 
 	if relation.JoinTable, err = Parse(reflect.New(reflect.StructOf(joinTableFields)).Interface(), schema.cacheStore,
 		schema.namer); err != nil {
-		schema.err = err
+		schema.setErr(err)
 	}
 	relation.JoinTable.Name = many2many
 	relation.JoinTable.Table = schema.namer.JoinTableName(many2many)
@@ -480,8 +487,8 @@ func (schema *Schema) guessRelation(relation *Relationship, field *Field, cgl gu
 			schema.guessRelation(relation, field, guessEmbeddedHas)
 		// case guessEmbeddedHas:
 		default:
-			schema.err = fmt.Errorf("invalid field found for struct %v's field %s: define a valid foreign key for relations or implement the Valuer/Scanner interface",
-				schema, field.Name)
+			schema.setErr(fmt.Errorf("invalid field found for struct %v's field %s: define a valid foreign key for relations or implement the Valuer/Scanner interface",
+				schema, field.Name))
 		}
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -57,8 +57,48 @@ type Schema struct {
 	AfterFind                 bool
 	err                       error
 	initialized               chan struct{}
+	fieldsInitialized         chan struct{}
 	namer                     Namer
 	cacheStore                *sync.Map
+}
+
+func (schema *Schema) wait(visited map[*Schema]struct{}) {
+	if schema == nil || schema.initialized == nil {
+		return
+	}
+
+	if _, ok := visited[schema]; ok {
+		return
+	}
+	visited[schema] = struct{}{}
+
+	<-schema.initialized
+	schema.Relationships.Mux.RLock()
+	rels := make([]*Relationship, 0, len(schema.Relationships.Relations))
+	for _, rel := range schema.Relationships.Relations {
+		rels = append(rels, rel)
+	}
+	schema.Relationships.Mux.RUnlock()
+
+	for _, rel := range rels {
+		if rel.FieldSchema != nil {
+			rel.FieldSchema.wait(visited)
+		}
+	}
+}
+
+func (schema *Schema) setErr(err error) {
+	if err != nil {
+		schema.Relationships.Mux.Lock()
+		schema.err = err
+		schema.Relationships.Mux.Unlock()
+	}
+}
+
+func (schema *Schema) getErr() error {
+	schema.Relationships.Mux.RLock()
+	defer schema.Relationships.Mux.RUnlock()
+	return schema.err
 }
 
 func (schema *Schema) String() string {
@@ -137,6 +177,11 @@ func Parse(dest interface{}, cacheStore *sync.Map, namer Namer) (*Schema, error)
 
 // ParseWithSpecialTableName get data type from dialector with extra schema table
 func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Namer, specialTableName string) (*Schema, error) {
+	return parseWithCallers(dest, cacheStore, namer, specialTableName, nil)
+}
+
+// nolint:cyclop
+func parseWithCallers(dest interface{}, cacheStore *sync.Map, namer Namer, specialTableName string, inProgress map[reflect.Type]struct{}) (*Schema, error) {
 	if dest == nil {
 		return nil, fmt.Errorf("%w: %+v", ErrUnsupportedDataType, dest)
 	}
@@ -173,9 +218,22 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 	// Load exist schema cache, return if exists
 	if v, ok := cacheStore.Load(schemaCacheKey); ok {
 		s := v.(*Schema)
+		// If this schema is currently being built by *this* goroutine
+		// (cycle), do NOT wait on s.initialized — that would deadlock.
+		// Returning the partial *Schema works as the outer-most
+		// frame for this type will finish populating it before its own
+		// initialized channel is closed, and any caller that obtained
+		// the schema via the public API waits on that channel.
+		if _, building := inProgress[modelType]; building {
+			return s, s.getErr()
+		}
 		// Wait for the initialization of other goroutines to complete
-		<-s.initialized
-		return s, s.err
+		if inProgress == nil {
+			s.wait(map[*Schema]struct{}{})
+		} else if s.fieldsInitialized != nil {
+			<-s.fieldsInitialized
+		}
+		return s, s.getErr()
 	}
 
 	var tableName string
@@ -193,33 +251,59 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 	}
 
 	schema := &Schema{
-		Name:             modelType.Name(),
-		ModelType:        modelType,
-		Table:            tableName,
-		DBNames:          make([]string, 0, 10),
-		Fields:           make([]*Field, 0, 10),
-		FieldsByName:     make(map[string]*Field, 10),
-		FieldsByBindName: make(map[string]*Field, 10),
-		FieldsByDBName:   make(map[string]*Field, 10),
-		Relationships:    Relationships{Relations: map[string]*Relationship{}},
-		cacheStore:       cacheStore,
-		namer:            namer,
-		initialized:      make(chan struct{}),
+		Name:              modelType.Name(),
+		ModelType:         modelType,
+		Table:             tableName,
+		DBNames:           make([]string, 0, 10),
+		Fields:            make([]*Field, 0, 10),
+		FieldsByName:      make(map[string]*Field, 10),
+		FieldsByBindName:  make(map[string]*Field, 10),
+		FieldsByDBName:    make(map[string]*Field, 10),
+		Relationships:     Relationships{Relations: map[string]*Relationship{}},
+		cacheStore:        cacheStore,
+		namer:             namer,
+		initialized:       make(chan struct{}),
+		fieldsInitialized: make(chan struct{}),
 	}
+
+	// Cache the schema early to allow other goroutines (and cycles in this goroutine) to find it
+	if v, loaded := cacheStore.LoadOrStore(schemaCacheKey, schema); loaded {
+		s := v.(*Schema)
+		if _, building := inProgress[modelType]; building {
+			return s, s.getErr()
+		}
+		if inProgress == nil {
+			s.wait(map[*Schema]struct{}{})
+		} else if s.fieldsInitialized != nil {
+			<-s.fieldsInitialized
+		}
+		return s, s.getErr()
+	}
+
 	// When the schema initialization is completed, the channel will be closed
 	defer close(schema.initialized)
+	// When the field initialization is completed, the channel will be closed
+	defer func() {
+		select {
+		case <-schema.fieldsInitialized:
+		default:
+			close(schema.fieldsInitialized)
+		}
+	}()
 
-	// Load exist schema cache, return if exists
-	if v, ok := cacheStore.Load(schemaCacheKey); ok {
-		s := v.(*Schema)
-		// Wait for the initialization of other goroutines to complete
-		<-s.initialized
-		return s, s.err
+	// Mark this type as in-progress for the current goroutine so that
+	// nested getOrParse calls (which may recurse back into this type
+	// via relationships) can detect the cycle and avoid blocking on
+	// our own initialized channel.
+	if inProgress == nil {
+		inProgress = make(map[reflect.Type]struct{}, 2)
 	}
+	inProgress[modelType] = struct{}{}
+	defer delete(inProgress, modelType)
 
 	for i := 0; i < modelType.NumField(); i++ {
 		if fieldStruct := modelType.Field(i); ast.IsExported(fieldStruct.Name) {
-			if field := schema.ParseField(fieldStruct); field.EmbeddedSchema != nil {
+			if field := schema.parseFieldWithCallers(fieldStruct, inProgress); field.EmbeddedSchema != nil {
 				schema.Fields = append(schema.Fields, field.EmbeddedSchema.Fields...)
 			} else {
 				schema.Fields = append(schema.Fields, field)
@@ -348,18 +432,12 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 		}
 	}
 
-	// Cache the schema
-	if v, loaded := cacheStore.LoadOrStore(schemaCacheKey, schema); loaded {
-		s := v.(*Schema)
-		// Wait for the initialization of other goroutines to complete
-		<-s.initialized
-		return s, s.err
-	}
+	close(schema.fieldsInitialized)
 
 	defer func() {
-		if schema.err != nil {
-			logger.Default.Error(context.Background(), schema.err.Error())
-			cacheStore.Delete(modelType)
+		if err := schema.getErr(); err != nil {
+			logger.Default.Error(context.Background(), err.Error())
+			cacheStore.Delete(schemaCacheKey)
 		}
 	}()
 
@@ -382,15 +460,26 @@ func ParseWithSpecialTableName(dest interface{}, cacheStore *sync.Map, namer Nam
 
 	// parse relationships
 	for _, field := range relationshipFields {
-		if schema.parseRelation(field); schema.err != nil {
-			return schema, schema.err
+		schema.parseRelationWithCallers(field, inProgress)
+		schema.Relationships.Mux.RLock()
+		err := schema.err
+		schema.Relationships.Mux.RUnlock()
+		if err != nil {
+			return schema, err
 		}
 	}
 
-	return schema, schema.err
+	schema.Relationships.Mux.RLock()
+	err := schema.err
+	schema.Relationships.Mux.RUnlock()
+	return schema, err
 }
 
 func getOrParse(dest interface{}, cacheStore *sync.Map, namer Namer) (*Schema, error) {
+	return getOrParseWithCallers(dest, cacheStore, namer, nil)
+}
+
+func getOrParseWithCallers(dest interface{}, cacheStore *sync.Map, namer Namer, inProgress map[reflect.Type]struct{}) (*Schema, error) {
 	modelType := reflect.ValueOf(dest).Type()
 
 	if modelType.Kind() != reflect.Struct {
@@ -407,8 +496,25 @@ func getOrParse(dest interface{}, cacheStore *sync.Map, namer Namer) (*Schema, e
 	}
 
 	if v, ok := cacheStore.Load(modelType); ok {
-		return v.(*Schema), nil
+		s := v.(*Schema)
+		// If the current goroutine is itself building this schema (cycle),
+		// return the cached (possibly partial) pointer immediately to
+		// avoid self-deadlock. The outer-most parse frame for this type
+		// will finish populating it.
+		if _, building := inProgress[modelType]; building {
+			return s, s.getErr()
+		}
+		// Otherwise another goroutine is responsible for closing
+		// s.initialized; wait until parsing is fully done before
+		// handing the schema to the caller — this prevents readers
+		// from seeing a half-built Relationships map.
+		if inProgress == nil {
+			s.wait(map[*Schema]struct{}{})
+		} else if s.fieldsInitialized != nil {
+			<-s.fieldsInitialized
+		}
+		return s, s.getErr()
 	}
 
-	return Parse(dest, cacheStore, namer)
+	return parseWithCallers(dest, cacheStore, namer, "", inProgress)
 }

--- a/schema/schema_race_test.go
+++ b/schema/schema_race_test.go
@@ -1,0 +1,191 @@
+package schema
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+type getOrParseRaceModel struct {
+	ID uint
+}
+
+type getOrParseEmbeddedRaceModel struct {
+	getOrParseRaceModel `gorm:"embedded"`
+}
+
+func TestGetOrParse_WaitsForCachedSchemaInitialization(t *testing.T) {
+	cacheStore := &sync.Map{}
+	modelType := reflect.TypeOf(getOrParseRaceModel{})
+
+	initialized := make(chan struct{})
+	cachedSchema := &Schema{
+		Name:        modelType.Name(),
+		ModelType:   modelType,
+		Table:       "get_or_parse_race_models",
+		initialized: initialized,
+		Relationships: Relationships{
+			Relations: map[string]*Relationship{},
+		},
+	}
+
+	cacheStore.Store(modelType, cachedSchema)
+
+	done := make(chan *Schema, 1)
+	go func() {
+		s, err := getOrParse(getOrParseRaceModel{}, cacheStore, NamingStrategy{})
+		if err != nil {
+			t.Errorf("getOrParse returned error: %v", err)
+			return
+		}
+		done <- s
+	}()
+
+	select {
+	case s := <-done:
+		t.Fatalf("getOrParse returned schema %v before initialized was closed", s)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cachedSchema.Relationships.Relations["Ready"] = &Relationship{Name: "Ready"}
+	close(initialized)
+
+	select {
+	case s := <-done:
+		if s != cachedSchema {
+			t.Fatalf("getOrParse returned unexpected schema pointer")
+		}
+		if _, ok := s.Relationships.Relations["Ready"]; !ok {
+			t.Fatalf("getOrParse returned before cached schema was fully populated")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("getOrParse did not return after initialized was closed")
+	}
+}
+
+func TestGetOrParse_AllowsCurrentParseChainToAvoidSelfDeadlock(t *testing.T) {
+	cacheStore := &sync.Map{}
+	modelType := reflect.TypeOf(getOrParseRaceModel{})
+
+	initialized := make(chan struct{})
+	cachedSchema := &Schema{
+		Name:        modelType.Name(),
+		ModelType:   modelType,
+		Table:       "get_or_parse_race_models",
+		initialized: initialized,
+		Relationships: Relationships{
+			Relations: map[string]*Relationship{},
+		},
+	}
+
+	cacheStore.Store(modelType, cachedSchema)
+
+	done := make(chan *Schema, 1)
+	go func() {
+		s, err := getOrParseWithCallers(
+			getOrParseRaceModel{},
+			cacheStore,
+			NamingStrategy{},
+			map[reflect.Type]struct{}{modelType: {}},
+		)
+		if err != nil {
+			t.Errorf("getOrParseWithCallers returned error: %v", err)
+			return
+		}
+		done <- s
+	}()
+
+	select {
+	case s := <-done:
+		if s != cachedSchema {
+			t.Fatalf("getOrParseWithCallers returned unexpected schema pointer")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("getOrParseWithCallers waited for a schema in the current parse chain")
+	}
+
+	close(initialized)
+}
+
+func TestGetOrParse_EmbeddedSelfDeadlock(t *testing.T) {
+	cacheStore := &sync.Map{}
+	modelType := reflect.TypeOf(getOrParseRaceModel{})
+
+	initialized := make(chan struct{})
+	cachedSchema := &Schema{
+		Name:        modelType.Name(),
+		ModelType:   modelType,
+		Table:       "get_or_parse_race_models",
+		initialized: initialized,
+		Relationships: Relationships{
+			Relations: map[string]*Relationship{},
+		},
+	}
+
+	cacheStore.Store(modelType, cachedSchema)
+
+	done := make(chan struct{})
+	go func() {
+		_, err := getOrParse(getOrParseEmbeddedRaceModel{}, cacheStore, NamingStrategy{})
+		if err != nil {
+			t.Errorf("getOrParse returned error: %v", err)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("getOrParse deadlocked on embedded model")
+	}
+
+	close(initialized)
+}
+
+type getOrParsePet struct {
+	ID     uint
+	UserID uint
+	User   *getOrParseUser `gorm:"foreignKey:UserID"`
+}
+
+type getOrParseUser struct {
+	ID   uint
+	Pets []*getOrParsePet `gorm:"foreignKey:UserID"`
+}
+
+func TestGetOrParse_CyclicDeadlock(t *testing.T) {
+	cacheStore := &sync.Map{}
+	namer := NamingStrategy{}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		_, err := getOrParse(&getOrParseUser{}, cacheStore, namer)
+		if err != nil {
+			t.Errorf("getOrParse returned error: %v", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, err := getOrParse(&getOrParsePet{}, cacheStore, namer)
+		if err != nil {
+			t.Errorf("getOrParse returned error: %v", err)
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("getOrParse deadlocked on cyclic models")
+	}
+}


### PR DESCRIPTION
- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?
Fixes a race condition in parsing where unparsed code can be leaked into the SQL query. It ensures that the different methods for parsing are synchronized with each other so that code is not added without being parsed. This is done in a way to avoid deadlocks. There is a test added to replicate the issue and a regression test.

Fixes #7773 


### User Case Description

When working with complex schemas that have multiple `Joins` we are seeing an intermitent issue where we received an postgres error for invalid SQL. We tracked this down to how the GORM parser is handling the parsing concurrently.
