### PR TITLE
Fix FirstOrCreate not returning Expr results to struct

### DIFF
--- a/finisher_api.go
+++ b/finisher_api.go
@@ -403,6 +403,15 @@ func (db *DB) FirstOrCreate(dest interface{}, conds ...interface{}) (tx *DB) {
 			}
 		}
 
+		if _, ok := tx.Statement.Clauses["RETURNING"]; !ok {
+			for _, v := range assigns {
+				if _, ok := v.(clause.Expr); ok {
+					tx = tx.Clauses(clause.Returning{})
+					break
+				}
+			}
+		}
+
 		return tx.Model(dest).Updates(assigns)
 	}
 


### PR DESCRIPTION
## Summary

When using `Assign` with `gorm.Expr` (e.g. `Assign("age", gorm.Expr("age + ?", 1))`), the SQL UPDATE correctly sets the column but the Go struct is not updated with the database-computed value.

This adds `clause.Returning{}` when any assign value is a `clause.Expr`, so the database-computed value is scanned back into the struct.

Fixes #7589

## Root Cause

`FirstOrCreate` builds an assigns map and calls `tx.Model(dest).Updates(assigns)`. When an assign value is a `clause.Expr` (like `age + 1`), the database computes the new value, but without `RETURNING`, the struct is never scanned with the result.

Users can work around this by manually adding `clause.Returning{}`, but this is unintuitive — the struct silently retains stale data.

## Fix

After building the assigns map, check if any value is a `clause.Expr`. If so, add `clause.Returning{}` to automatically retrieve the computed values.

## Limitations

This fix relies on `RETURNING` support (PostgreSQL, SQLite). For databases without `RETURNING` support (e.g. MySQL), the struct will remain unupdated — but this is the current behavior already; the fix does not make it worse.

## Test plan

- [ ] `FirstOrCreate` with `Assign("age", gorm.Expr("age + ?", 1))` updates the struct on PostgreSQL
- [ ] `FirstOrCreate` with non-Expr assigns still works without `RETURNING`
- [ ] `FirstOrCreate` with explicit `clause.Returning{}` is not double-applied