### PR TITLE
fix: populate OnConflict columns from primary fields in Save fallback

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -117,7 +117,13 @@ func (db *DB) Save(value interface{}) (tx *DB) {
 		updateTx := tx.callbacks.Update().Execute(tx.Session(&Session{Initialized: true}))
 
 		if updateTx.Error == nil && updateTx.RowsAffected == 0 && !updateTx.DryRun && !selectedUpdate {
-			return tx.Session(&Session{SkipHooks: true}).Clauses(clause.OnConflict{UpdateAll: true}).Create(value)
+			onConflictClause := clause.OnConflict{UpdateAll: true}
+			if tx.Statement.Schema != nil {
+				for _, field := range tx.Statement.Schema.PrimaryFields {
+					onConflictClause.Columns = append(onConflictClause.Columns, clause.Column{Name: field.DBName})
+				}
+			}
+			return tx.Session(&Session{SkipHooks: true}).Clauses(onConflictClause).Create(value)
 		}
 
 		return updateTx


### PR DESCRIPTION
## Problem

When `Save`'s initial UPDATE reports 0 rows affected, it falls back to an INSERT with ON CONFLICT. The existing OnConflict clause specifies only `UpdateAll: true` with no `Columns`, causing PostgreSQL to reject the query:

```
ON CONFLICT DO UPDATE requires inference specification or constraint name (SQLSTATE 42601)
```

This occurs on tables with multiple unique constraints (e.g., a primary key column plus a UNIQUE column) where PostgreSQL cannot infer which constraint to use as the conflict target.

## Root Cause

In `finisher_api.go`, the `Save` fallback creates an `OnConflict` clause with only `UpdateAll: true`. While the Create callback in `callbacks/create.go` has logic to auto-populate `Columns` from the schema's primary fields (line 403-407), this auto-population does not fire inside the `SkipHooks: true` session that `Save` creates for the fallback INSERT.

## Fix

Populate `OnConflict.Columns` explicitly at the call site by reading the primary key fields from the schema before handing the clause to `Create`. This produces `INSERT ... ON CONFLICT (id) DO UPDATE SET ...` instead of the bare `ON CONFLICT DO UPDATE`.

## Reproduces when

- Calling `db.Save()` on an existing record where the UPDATE reports 0 rows affected
- The target table has multiple unique constraints (primary key + unique column)
- Database is PostgreSQL (MySQL/SQLite do not enforce the columns requirement)

## Checklist

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested