### PR TITLE
perf: add typed slice fast paths in Statement.AddVar

### DIFF
--- a/addvar_test.go
+++ b/addvar_test.go
@@ -1,0 +1,296 @@
+package gorm
+
+import (
+	"reflect"
+	"testing"
+
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
+)
+
+// addVarTestDialector is a minimal Dialector implementation used by AddVar
+// tests and benchmarks. It cannot live in gorm/utils/tests because that
+// package depends on gorm.io/gorm, which would create an import cycle when
+// referenced from inside package gorm.
+type addVarTestDialector struct{}
+
+func (addVarTestDialector) Name() string {
+	return "addvar_test"
+}
+
+func (addVarTestDialector) Initialize(*DB) error {
+	return nil
+}
+
+func (addVarTestDialector) Migrator(*DB) Migrator {
+	return nil
+}
+
+func (addVarTestDialector) DataTypeOf(*schema.Field) string {
+	return ""
+}
+
+func (addVarTestDialector) DefaultValueOf(*schema.Field) clause.Expression {
+	return clause.Expr{SQL: "DEFAULT"}
+}
+
+func (addVarTestDialector) BindVarTo(writer clause.Writer, stmt *Statement, v interface{}) {
+	_ = writer.WriteByte('?')
+}
+
+func (addVarTestDialector) QuoteTo(writer clause.Writer, str string) {
+	_, _ = writer.WriteString(str)
+}
+
+func (addVarTestDialector) Explain(sql string, vars ...interface{}) string {
+	return sql
+}
+
+func newAddVarStatement() *Statement {
+	db := &DB{Config: &Config{Dialector: addVarTestDialector{}}}
+	db.Statement = &Statement{DB: db}
+	return db.Statement
+}
+
+func TestAddVarIntSlice(t *testing.T) {
+	stmt := newAddVarStatement()
+	stmt.AddVar(&stmt.SQL, []int{1, 2, 3})
+
+	if got, want := stmt.SQL.String(), "(?,?,?)"; got != want {
+		t.Errorf("SQL mismatch: got %q, want %q", got, want)
+	}
+	if got, want := len(stmt.Vars), 3; got != want {
+		t.Fatalf("Vars length mismatch: got %d, want %d", got, want)
+	}
+	for i, v := range stmt.Vars {
+		iv, ok := v.(int)
+		if !ok {
+			t.Errorf("Vars[%d] type = %T, want int", i, v)
+			continue
+		}
+		if iv != i+1 {
+			t.Errorf("Vars[%d] = %d, want %d", i, iv, i+1)
+		}
+	}
+}
+
+func TestAddVarInt64Slice(t *testing.T) {
+	stmt := newAddVarStatement()
+	stmt.AddVar(&stmt.SQL, []int64{10, 20, 30})
+
+	if got, want := stmt.SQL.String(), "(?,?,?)"; got != want {
+		t.Errorf("SQL mismatch: got %q, want %q", got, want)
+	}
+	for i, v := range stmt.Vars {
+		if _, ok := v.(int64); !ok {
+			t.Errorf("Vars[%d] type = %T, want int64", i, v)
+		}
+	}
+}
+
+func TestAddVarUintSlice(t *testing.T) {
+	stmt := newAddVarStatement()
+	stmt.AddVar(&stmt.SQL, []uint{1, 2})
+
+	if got, want := stmt.SQL.String(), "(?,?)"; got != want {
+		t.Errorf("SQL mismatch: got %q, want %q", got, want)
+	}
+	for i, v := range stmt.Vars {
+		if _, ok := v.(uint); !ok {
+			t.Errorf("Vars[%d] type = %T, want uint", i, v)
+		}
+	}
+}
+
+func TestAddVarFloat64Slice(t *testing.T) {
+	stmt := newAddVarStatement()
+	stmt.AddVar(&stmt.SQL, []float64{1.5, 2.5})
+
+	if got, want := stmt.SQL.String(), "(?,?)"; got != want {
+		t.Errorf("SQL mismatch: got %q, want %q", got, want)
+	}
+	if v, ok := stmt.Vars[0].(float64); !ok || v != 1.5 {
+		t.Errorf("Vars[0] = %v (%T), want float64(1.5)", stmt.Vars[0], stmt.Vars[0])
+	}
+}
+
+func TestAddVarStringSlice(t *testing.T) {
+	stmt := newAddVarStatement()
+	stmt.AddVar(&stmt.SQL, []string{"a", "b"})
+
+	if got, want := stmt.SQL.String(), "(?,?)"; got != want {
+		t.Errorf("SQL mismatch: got %q, want %q", got, want)
+	}
+	for i, v := range stmt.Vars {
+		if _, ok := v.(string); !ok {
+			t.Errorf("Vars[%d] type = %T, want string", i, v)
+		}
+	}
+}
+
+func TestAddVarBoolSlice(t *testing.T) {
+	stmt := newAddVarStatement()
+	stmt.AddVar(&stmt.SQL, []bool{true, false})
+
+	if got, want := stmt.SQL.String(), "(?,?)"; got != want {
+		t.Errorf("SQL mismatch: got %q, want %q", got, want)
+	}
+	for i, v := range stmt.Vars {
+		if _, ok := v.(bool); !ok {
+			t.Errorf("Vars[%d] type = %T, want bool", i, v)
+		}
+	}
+}
+
+func TestAddVarEmptyTypedSlice(t *testing.T) {
+	stmt := newAddVarStatement()
+	stmt.AddVar(&stmt.SQL, []int{})
+
+	if got, want := stmt.SQL.String(), "(NULL)"; got != want {
+		t.Errorf("SQL mismatch: got %q, want %q", got, want)
+	}
+	if len(stmt.Vars) != 0 {
+		t.Errorf("Vars should be empty, got %v", stmt.Vars)
+	}
+}
+
+func TestAddVarByteSlice(t *testing.T) {
+	stmt := newAddVarStatement()
+	stmt.AddVar(&stmt.SQL, []byte("abc"))
+
+	if got, want := stmt.SQL.String(), "?"; got != want {
+		t.Errorf("SQL mismatch for []byte: got %q, want %q", got, want)
+	}
+	if len(stmt.Vars) != 1 {
+		t.Fatalf("Vars length for []byte = %d, want 1", len(stmt.Vars))
+	}
+	if _, ok := stmt.Vars[0].([]byte); !ok {
+		t.Errorf("Vars[0] type = %T, want []byte", stmt.Vars[0])
+	}
+}
+
+func TestAddVarCustomSliceAliasFallback(t *testing.T) {
+	type userIDs []int
+	stmt := newAddVarStatement()
+	stmt.AddVar(&stmt.SQL, userIDs{1, 2, 3})
+
+	if got, want := stmt.SQL.String(), "(?,?,?)"; got != want {
+		t.Errorf("SQL mismatch: got %q, want %q", got, want)
+	}
+	for i, v := range stmt.Vars {
+		if _, ok := v.(int); !ok {
+			t.Errorf("Vars[%d] type = %T, want int (preserved by reflect fallback)", i, v)
+		}
+	}
+}
+
+func TestAddVarInterfaceSliceUnchanged(t *testing.T) {
+	stmt := newAddVarStatement()
+	stmt.AddVar(&stmt.SQL, []interface{}{1, "two", 3.0})
+
+	if got, want := stmt.SQL.String(), "(?,?,?)"; got != want {
+		t.Errorf("SQL mismatch: got %q, want %q", got, want)
+	}
+	if len(stmt.Vars) != 3 {
+		t.Fatalf("Vars length = %d, want 3", len(stmt.Vars))
+	}
+	if reflect.TypeOf(stmt.Vars[0]).Kind() != reflect.Int {
+		t.Errorf("Vars[0] kind = %v, want int", reflect.TypeOf(stmt.Vars[0]).Kind())
+	}
+	if _, ok := stmt.Vars[1].(string); !ok {
+		t.Errorf("Vars[1] type = %T, want string", stmt.Vars[1])
+	}
+	if _, ok := stmt.Vars[2].(float64); !ok {
+		t.Errorf("Vars[2] type = %T, want float64", stmt.Vars[2])
+	}
+}
+
+// addVarSink prevents the compiler from optimizing away benchmark results.
+var addVarSink string
+
+func benchmarkAddVar(b *testing.B, v interface{}) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		stmt := newAddVarStatement()
+		stmt.AddVar(&stmt.SQL, v)
+		addVarSink = stmt.SQL.String()
+	}
+}
+
+func BenchmarkStatementAddVar(b *testing.B) {
+	const n = 100
+
+	b.Run("int_slice", func(b *testing.B) {
+		v := make([]int, n)
+		for i := range v {
+			v[i] = i
+		}
+		benchmarkAddVar(b, v)
+	})
+
+	b.Run("int64_slice", func(b *testing.B) {
+		v := make([]int64, n)
+		for i := range v {
+			v[i] = int64(i)
+		}
+		benchmarkAddVar(b, v)
+	})
+
+	b.Run("uint_slice", func(b *testing.B) {
+		v := make([]uint, n)
+		for i := range v {
+			v[i] = uint(i) //nolint:gosec // benchmark loop index is bounded by n
+		}
+		benchmarkAddVar(b, v)
+	})
+
+	b.Run("float64_slice", func(b *testing.B) {
+		v := make([]float64, n)
+		for i := range v {
+			v[i] = float64(i)
+		}
+		benchmarkAddVar(b, v)
+	})
+
+	b.Run("string_slice", func(b *testing.B) {
+		v := make([]string, n)
+		for i := range v {
+			v[i] = "v"
+		}
+		benchmarkAddVar(b, v)
+	})
+
+	b.Run("bool_slice", func(b *testing.B) {
+		v := make([]bool, n)
+		for i := range v {
+			v[i] = i%2 == 0
+		}
+		benchmarkAddVar(b, v)
+	})
+
+	b.Run("interface_slice", func(b *testing.B) {
+		v := make([]interface{}, n)
+		for i := range v {
+			v[i] = i
+		}
+		benchmarkAddVar(b, v)
+	})
+
+	b.Run("custom_alias_slice", func(b *testing.B) {
+		type userIDs []int
+		v := make(userIDs, n)
+		for i := range v {
+			v[i] = i
+		}
+		benchmarkAddVar(b, v)
+	})
+
+	b.Run("byte_slice_scalar", func(b *testing.B) {
+		v := make([]byte, n)
+		for i := range v {
+			v[i] = byte(i)
+		}
+		benchmarkAddVar(b, v)
+	})
+}

