### PR TITLE
fix(update): avoid polluting reusable zero-value model

### DIFF
--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -18,6 +18,10 @@ func SetupUpdateReflectValue(db *gorm.DB) {
 				db.Statement.ReflectValue = db.Statement.ReflectValue.Elem()
 			}
 
+			if isZeroValueModel(db.Statement.ReflectValue) {
+				db.Statement.ReflectValue = reflect.New(db.Statement.ReflectValue.Type()).Elem()
+			}
+
 			if dest, ok := db.Statement.Dest.(map[string]interface{}); ok {
 				for _, rel := range db.Statement.Schema.Relationships.BelongsTo {
 					if _, ok := dest[rel.Name]; ok {
@@ -27,6 +31,14 @@ func SetupUpdateReflectValue(db *gorm.DB) {
 			}
 		}
 	}
+}
+
+func isZeroValueModel(reflectValue reflect.Value) bool {
+	if !reflectValue.IsValid() || reflectValue.Kind() != reflect.Struct || !reflectValue.CanAddr() {
+		return false
+	}
+
+	return reflectValue.IsZero()
 }
 
 // BeforeUpdate before update hooks

--- a/callbacks/update_test.go
+++ b/callbacks/update_test.go
@@ -1,0 +1,73 @@
+package callbacks_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/utils/tests"
+)
+
+func TestUpdatesFromReusableModelSessionDoesNotLeakPrimaryKey(t *testing.T) {
+	db := openDryRunDB(t)
+	base := db.Model(new(tests.User)).Session(&gorm.Session{})
+
+	update := func(id uint, age uint) *gorm.DB {
+		tx := base.Where("id = ?", id).Updates(&tests.User{
+			Model: gorm.Model{ID: id},
+			Age:   age,
+		})
+		if model := base.Statement.Model.(*tests.User); model.ID != 0 {
+			t.Errorf("reusable base model should remain zero after updating ID %d, got ID %d", id, model.ID)
+		}
+		return tx
+	}
+
+	first := update(111, 666)
+	second := update(222, 777)
+	third := update(333, 888)
+
+	for _, tx := range []*gorm.DB{second, third} {
+		if strings.Contains(tx.Statement.SQL.String(), "AND `id` = ?") {
+			t.Fatalf("update leaked stale primary key condition, sql: %s; first vars: %v; current vars: %v",
+				tx.Statement.SQL.String(), first.Statement.Vars, tx.Statement.Vars)
+		}
+
+		if len(tx.Statement.Vars) != len(first.Statement.Vars) {
+			t.Fatalf("update should not carry extra vars, first vars: %v; current vars: %v", first.Statement.Vars, tx.Statement.Vars)
+		}
+	}
+}
+
+func TestUpdatesWithNonZeroModelKeepsPrimaryKeyCondition(t *testing.T) {
+	db := openDryRunDB(t)
+
+	tx := db.Model(&tests.User{Model: gorm.Model{ID: 999}}).Where("id = ?", 111).Updates(&tests.User{
+		Model: gorm.Model{ID: 111},
+		Age:   666,
+	})
+
+	if !strings.Contains(tx.Statement.SQL.String(), "AND `id` = ?") {
+		t.Fatalf("non-zero model primary key condition was not preserved, sql: %s; vars: %v",
+			tx.Statement.SQL.String(), tx.Statement.Vars)
+	}
+
+	if got := tx.Statement.Vars[len(tx.Statement.Vars)-1]; got != uint(999) {
+		t.Fatalf("non-zero model primary key condition should use model ID 999, got %v; vars: %v", got, tx.Statement.Vars)
+	}
+}
+
+func openDryRunDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(tests.DummyDialector{}, &gorm.Config{
+		DryRun:  true,
+		NowFunc: func() time.Time { return time.Unix(1, 0) },
+	})
+	if err != nil {
+		t.Fatalf("open db failed: %v", err)
+	}
+
+	return db
+}


### PR DESCRIPTION
Fixes #7725.

This PR targets the repository-layer pattern clarified in the issue: a reusable `db.Model(new(T)).Session(...)` base followed by repeated `Updates(record)` calls, where each record naturally contains its primary key.

The fix is intentionally scoped to the update callback. It does not change `Statement.clone()` behavior globally.

It only avoids writing update-destination values back into a reusable zero-value model. Non-zero models such as `Model(&User{ID: 999})` keep their existing behavior and still contribute primary-key conditions.

Tests:
- `go test ./callbacks -run 'TestUpdates(FromReusableModelSessionDoesNotLeakPrimaryKey|WithNonZeroModelKeepsPrimaryKeyCondition)' -v`
- `go test ./callbacks -v`
- `go test ./...`
- `GORM_DIALECT=sqlite GITHUB_ACTION=true go test -count=1 ./tests`