### PR TITLE
Fix Count ORDER BY cleanup for scoped Order clauses

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -453,6 +453,13 @@ func (db *DB) Delete(value interface{}, conds ...interface{}) (tx *DB) {
 
 func (db *DB) Count(count *int64) (tx *DB) {
 	tx = db.getInstance()
+	if len(tx.Statement.scopes) > 0 {
+		for len(tx.Statement.scopes) > 0 {
+			tx = tx.executeScopes()
+		}
+		db = tx
+	}
+
 	if tx.Statement.Model == nil {
 		tx.Statement.Model = tx.Statement.Dest
 		defer func() {

--- a/tests/count_test.go
+++ b/tests/count_test.go
@@ -36,6 +36,28 @@ func TestCountWithGroup(t *testing.T) {
 	}
 }
 
+func TestCountWithOrderInScope(t *testing.T) {
+	var count int64
+	dryDB := DB.Session(&gorm.Session{DryRun: true})
+
+	scopeResult := dryDB.Scopes(func(tx *gorm.DB) *gorm.DB {
+		return tx.Order("name desc")
+	}).Model(&User{}).Count(&count)
+	if strings.Contains(strings.ToUpper(scopeResult.Statement.SQL.String()), "ORDER BY") {
+		t.Fatalf("Count with order in scope should not generate ORDER BY, got %v", scopeResult.Statement.SQL.String())
+	}
+
+	directResult := dryDB.Model(&User{}).Order("name desc").Count(&count)
+	if strings.Contains(strings.ToUpper(directResult.Statement.SQL.String()), "ORDER BY") {
+		t.Fatalf("Count with direct order should not generate ORDER BY, got %v", directResult.Statement.SQL.String())
+	}
+
+	groupResult := dryDB.Model(&User{}).Group("name").Order("name desc").Count(&count)
+	if !strings.Contains(strings.ToUpper(groupResult.Statement.SQL.String()), "ORDER BY") {
+		t.Fatalf("Count with group should keep ORDER BY, got %v", groupResult.Statement.SQL.String())
+	}
+}
+
 func TestCount(t *testing.T) {
 	var (
 		user1                 = *GetUser("count-1", Config{})


### PR DESCRIPTION
## Summary

Fixes #7516

This updates `Count()` to execute pending scopes before it inspects or mutates
statement clauses. That ensures clauses added inside `Scopes()`, such as
`Order("name desc")`, are visible to the existing Count cleanup logic that
removes `ORDER BY` when there is no `GROUP BY`.

## Tests

Added `TestCountWithOrderInScope` in `tests/count_test.go`.

The new test uses `DB.Session(&gorm.Session{DryRun: true})` to assert that:

- `Order()` added inside `Scopes()` does not leave `ORDER BY` in Count SQL when there is no `Group()`.
- Direct chained `Order().Count()` keeps the existing behavior and also omits `ORDER BY`.
- `Group().Order().Count()` still preserves `ORDER BY`.