### PR TITLE
Fix potential rows leak on panic by deferring rows.Close()

### DIFF
--- a/callbacks/delete.go
+++ b/callbacks/delete.go
@@ -172,7 +172,9 @@ func Delete(config *Config) func(db *gorm.DB) {
 
 			if rows, err := db.Statement.ConnPool.QueryContext(db.Statement.Context, db.Statement.SQL.String(), db.Statement.Vars...); db.AddError(err) == nil {
 				defer func() {
-					db.AddError(rows.Close())
+					if err := rows.Close(); err != nil {
+						_ = db.AddError(err)
+					}
 				}()
 
 				gorm.Scan(rows, db, mode)

--- a/callbacks/delete.go
+++ b/callbacks/delete.go
@@ -171,12 +171,15 @@ func Delete(config *Config) func(db *gorm.DB) {
 			}
 
 			if rows, err := db.Statement.ConnPool.QueryContext(db.Statement.Context, db.Statement.SQL.String(), db.Statement.Vars...); db.AddError(err) == nil {
+				defer func() {
+					db.AddError(rows.Close())
+				}()
+
 				gorm.Scan(rows, db, mode)
 
 				if db.Statement.Result != nil {
 					db.Statement.Result.RowsAffected = db.RowsAffected
 				}
-				db.AddError(rows.Close())
 			}
 		}
 	}

--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -88,7 +88,9 @@ func Update(config *Config) func(db *gorm.DB) {
 			if ok, mode := hasReturning(db, supportReturning); ok {
 				if rows, err := db.Statement.ConnPool.QueryContext(db.Statement.Context, db.Statement.SQL.String(), db.Statement.Vars...); db.AddError(err) == nil {
 					defer func() {
-						db.AddError(rows.Close())
+						if err := rows.Close(); err != nil {
+							_ = db.AddError(err)
+						}
 					}()
 
 					dest := db.Statement.Dest

--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -87,11 +87,14 @@ func Update(config *Config) func(db *gorm.DB) {
 		if !db.DryRun && db.Error == nil {
 			if ok, mode := hasReturning(db, supportReturning); ok {
 				if rows, err := db.Statement.ConnPool.QueryContext(db.Statement.Context, db.Statement.SQL.String(), db.Statement.Vars...); db.AddError(err) == nil {
+					defer func() {
+						db.AddError(rows.Close())
+					}()
+
 					dest := db.Statement.Dest
 					db.Statement.Dest = db.Statement.ReflectValue.Addr().Interface()
 					gorm.Scan(rows, db, mode)
 					db.Statement.Dest = dest
-					db.AddError(rows.Close())
 
 					if db.Statement.Result != nil {
 						db.Statement.Result.RowsAffected = db.RowsAffected

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -544,7 +544,9 @@ func (db *DB) Scan(dest interface{}) (tx *DB) {
 
 	if rows, err := tx.Rows(); err == nil {
 		defer func() {
-			tx.AddError(rows.Close())
+			if err := rows.Close(); err != nil {
+				_ = tx.AddError(err)
+			}
 		}()
 
 		if rows.Next() {

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -543,13 +543,16 @@ func (db *DB) Scan(dest interface{}) (tx *DB) {
 	tx.Config = &config
 
 	if rows, err := tx.Rows(); err == nil {
+		defer func() {
+			tx.AddError(rows.Close())
+		}()
+
 		if rows.Next() {
 			tx.ScanRows(rows, dest)
 		} else {
 			tx.RowsAffected = 0
 			tx.AddError(rows.Err())
 		}
-		tx.AddError(rows.Close())
 	}
 
 	currentLogger.Trace(tx.Statement.Context, newLogger.BeginAt, func() (string, int64) {

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -920,6 +920,7 @@ func TestSelectWithVariables(t *testing.T) {
 	DB.Save(&User{Name: "select_with_variables"})
 
 	rows, _ := DB.Table("users").Where("name = ?", "select_with_variables").Select("? as fake", gorm.Expr("name")).Rows()
+	defer rows.Close()
 
 	if !rows.Next() {
 		t.Errorf("Should have returned at least one row")
@@ -927,8 +928,6 @@ func TestSelectWithVariables(t *testing.T) {
 		columns, _ := rows.Columns()
 		AssertEqual(t, columns, []string{"fake"})
 	}
-
-	rows.Close()
 }
 
 func TestSelectWithArrayInput(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/go-gorm/gorm/issues/7790

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

## Description

This PR updates `rows.Close()` handling to use `defer` in code paths where `*sql.Rows` may remain unclosed if a panic occurs.

### What did this pull request do?

* Defer `rows.Close()` in `callbacks/delete.go`
* Defer `rows.Close()` in `callbacks/update.go`
* Defer `rows.Close()` in `finisher_api.go`
* Use `defer rows.Close()` in `tests/query_test.go`

This aligns the behavior with the existing pattern already used in `callbacks/query.go` and `callbacks/create.go`.

### User Case Description

Previously, `rows.Close()` was called inline after `gorm.Scan(...)` / `ScanRows(...)`. In the event of a panic while scanning rows, `rows.Close()` could be skipped, potentially leaving database connections open.

Using `defer` ensures cleanup happens even during panic unwinding while keeping behavior unchanged during normal execution.

### Testing

* Run existing test suite
* No functional behavior changed