--- a/statement.go
+++ b/statement.go
@@ -210,6 +210,37 @@ func (stmt *Statement) AddVar(writer clause.Writer, vars ...interface{}) {
 			} else {
 				writer.WriteString("(NULL)")
 			}
+		// Typed slice fast paths: avoid the per-element reflect.Value.Interface()
+		// boxing and the recursive AddVar dispatch used by the reflect fallback.
+		// []uint8 (= []byte) is intentionally omitted because it is handled as a
+		// scalar bind by the case above; custom slice aliases (e.g. type T []int)
+		// still go through the reflect fallback to preserve existing behavior.
+		case []int:
+			addVarsTyped(stmt, writer, v)
+		case []int8:
+			addVarsTyped(stmt, writer, v)
+		case []int16:
+			addVarsTyped(stmt, writer, v)
+		case []int32:
+			addVarsTyped(stmt, writer, v)
+		case []int64:
+			addVarsTyped(stmt, writer, v)
+		case []uint:
+			addVarsTyped(stmt, writer, v)
+		case []uint16:
+			addVarsTyped(stmt, writer, v)
+		case []uint32:
+			addVarsTyped(stmt, writer, v)
+		case []uint64:
+			addVarsTyped(stmt, writer, v)
+		case []float32:
+			addVarsTyped(stmt, writer, v)
+		case []float64:
+			addVarsTyped(stmt, writer, v)
+		case []string:
+			addVarsTyped(stmt, writer, v)
+		case []bool:
+			addVarsTyped(stmt, writer, v)
 		case interface{ getInstance() *DB }:
 			cv := v.getInstance()
 
