### PR TITLE
feat: apply QueryFields to RETRUNING clauses

### DIFF
--- a/callbacks/create.go
+++ b/callbacks/create.go
@@ -62,6 +62,10 @@ func Create(config *Config) func(db *gorm.DB) {
 					}
 				}
 			}
+
+			if supportReturning {
+				populateReturningColumns(db)
+			}
 		}
 
 		if db.Statement.SQL.Len() == 0 {

--- a/callbacks/delete.go
+++ b/callbacks/delete.go
@@ -122,6 +122,10 @@ func Delete(config *Config) func(db *gorm.DB) {
 			for _, c := range db.Statement.Schema.DeleteClauses {
 				db.Statement.AddClause(c)
 			}
+
+			if supportReturning {
+				populateReturningColumns(db)
+			}
 		}
 
 		if db.Statement.SQL.Len() == 0 {

--- a/callbacks/helper.go
+++ b/callbacks/helper.go
@@ -106,6 +106,37 @@ func hasReturning(tx *gorm.DB, supportReturning bool) (bool, gorm.ScanMode) {
 	return false, 0
 }
 
+// populateReturningColumns populates empty Returning.Columns from model schema when QueryFields is enabled.
+func populateReturningColumns(db *gorm.DB) {
+	if !db.QueryFields || db.Statement.Schema == nil {
+		return
+	}
+
+	c, ok := db.Statement.Clauses["RETURNING"]
+	if !ok {
+		return
+	}
+
+	returning, ok := c.Expression.(clause.Returning)
+	if !ok {
+		return
+	}
+
+	if len(returning.Columns) > 0 {
+		return
+	}
+
+	columns := make([]clause.Column, len(db.Statement.Schema.DBNames))
+	for idx, dbName := range db.Statement.Schema.DBNames {
+		columns[idx] = clause.Column{Name: dbName}
+	}
+
+	db.Statement.Clauses["RETURNING"] = clause.Clause{
+		Name:       "RETURNING",
+		Expression: clause.Returning{Columns: columns},
+	}
+}
+
 func checkMissingWhereConditions(db *gorm.DB) {
 	if !db.AllowGlobalUpdate && db.Error == nil {
 		where, withCondition := db.Statement.Clauses["WHERE"]

--- a/callbacks/helper_test.go
+++ b/callbacks/helper_test.go
@@ -2,10 +2,12 @@ package callbacks
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
 )
 
 func TestLoadOrStoreVisitMap(t *testing.T) {
@@ -96,6 +98,65 @@ func TestConvertMapToValuesForCreate(t *testing.T) {
 	}
 }
 
+func TestPopulateReturningColumns(t *testing.T) {
+	type user struct {
+		ID   uint
+		Name string
+	}
+
+	s, err := schema.Parse(&user{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("parse schema error: %v", err)
+	}
+
+	testCase := []struct {
+		name          string
+		queryFields   bool
+		input         clause.Returning
+		expectColumns []clause.Column
+	}{
+		{
+			name:        "populates empty Returning when QueryFields is enabled",
+			queryFields: true,
+			input:       clause.Returning{},
+			expectColumns: []clause.Column{
+				{Name: "id"},
+				{Name: "name"},
+			},
+		},
+		{
+			name:          "does not populate when QueryFields is disabled",
+			queryFields:   false,
+			input:         clause.Returning{},
+			expectColumns: nil,
+		},
+		{
+			name:          "does not override explicit columns",
+			queryFields:   true,
+			input:         clause.Returning{Columns: []clause.Column{{Name: "id"}}},
+			expectColumns: []clause.Column{{Name: "id"}},
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			db := &gorm.DB{Config: &gorm.Config{}, Statement: &gorm.Statement{Settings: sync.Map{}, Schema: s, Table: "users"}}
+			db.QueryFields = tc.queryFields
+			db.Statement.Clauses = map[string]clause.Clause{
+				"RETURNING": {Name: "RETURNING", Expression: tc.input},
+			}
+
+			populateReturningColumns(db)
+
+			rt := db.Statement.Clauses["RETURNING"]
+			returning := rt.Expression.(clause.Returning)
+			if !reflect.DeepEqual(returning.Columns, tc.expectColumns) {
+				t.Errorf("expected %v, got %v", tc.expectColumns, returning.Columns)
+			}
+		})
+	}
+}
+
 func TestConvertSliceOfMapToValuesForCreate(t *testing.T) {
 	testCase := []struct {
 		name   string
@@ -153,5 +214,4 @@ func TestConvertSliceOfMapToValuesForCreate(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/callbacks/update.go
+++ b/callbacks/update.go
@@ -65,6 +65,10 @@ func Update(config *Config) func(db *gorm.DB) {
 			for _, c := range db.Statement.Schema.UpdateClauses {
 				db.Statement.AddClause(c)
 			}
+
+			if supportReturning {
+				populateReturningColumns(db)
+			}
 		}
 
 		if db.Statement.SQL.Len() == 0 {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
When `QueryFields` is enabled, `clause.Returning{}` with empty `Columns` now generates an explicit column list from the model schema instead of `RETURNING *`.

This applies to Create, Update, and Delete callbacks. When `QueryFields` is disabled (default), the behavior is unchanged.


### User Case Description

<!-- Your use case -->
`QueryFields` expands `SELECT *` to explicit column lists, but `RETURNING *` was not covered.
This causes issues when the database table has more columns than the Go model, e.g. during rolling deployments where a migration adds a column before all application instances are updated.

Fixes #7804
Fixes #7690
