### PR TITLE
fix(migrator): normalize DB-side "NULL" default to fix infinite AlterColumn loop on Postgres

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -545,7 +545,7 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 	if !field.PrimaryKey {
 		currentDefaultNotNull := field.HasDefaultValue && (field.DefaultValueInterface != nil || !strings.EqualFold(field.DefaultValue, "NULL"))
 		dv, dvNotNull := columnType.DefaultValue()
-		if dvNotNull && !currentDefaultNotNull {
+		if dvNotNull && !currentDefaultNotNull && !strings.EqualFold(dv, "NULL") {
 			// default value -> null
 			alterColumn = true
 		} else if !dvNotNull && currentDefaultNotNull {


### PR DESCRIPTION
- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested
### Description
Normalize DB-side `DEFAULT NULL` literal to prevent infinite `AlterColumn` loop on PostgreSQL.
### What did this pull request do?
- Add `!strings.EqualFold(dv, "NULL")` to the first default value comparison case in `MigrateColumn`
- Mirrors the existing model-side normalization where `default:NULL` tag is treated as no-default
- Prevents `AlterColumn` from being triggered on every startup when a PostgreSQL column has `DEFAULT NULL` in its `column_default` catalog entry
### User Case Description
PostgreSQL's `information_schema.columns.column_default` stores the literal string `"NULL"` for columns explicitly defined with `DEFAULT NULL`, while MySQL and other drivers return SQL NULL (empty) for the same semantic state.
GORM's `MigrateColumn` already normalizes the model side — `default:NULL` tag is treated as "no default" via `EqualFold`. But the DB side comparison was missing the same normalization, causing:
- `dvNotNull = true` (DB returns string `"NULL"`)
- `currentDefaultNotNull = false` (model side normalized to no-default)
This triggers `AlterColumn` on every startup. The postgres driver then issues `ALTER COLUMN TYPE ... USING ...` (full table rewrite holding AccessExclusiveLock) due to a separate alias-comparison bug, turning a metadata mismatch into a production outage on large tables.
Affected drivers: PostgreSQL only. MySQL/SQLite/SQLServer all collapse `DEFAULT NULL` to "no default" in their column metadata.
Related: #7553, #7590, #7769