### PR TITLE
fix: defer context cancel func to prevent goroutine leak

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -95,7 +95,9 @@ func (p *processor) Execute(db *DB) *DB {
 
 	if db.DefaultContextTimeout > 0 {
 		if _, ok := stmt.Context.Deadline(); !ok {
-			stmt.Context, _ = context.WithTimeout(stmt.Context, db.DefaultContextTimeout)
+			var cancel context.CancelFunc
+			stmt.Context, cancel = context.WithTimeout(stmt.Context, db.DefaultContextTimeout)
+			defer cancel()
 		}
 	}
 


### PR DESCRIPTION
## Problem

`context.WithTimeout` returns a `CancelFunc` that must be called to release the associated timer goroutine. In `callbacks.go` `Execute()` (line 97), the `CancelFunc` was discarded with `_`, causing the timer goroutine to leak until the timeout expires on every query when `DefaultContextTimeout` is configured.

## Changes

**callbacks.go** `Execute()` (line 98):
```go
// Before
stmt.Context, _ = context.WithTimeout(stmt.Context, db.DefaultContextTimeout)

// After
var cancel context.CancelFunc
stmt.Context, cancel = context.WithTimeout(stmt.Context, db.DefaultContextTimeout)
defer cancel()
```

This is safe because the callback runs synchronously within `Execute()` — the `cancel` fires only after the operation completes.

## Note on `finisher_api.go` `Begin()`

An earlier revision of this PR also added `defer cancel()` inside `Begin()`. That was incorrect and has been reverted (thanks @viacheslav-danilin for [catching it](https://github.com/go-gorm/gorm/pull/7809#issuecomment-4674263951)): the returned `tx` outlives `Begin()`, so deferring at function scope would cancel the context immediately and break every subsequent operation on the transaction.

Properly fixing the `Begin()` path requires tying `cancel` to the transaction's lifetime (calling it from `Commit()` / `Rollback()`), which is a larger change and feels out of scope here. Happy to do it as a follow-up if maintainers want.

## Testing

All existing tests pass (`go test ./...`).

Related: #7786