@@ -266,6 +297,30 @@ func (stmt *Statement) AddVar(writer clause.Writer, vars ...interface{}) {
 			}
 		}
 	}
+}
+
+// addVarsTyped writes a parenthesized, comma-separated list of bind variables
+// for a slice of a concrete primitive type, appending each element to
+// stmt.Vars with its original type preserved. Empty slices are rendered as
+// "(NULL)" to match the existing reflect-based behavior in AddVar.
+//
+// Writer errors are intentionally ignored: clause.Writer is satisfied by
+// strings.Builder whose Write methods never return a non-nil error, matching
+// the rest of AddVar.
+func addVarsTyped[T any](stmt *Statement, writer clause.Writer, vars []T) {
+	if len(vars) == 0 {
+		_, _ = writer.WriteString("(NULL)")
+		return
+	}
+	_ = writer.WriteByte('(')
+	for i, v := range vars {
+		if i > 0 {
+			_ = writer.WriteByte(',')
+		}
+		stmt.Vars = append(stmt.Vars, v)
+		stmt.BindVarTo(writer, stmt, v)
+	}
+	_ = writer.WriteByte(')')
 }
 
 // AddClause add clause


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add concrete type-switch fast paths in `Statement.AddVar` for the common typed slices: `[]int{,8,16,32,64}`, `[]uint{,16,32,64}`, `[]float{32,64}`, `[]string`, `[]bool`. These cases now append each element directly to `stmt.Vars` and call `BindVarTo` via a small generic helper `addVarsTyped[T any]`, instead of falling through to the reflect path that walks the slice, boxes each element via `reflect.Value.Interface()`, and recurses into `AddVar`.

