### PR TITLE
docs: format InnerJoins example as a godoc code block

### DIFF
--- a/chainable_api.go
+++ b/chainable_api.go
@@ -250,7 +250,8 @@ func (db *DB) Joins(query string, args ...interface{}) (tx *DB) {
 }
 
 // InnerJoins specify inner joins conditions
-// db.InnerJoins("Account").Find(&user)
+//
+//	db.InnerJoins("Account").Find(&user)
 func (db *DB) InnerJoins(query string, args ...interface{}) (tx *DB) {
 	return joins(db, clause.InnerJoin, query, args...)
 }


### PR DESCRIPTION
The `InnerJoins` example doesn't render as a code block on pkg.go.dev. The example line has no blank comment line before it and isn't indented, so godoc folds it into the description paragraph and shows it as one run-on line:

> InnerJoins specify inner joins conditions db.InnerJoins("Account").Find(&user)

The sibling `Joins` directly above already uses the standard godoc form (blank line + tab indent), so this just brings `InnerJoins` in line with it. Doc comment only, no code change.