`[]byte` keeps binding as a scalar (existing `case []byte` above stays first), and custom slice aliases (`type T []int`, etc.) keep the reflect fallback so behavior is preserved.

Element types stored in `stmt.Vars` and the generated SQL placeholders are identical to the previous behavior, only the dispatch path changes.

### User Case Description

Any query that passes a concrete typed slice to GORM hits this path. The most common cases are `WHERE id IN (?)`-style conditions and other `IN`-clauses with primary keys, foreign keys, status enums, etc.:

```go
ids := []int64{1, 2, 3, /* ... */}
db.Where("id IN ?", ids).Find(&users)

names := []string{"alice", "bob", "carol"}
db.Where("name IN ?", names).Find(&users)
```

For a 100-element `[]int`, the previous reflect-based path costs ~5200 ns and 217 allocs per call. After the fix that drops to ~1200 ns and 17 allocs, with no change in generated SQL or `stmt.Vars` contents. The win compounds on hot endpoints that build `IN`-clauses on every request.

### Benchmarks

`darwin/arm64`, `n=100`, best of 3:

| Case | Before ns/op | After ns/op | Before allocs | After allocs |
|---|---:|---:|---:|---:|
| `[]int` | 5204 | 1216 | 217 | 17 |
| `[]int64` | 5467 | 1219 | 217 | 17 |
| `[]uint` | 5727 | 1212 | 217 | 17 |
| `[]bool` | 5141 | 1131 | 217 | 17 |
| `[]float64` | 5413 | 2175 | 217 | 215 |
| `[]string` | 5730 | 3464 | 217 | 217 |
| `[]interface{}` (control) | 2558 | 2530 | 17 | 17 |
| custom alias (control) | 5290 | 5152 | 217 | 217 |
| `[]byte` scalar (control) | 173 | 157 | 7 | 7 |

`[]float64` and `[]string` keep their boxing allocations (irreducible when storing into `[]interface{}`) but still save the reflect dispatch. Integer and bool slices get alloc-free boxing via the runtime's `staticuint64s` cache.

### Changes

- `statement.go`: 13 typed-slice cases before the reflect fallback, plus a small generic helper `addVarsTyped[T any]`.
- `addvar_test.go`: 10 correctness tests covering each typed path, empty slices, `[]byte` scalar handling, custom alias fallback, and `[]interface{}` recursion; plus `BenchmarkStatementAddVar` with 9 sub-benchmarks.

Part of #7791
